### PR TITLE
Update docs for local-only template resolution and no-provider model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,8 @@ directly to what the template parser reads:
 | Path | Purpose | Required |
 |------|---------|----------|
 | `context/instructions.md` | The agent's standing brief | **Yes** |
-| `context/*.md` (others) | Extra context, auto-referenced from the instructions | No |
+| `context/*.md` (others) | Extra context, referenced from `instructions.md` by relative path (`context/<file>`) | No |
 | `.mcp.json` → `mcpServers` | MCP tool servers (command + args only) | No |
-| `agent.json` → `provider` | Provider override (defaults to `claude`) | No |
 | `skills/<name>/` | A skill (the whole folder is copied) | No |
 | `README.md` | Human docs for the template | Recommended |
 
@@ -47,13 +46,19 @@ Templates are public. Never commit API keys, tokens, or any credential.
 1. Fork this repo and create a branch.
 2. Create your template at `<category>/<template>/`.
 3. Write `context/instructions.md`, the only required file.
-4. Add what the agent needs: `.mcp.json` (no secrets), `agent.json` if you need a
-   non-default provider, any `skills/<name>/` folders, and a per-template
-   `README.md` covering what it does and which MCP servers and credentials it
-   expects.
-5. Test it end to end from your clone:
+4. Add what the agent needs: `.mcp.json` (no secrets), any `skills/<name>/`
+   folders, and a per-template `README.md` covering what it does and which MCP
+   servers and credentials it expects. The provider is not set in the template;
+   it is chosen on the agent later.
+5. Test it end to end. `--template` resolves relative to your NanoClaw install's
+   templates directory, not your clone, so do one of:
    ```bash
-   ncl groups create --template ./<category>/<template> --name "Test"
+   # Option A: point the templates dir at your clone, then stamp the bare ref
+   NANOCLAW_TEMPLATES_DIR="$(pwd)" ncl groups create --template <category>/<template> --name "Test"
+
+   # Option B: copy the template into your install's templates/ dir, then stamp
+   cp -R <category>/<template> <nanoclaw>/templates/<category>/<template>
+   ncl groups create --template <category>/<template> --name "Test"
    ```
 6. Re-check the diff for any secret before you commit.
 7. Open a PR describing what the template does and which MCP servers it expects.
@@ -64,5 +69,6 @@ Templates are public. Never commit API keys, tokens, or any credential.
 - [ ] `context/instructions.md` is present.
 - [ ] `.mcp.json` has no secrets (command and args only).
 - [ ] A per-template `README.md` explains the template and its credentials.
-- [ ] Stamped and tested locally with `ncl groups create --template ./...`.
+- [ ] Stamped and tested locally with a bare ref (via `NANOCLAW_TEMPLATES_DIR`
+      or a copy into `templates/`).
 - [ ] No API keys, tokens, or other secrets anywhere in the diff.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ an AI assistant that runs agents securely in their own containers.
 
 A **template** is a folder you can stamp into a working NanoClaw agent. It
 carries the agent's standing instructions, its MCP tool servers, and its skills,
