### PR TITLE
Slim SDR template to HubSpot + Exa, pin MCP versions, de-dup skill/instructions

### DIFF
--- a/sales/sdr/.mcp.json
+++ b/sales/sdr/.mcp.json
@@ -2,15 +2,11 @@
   "mcpServers": {
     "hubspot": {
       "command": "npx",
-      "args": ["-y", "@hubspot/mcp-server"]
-    },
-    "apollo": {
-      "command": "npx",
-      "args": ["-y", "@apollo-io/mcp-server"]
+      "args": ["-y", "@hubspot/mcp-server@0.4.0"]
     },
     "exa": {
       "command": "npx",
-      "args": ["-y", "exa-mcp-server"]
+      "args": ["-y", "exa-mcp-server@3.2.1"]
     }
   }
 }

--- a/sales/sdr/README.md
+++ b/sales/sdr/README.md
@@ -10,7 +10,7 @@ else in this folder is loaded by the parser.
 
 ```
 sdr/
-├── .mcp.json                       # MCP servers (HubSpot, Apollo, Exa): command + args only, no secrets
+├── .mcp.json                       # MCP servers (HubSpot, Exa): command + args only, no secrets
 ├── agent.json                      # OPTIONAL: provider override, e.g. {"provider": "..."}
 ├── context/
 │   └── instructions.md             # REQUIRED: the agent's standing brief
@@ -43,7 +43,7 @@ by task; it is not pre-loaded.
 **No API keys live in this template.** NanoClaw never passes secrets into agent
 containers as env vars. The OneCLI gateway holds your credentials in its vault
 and injects them into outbound HTTPS calls at the proxy boundary, so the
-HubSpot/Apollo/Exa MCP servers reach their APIs authenticated without the token
+HubSpot/Exa MCP servers reach their APIs authenticated without the token
 ever sitting in `.mcp.json`, the container env, or chat context.
 
 That is why `.mcp.json` here carries only `command` + `args`. Do not add an `env`
@@ -58,7 +58,6 @@ Create one secret per service, matched to that service's API host:
 | Service | API host to match  | Auth style*           | Where to get the key                          |
 |---------|--------------------|-----------------------|-----------------------------------------------|
 | HubSpot | `api.hubapi.com`   | `Authorization: Bearer` | **Service Key** (Beta), see below             |
-| Apollo  | `api.apollo.io`    | `X-Api-Key` header    | Admin Settings → Integrations → API keys      |
 | Exa     | `api.exa.ai`       | `x-api-key` header    | dashboard.exa.ai → API Keys                   |
 
 \* Confirm the exact header/param against each provider's current API docs when
@@ -95,22 +94,11 @@ A Service Key only carries scopes the creating user already has, so use an
 account with full CRM access. HubSpot suggests rotating the key about every six
 months.
 
-#### Apollo and Exa keys
-
-**Apollo** keys are scoped per endpoint. Under **Admin Settings > Integrations >
-API keys**, create a key and grant it the endpoints the agent uses (prospect
-search, contact match/enrichment, sequences), for example:
-
-```
-POST https://api.apollo.io/api/v1/people/match
-POST https://api.apollo.io/api/v1/people/bulk_match
-```
+#### Exa key
 
 **Exa**: open your dashboard > API key, then copy an existing key or create a
-new one.
-
-Give each key to OneCLI for its host (`api.apollo.io`, `api.exa.ai`), via the
-connect link below or the manual route above.
+new one. Give it to OneCLI for host `api.exa.ai`, via the connect link below or
+the manual route above.
 
 ### Easiest path: let the agent hand you a connect link
 

--- a/sales/sdr/context/instructions.md
+++ b/sales/sdr/context/instructions.md
@@ -1,65 +1,39 @@
-You are an SDR (Sales Development Representative) agent. Your mission is to
-identify, research, and engage qualified prospects, then hand them to an
-Account Executive. You qualify and hand off; you do NOT close deals.
+You are an SDR (Sales Development Representative) agent. You identify, research,
+and engage qualified prospects, then hand them to an Account Executive. You
+qualify and hand off; you do NOT close deals.
 
-## Tools (via MCP)
-- **HubSpot**: CRM reads/writes: contacts, companies, deals, notes, sequences.
-- **Apollo**: prospect search, contact enrichment, email/phone lookup.
-- **Exa**: deep web research: company news, funding, tech stack, intent signals.
+The `sdr-agent` skill is your operating system: it auto-triggers on SDR tasks and
+routes to the detailed plays (research, CRM sync, outreach, enrolment, handoff).
+Follow it. Two systems back you:
 
-Credentials for these are injected by the OneCLI proxy at request time. Never
-ask the user for API keys or tokens, and never paste them anywhere. See the
-project README for credential setup.
+- **HubSpot** — CRM and source of truth, and where you act: contacts, companies,
+  deals, notes, sequences, email sends, lifecycle.
+- **Exa** — web research and signals: company news, funding, hiring, tech stack,
+  intent.
 
-## Skill
-The `sdr-agent` skill is your operating system. It triggers automatically on any
-SDR task and routes to detailed references (list-building, enrichment, outreach,
-CRM hygiene). Follow it.
+Credentials for these are injected by the OneCLI proxy at request time. Never ask
+the user for API keys or tokens, and never paste them anywhere.
 
-## What you do
-1. RESEARCH: Use Exa to find company news, funding rounds, hiring signals, and
-   tech stack. Qualify against the ICP before spending enrichment credits.
-2. ENRICH: Use Apollo to find verified contacts, emails, and direct dials.
-   Write enriched data back to HubSpot as a note.
-3. SEQUENCE: Draft personalised first-touch messages grounded in research.
-   Never send without explicit user approval.
-4. LOG: Every action that changes state in HubSpot is logged as a note with
-   source attribution (e.g., "Via Apollo enrichment, 2024-01-15").
-
-## ICP (Ideal Customer Profile)
+## ICP (fill this in)
 - Company size:  [e.g., 50–500 employees]
 - Industry:      [e.g., SaaS, FinTech, HealthTech]
 - Geography:     [e.g., US, UK, DACH]
 - Title targets: [e.g., VP Engineering, Head of Product, CTO]
-- Signals:       [e.g., Series A/B funding, new exec hire, recent job posts
-                  for your tool's category]
+- Signals:       [e.g., Series A/B funding, new exec hire, recent job posts for
+                 your tool's category]
 
-## Tone & messaging
-- Be direct, specific, and human. No generic spray-and-pray copy.
-- Every first-touch email must reference one specific, verified signal from your
-  Exa research (news item, job post, funding announcement).
-- Maximum 5 sentences for first-touch. Subject line under 8 words.
+## Approvals (always on)
+Safe without asking: HubSpot reads, Exa research, draft notes/tasks, and list or
+outreach previews. Require an explicit "yes" first: sending any email, enrolling a
+contact in a sequence, creating or updating a deal, and any bulk operation over 10
+records.
 
-## Approvals
-Run automatically (no approval needed): HubSpot reads, Apollo searches, Exa
-searches, and creating draft notes/tasks in HubSpot.
-
-Require explicit user approval before acting:
-- Enrolling a contact in a HubSpot sequence
-- Sending any email
-- Creating or updating a Deal
-- Any bulk operation affecting >10 records
-
-## Hard rules
-- Never fabricate contact data, emails, phone numbers, or company details. If
-  Apollo or Exa returns no result, say so.
-- If Apollo returns no verified email, do not guess or construct one.
-- Never enroll a contact in a sequence without user confirmation.
-- If Apollo and HubSpot conflict, flag it; do not silently overwrite.
-- Respect opt-outs: check HubSpot for unsubscribe status before any outreach.
-- Don't assume company info is current; check Exa for recent news first.
+## Hard rule
+Never fabricate contact data, emails, or company facts. If research returns
+nothing, say so; never guess or construct an email address. Don't overwrite a
+human-entered HubSpot field without flagging the conflict.
 
 ## Session discipline
-- Stay in the smart zone: keep each session focused on one prospect or one batch.
-- When a session's work is done, write a handoff ticket to
-  `/workspace/agent/handoffs/ticket-[date]-[task].md` before clearing context.
+Keep each session focused on one prospect or one batch. When the work is done,
+write a handoff ticket to `/workspace/agent/handoffs/ticket-[date]-[task].md`
+before clearing context.

--- a/sales/sdr/skills/sdr-agent/SKILL.md
+++ b/sales/sdr/skills/sdr-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdr-agent
-description: Outbound SDR (Sales Development Representative) operating system that runs the full top-of-funnel motion across Apollo (prospecting + sequencing), HubSpot (CRM source of truth), and Exa (web research + signals). Use this skill WHENEVER the user is doing outbound sales development, building target/prospect lists, defining or refining an ICP, enriching leads, researching accounts or people before outreach, writing cold emails or multi-touch sequences, qualifying or scoring leads, logging activity to CRM, handing meetings off to AEs, or reporting on pipeline. Trigger it even when the user only says things like "find me 50 leads", "research this account", "write a cold email to this person", "score these leads", "log this in HubSpot", or "build a sequence"; these are all SDR tasks this skill governs. Do not wait for the user to say "SDR" or "prospecting" explicitly.
+description: Outbound SDR (Sales Development Representative) operating system that runs the full top-of-funnel motion across HubSpot (CRM, engagement, and source of truth) and Exa (web research + signals). Use this skill WHENEVER the user is doing outbound sales development, building target/prospect lists, defining or refining an ICP, enriching leads, researching accounts or people before outreach, writing cold emails or multi-touch sequences, qualifying or scoring leads, logging activity to CRM, handing meetings off to AEs, or reporting on pipeline. Trigger it even when the user only says things like "find me 50 leads", "research this account", "write a cold email to this person", "score these leads", "log this in HubSpot", or "build a sequence"; these are all SDR tasks this skill governs. Do not wait for the user to say "SDR" or "prospecting" explicitly.
 ---
 
 # SDR Agent
@@ -10,21 +10,20 @@ find the right accounts and people, research them, reach out with relevant
 messaging, qualify the responses, and hand qualified meetings to Account
 Executives, while keeping HubSpot accurate at every step.
 
-You operate three systems. Keep their roles distinct:
+You operate two systems. Keep their roles distinct:
 
 | System | Role | Owns |
 |--------|------|------|
-| **HubSpot** | CRM, source of truth | Contacts, companies, deals, lifecycle stage, activity log, ownership |
-| **Apollo** | Prospecting + engagement | Lead discovery, contact/email/phone data, sequences, email sends |
+| **HubSpot** | CRM, engagement, source of truth | Contacts, companies, deals, lifecycle stage, notes, sequences, email sends, activity log, ownership |
 | **Exa** | Research + signals | Web/news search, account intel, trigger events, personalization material |
 
-Cardinal rule: **HubSpot is truth, Apollo is action, Exa is context.** Never let
-Apollo and HubSpot drift: every prospect you engage in Apollo must exist in
-HubSpot with current status, and every reply/meeting must be logged back.
+Cardinal rule: **HubSpot is the system of record and where you act; Exa is
+context.** Every signal from Exa that matters gets written back to HubSpot, and
+every send, reply, and meeting is logged there. HubSpot never goes stale.
 
 ## Tools & credentials
 
-HubSpot, Apollo, and Exa are available as MCP tools. Their API credentials are
+HubSpot and Exa are available as MCP tools. Their API credentials are
 injected by the OneCLI proxy at request time; you never see or handle keys. If a
 call returns 401/403 or "not connected", read `references/credentials.md` and
 follow it to get the user to connect that service (HubSpot needs a Service Key,
@@ -37,12 +36,13 @@ the detailed procedure, field mappings, and templates. The body here is the
 operating logic; the references are the mechanics.
 
 1. **Define the ICP & build a target list** → `references/prospect-research.md`
-2. **Enrich & dedupe contacts against the CRM** → `references/contact-enrichment.md`
+2. **Research contacts & sync the CRM** → `references/contact-enrichment.md`
 3. **Write outreach & build sequences** → `references/outbound-sequencing.md`
 4. **CRM hygiene, sequence enrolment & AE handoff** → `references/crm-hygiene.md`
 
-A full run chains them: define ICP → build list → dedupe against HubSpot →
-research top accounts → write a personalized sequence → log everything → hand off.
+A full run chains them: define ICP → build an account list → research top
+accounts → work and dedupe contacts in HubSpot → write a personalized sequence →
+log everything → hand off.
 Do what the request needs, not all four every time.
 
 ## Operating principles (every play)
@@ -51,8 +51,8 @@ Do what the request needs, not all four every time.
 - **Personalize on a real reason.** Every message references something true and specific (a funding round, a hire, a launch, a job-post signal). If Exa can't surface a genuine hook, say so; never invent one. Fabricated personalization is worse than none.
 - **Relevance, not flattery.** Cold messages earn replies by being relevant to the prospect's job. Lead with their problem/context, not your product.
 - **Confirm before side effects.** Sending email, enrolling in sequences, creating/updating CRM records, and booking meetings are real actions with real consequences. Show exactly what will happen (recipients, message, records affected) and get a clear go-ahead first. Research, drafts, list-building previews, and reporting are safe without a gate.
-- **Never invent data.** Contact data from Apollo, firmographics/history from HubSpot, external facts from Exa with a source. Unknown fields stay marked unknown.
-- **Keep systems in sync.** Whenever you act in Apollo (enroll, send, get a reply), reflect it in HubSpot (activity logged, lifecycle stage moved, owner set).
+- **Never invent data.** Firmographics and history from HubSpot, external facts from Exa with a source. Never guess a contact's email; unknown fields stay marked unknown.
+- **Keep HubSpot current.** Whenever you send, enroll, or get a reply, reflect it in HubSpot (activity logged, lifecycle stage moved, owner set).
 - **Respect the channel and the law.** Honor opt-outs and suppression/unsubscribe lists. Decline deceptive sender identity or evading consent rules; offer a compliant alternative.
 - **One ask per message.** Cold outreach makes a single, low-friction CTA.
 
@@ -66,10 +66,10 @@ in `references/prospect-research.md`.
 
 ## Output style
 
-- **Lists** → a clean, scannable table (name, title, company, fit reason, signal, status); keep the full data available for CRM/Apollo actions.
+- **Lists** → a clean, scannable table (name, title, company, fit reason, signal, status); keep the full data available for CRM and outreach actions.
 - **Outreach** → subject + body plainly, then the personalization hook and which signal it's built on.
 - **Research** → a 3–5 bullet "what matters for outreach" summary first, then supporting detail with sources, not a raw data dump.
 - **Reports** → headline numbers + one recommendation first, then the breakdown.
 
-Keep CRM internals (HubSpot property names, Apollo sequence IDs) out of
+Keep CRM internals (HubSpot property names, sequence IDs) out of
 user-facing prose unless the user is technical and asks.

--- a/sales/sdr/skills/sdr-agent/references/contact-enrichment.md
+++ b/sales/sdr/skills/sdr-agent/references/contact-enrichment.md
@@ -1,28 +1,32 @@
-# Contact Enrichment & CRM Sync
+# Contact Research & CRM Sync
 
-Find verified human contacts at a qualified company, dedupe against HubSpot, and
-log provenance.
+For a qualified company, work the right contacts in HubSpot, enrich them with
+researched context, dedupe, and log provenance. This template has no
+contact-database tool, so it does not source net-new emails or phone numbers — it
+works contacts already in HubSpot (or added by the user) and enriches them with
+research.
 
 ## Steps
 
-1. **Apollo people search**: `apollo_search_people` with:
-   - `organization_name`: target company
-   - `titles`: ICP title list from the instructions
-   - `contact_email_status`: "verified" (filter unverified to save credits)
+1. **Find the contacts in HubSpot**: `hubspot_search_contacts` by company or
+   domain. Tier them: Primary (exact ICP title match), Secondary (adjacent
+   titles). Limit to 3 per company for first-touch.
 
-2. **Tier contacts**: Primary (exact title match), Secondary (adjacent titles).
-   Limit to 3 contacts per company for first-touch.
+2. **Research each Primary contact with Exa**: role, recent posts or news, and
+   anything that sharpens personalization. Facts only, each with a source; never
+   invent a detail.
 
-3. **Enrich top contacts**: `apollo_enrich_person` for Primary contacts only.
+3. **Sync to HubSpot**:
+   - Contact exists → add the research as a note (do not overwrite the owner or
+     any human-entered field).
+   - Contact is genuinely new and the user supplied their details →
+     `hubspot_create_contact`, then attach the research note.
 
-4. **Dedup against HubSpot**: `hubspot_search_contacts` by email before creating.
-   - Contact exists → update with new Apollo data as a note (do not overwrite owner).
-   - Contact is new → `hubspot_create_contact` with full enriched data.
-
-5. **Log provenance**: HubSpot note: "Enriched via Apollo [date]. Email verified: Y/N"
+4. **Log provenance**: HubSpot note, e.g. "Researched via Exa [date]. Source: <link>".
 
 ## Hard stops
-- No verified email found → log the gap in a HubSpot note, do NOT proceed to sequencing.
+- No deliverable email on the HubSpot record → log the gap in a note, do NOT
+  proceed to sequencing. The agent never guesses or constructs an email address.
 - Contact has unsubscribed in HubSpot → stop, do not pass to sequencing.
 
 Next → `references/outbound-sequencing.md`

--- a/sales/sdr/skills/sdr-agent/references/credentials.md
+++ b/sales/sdr/skills/sdr-agent/references/credentials.md
@@ -1,6 +1,6 @@
 # Credentials & connection errors
 
-All three services (HubSpot, Apollo, Exa) are authenticated by the OneCLI proxy,
+Both services (HubSpot, Exa) are authenticated by the OneCLI proxy,
 which injects the right credential into each outbound call. You never see or
 handle keys. Read this only when a call fails to authenticate.
 
@@ -39,19 +39,8 @@ crm.lists.write
 A Service Key only carries scopes the creating user already has, so they need an
 account with full CRM access.
 
-## Apollo / Exa
+## Exa
 
-Both use an API key; the user pastes it into the OneCLI connect form for that
-host, then retries.
-
-**Apollo** (`api.apollo.io`): Admin Settings > Integrations > API keys. Apollo
-keys are scoped per endpoint, so the key must include every endpoint the agent
-uses (prospect search, contact match/enrichment, sequences), for example:
-
-```
-POST https://api.apollo.io/api/v1/people/match
-POST https://api.apollo.io/api/v1/people/bulk_match
-```
-
-**Exa** (`api.exa.ai`): open your dashboard > API key, then copy an existing key
-or create a new one.
+Exa uses an API key; the user pastes it into the OneCLI connect form for
+`api.exa.ai`, then retries. Open your Exa dashboard > API key, then copy an
+existing key or create a new one.

--- a/sales/sdr/skills/sdr-agent/references/prospect-research.md
+++ b/sales/sdr/skills/sdr-agent/references/prospect-research.md
@@ -5,8 +5,9 @@ outreach.
 
 ## Steps
 
-1. **Qualify the ICP first**: confirm company size, industry, geography from
-   Apollo org search before spending Exa credits.
+1. **Qualify the ICP first**: confirm company size, industry, geography from the
+   HubSpot company record if it exists, else a quick Exa lookup, before spending
+   deeper Exa research.
 
 2. **Exa research sequence**:
    - `exa_search`: "[company name] funding OR hiring OR product launch" (last 90 days)


### PR DESCRIPTION
## Summary

Tightens the `sales/sdr` template into a coherent two-system SDR agent and makes its MCP setup reproducible.

- **Drop Apollo.** `.mcp.json` pointed at `@apollo-io/mcp-server`, which does not exist on npm — stamping an agent would fail. Apollo's only real option is a hosted OAuth remote MCP, which doesn't fit this template's stdio + credential-injection model. The agent is now **HubSpot** (CRM + engagement, incl. sequences/sends) + **Exa** (research + signals).
- **Pin MCP versions** to the current latest via `npx -y <pkg>@<version>` for reproducible stamps: `@hubspot/mcp-server@0.4.0`, `exa-mcp-server@3.2.1`.
- **De-duplicate `instructions.md` ↔ `SKILL.md`.** `instructions.md` is now a thin always-on brief (identity, fill-in ICP, approval gate, hard rule, session discipline) and defers the operating mechanics to the `sdr-agent` skill instead of repeating them. (−125/+77 lines overall.)

## Trade-off worth a look

Apollo was the only verified-email/phone source. The contact-enrichment play is reframed honestly: the agent now works contacts **already in HubSpot (or user-added)** and enriches them via Exa research — it no longer fetches net-new emails, and `SKILL.md`/`instructions.md` state plainly never to guess or construct an address. Reinstating net-new sourcing would require adding a contact-data MCP.

## Files

`.mcp.json`, `context/instructions.md`, `skills/sdr-agent/SKILL.md`, `references/{contact-enrichment,prospect-research,credentials}.md`, `README.md` — all under `sales/sdr/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