-but **no secrets**. Point `ncl` at one and you get a configured agent group in
-seconds.
+but **no secrets and no provider**. Templates are provider-neutral; you pick the
+runtime separately, so one template works on any provider. Point `ncl` at one and
+you get a configured agent group in seconds.
 
 > New to NanoClaw? Start at the [main repo](https://github.com/nanocoai/nanoclaw)
 > or [docs.nanoclaw.dev](https://docs.nanoclaw.dev).
@@ -16,8 +17,10 @@ seconds.
 There are two ways to stamp an agent from a template.
 
 **1. During install.** Running the NanoClaw installer (`bash nanoclaw.sh`) opens
-a setup wizard. Choose **Template setup**, and it lists the templates in this
-repo so you can start your first agent from one.
+a setup wizard with two template choices: **NanoClaw template library** clones
+this repo and copies the template you pick into your local `templates/`, and
+**Local templates** lists what is already in `templates/`. It then stamps and
+wires your first agent.
 
 **2. Anytime, via the CLI:**
 
@@ -25,29 +28,18 @@ repo so you can start your first agent from one.
 ncl groups create --template sales/sdr --name "SDR Agent"
 ```
 
-`--template <ref>` accepts three forms, resolved by the *shape* of the value.
-They are checked **in this order**, and the first match wins:
+`--template <ref>` is a path relative to your local templates directory
+(`templates/` by default, or `NANOCLAW_TEMPLATES_DIR`, a local path only).
+Refs are multi-segment, e.g. `sales/sdr` resolves to `templates/sales/sdr`.
+For safety, absolute paths, a leading `~`, and `../` escapes are rejected.
 
-| Form | Example | What it does |
-|------|---------|--------------|
-| **Local path** (`./` `../` `/` `~`) | `./sales/sdr` | Stamp from a folder on disk |
-| **Git repo** (`git+…`, `git@…`, `*.git`) | `git+https://github.com/you/repo.git#path@v1` | Clone and stamp from any repo |
-| **Bare name** (fallback) | `sales/sdr` | Fetch `<category>/<template>` from this repo |
+To use a template from this repo, get it into your local `templates/` first.
+The install wizard's **NanoClaw template library** option clones this repo and
+copies the template you pick into `templates/` for you; or copy the folder by
+hand. Then stamp it with its bare ref.
 
-A bare name like `sales/sdr` is the common case for this repo. It's the
-fallback used when the value isn't a local path or a git URL.
-
-Extras:
-
-- `@<ref>` pins a branch or tag, not a commit SHA (e.g. `sales/sdr@v2`)
-- `#<subpath>` selects a folder inside a git repo
-- `--source <git-uri>` overrides the default repo (applies to **bare names** only)
-- `--name` is optional; without it the agent group is named after the template folder
-
-The default source for bare names is
-`git+https://github.com/nanocoai/nanoclaw-templates`. There is no local cache:
-each stamp re-fetches the template, copies it into your new agent group, then
-discards the clone.
+`--name` is optional; without it the agent group is named after the template
+folder.
 
 ## Repository layout
 
@@ -75,10 +67,9 @@ defaults sensibly.
 ```
 <template>/
 ├── context/
-│   ├── instructions.md   # REQUIRED: the agent's standing brief
-│   └── *.md              # optional: extra context, auto-appended to instructions as @context/<file>.md
+│   ├── instructions.md   # REQUIRED: the agent's persona (marks the folder as a template)
+│   └── *.md              # optional: extra context, referenced from instructions.md by relative path
 ├── .mcp.json             # optional: MCP servers (command/args/env), NO secrets
-├── agent.json            # optional: {"provider": "claude"}
 ├── skills/
 │   └── <name>/           # optional: one folder per skill (SKILL.md + any references/)
 └── README.md             # recommended: docs for this template
@@ -86,18 +77,22 @@ defaults sensibly.
 
 | Path | Loaded as | Required |
 |------|-----------|----------|
-| `context/instructions.md` | The agent's instructions | **Yes** |
-| `context/*.md` (others) | Extra context files | No |
+| `context/instructions.md` | The agent's persona, prepended to its `CLAUDE.md`/`AGENTS.md` every spawn (system-prompt tier, any provider) | **Yes** |
+| `context/*.md` (others) | Extra context, referenced from `instructions.md` by relative path (`context/<file>`) | No |
 | `.mcp.json` → `mcpServers` | MCP tool servers | No |
-| `agent.json` → `provider` | Provider (defaults to `claude`) | No |
 | `skills/<name>/` | A skill (folder copied whole) | No |
 
 Notes for template authors:
 
 - The presence of `context/instructions.md` is what marks a folder as a
   template, both for listing and for stamping.
-- `agent.json` only reads **`provider`**. There is no `model`/`effort` key here;
-  those are configured on the agent later, not from the template.
+- **Keep `instructions.md` focused (under ~200 lines).** It is always in the
+  agent's prompt, and some providers cap that doc (Codex ~32 KB), so an
+  over-long persona gets truncated. Put bulk material in `skills/` or
+  `context/*.md`.
+- **Reference extra `context/*.md` by plain relative path** from
+  `instructions.md` (e.g. `` `context/pricing.md` ``), not `@context/...`. A
+  plain path works under any provider.
 - Each immediate subfolder of `skills/` is **one skill**, named after the folder.
   The entire folder is copied, so place `SKILL.md` and any `references/*.md`
   inside it per the skills convention.

--- a/sales/sdr/.mcp.json
+++ b/sales/sdr/.mcp.json
@@ -2,7 +2,8 @@
   "mcpServers": {
     "hubspot": {
       "command": "npx",
-      "args": ["-y", "@hubspot/mcp-server@0.4.0"]
+      "args": ["-y", "@hubspot/mcp-server@0.4.0"],
+      "env": { "PRIVATE_APP_ACCESS_TOKEN": "placeholder" }
     },
     "exa": {
       "command": "npx",

--- a/sales/sdr/README.md
+++ b/sales/sdr/README.md
@@ -11,7 +11,6 @@ else in this folder is loaded by the parser.
 ```
 sdr/
 ├── .mcp.json                       # MCP servers (HubSpot, Exa): command + args only, no secrets
-├── agent.json                      # OPTIONAL: provider override, e.g. {"provider": "..."}
 ├── context/
 │   └── instructions.md             # REQUIRED: the agent's standing brief
 ├── skills/
@@ -25,9 +24,8 @@ sdr/
 └── README.md                       # this file
 ```
 
-Optional, if you need them: `agent.json` (`{"provider": "..."}`) and extra
-`context/*.md` files (auto-referenced from `instructions.md`). If `agent.json`
-is absent or omits `provider`, the agent defaults to Claude.
+Optional, if you need them: extra `context/*.md` files, referenced from
+`instructions.md` by plain relative path (e.g. `context/<file>.md`).
 
 ## Stamp an agent from this template
 

--- a/sales/sdr/agent.json
+++ b/sales/sdr/agent.json
@@ -1,3 +1,0 @@
-{
-    "provider": "claude"
-}


### PR DESCRIPTION
Brings `README.md`, `CONTRIBUTING.md`, and the `sales/sdr` example in line with the NanoClaw-side changes to template resolution and how a template's parts reach the agent. The docs previously described the old model.

## What changed

- **Template resolution is local-only.** `--template <ref>` is a path under the local templates dir (`templates/` by default, or `NANOCLAW_TEMPLATES_DIR`). Removed git URLs, `--source`, `@<ref>` pins, `#<subpath>`, and the remote-fetch / no-local-cache language. Install-wizard flow updated to the two template choices.
- **Templates carry no provider.** Removed every `agent.json` reference and deleted `sales/sdr/agent.json`. Provider is chosen on the agent later, not baked into the template. Intro now says "no secrets **and no provider**".
- **`instructions.md` is the persona** (system-prompt tier on any provider). Added the ~200-line / Codex ~32 KB truncation note; bulk material goes in `skills/` or `context/*.md`.
- **Extra `context/*.md` are referenced by plain relative path**, not `@context/...` (Claude-only, resolves wrong once the persona is composed).
- **`CONTRIBUTING` local-test command fixed** — `--template` resolves against the install's templates dir, so use a bare ref via `NANOCLAW_TEMPLATES_DIR` or a copy into `templates/`. PR checklist updated.

## Files
- `README.md` — ref-forms section, install paragraph, anatomy tree + table, author notes, intro framing
- `CONTRIBUTING.md` — template table, add-a-template steps, PR checklist
- `sales/sdr/README.md` — dropped `agent.json` + provider paragraph
- `sales/sdr/agent.json` — deleted