### PR TITLE
Fix extra-context referencing to match additional_context/ convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ directly to what the template parser reads:
 | Path | Purpose | Required |
 |------|---------|----------|
 | `context/instructions.md` | The agent's standing brief | **Yes** |
-| `context/*.md` (others) | Extra context, referenced from `instructions.md` by relative path (`context/<file>`) | No |
+| `context/additional_context/*.md` | Extra context, referenced from `instructions.md` by relative path (`additional_context/<file>`) | No |
 | `.mcp.json` → `mcpServers` | MCP tool servers (command + args only) | No |
 | `skills/<name>/` | A skill (the whole folder is copied) | No |
 | `README.md` | Human docs for the template | Recommended |

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ defaults sensibly.
 ```
 <template>/
 ├── context/
-│   ├── instructions.md   # REQUIRED: the agent's persona (marks the folder as a template)
-│   └── *.md              # optional: extra context, referenced from instructions.md by relative path
+│   ├── instructions.md          # REQUIRED: the agent's persona (marks the folder as a template)
+│   └── additional_context/      # optional: extra .md files, referenced from instructions.md by relative path
+│       └── *.md
 ├── .mcp.json             # optional: MCP servers (command/args/env), NO secrets
 ├── skills/
 │   └── <name>/           # optional: one folder per skill (SKILL.md + any references/)
@@ -78,7 +79,7 @@ defaults sensibly.
 | Path | Loaded as | Required |
 |------|-----------|----------|
 | `context/instructions.md` | The agent's persona, prepended to its `CLAUDE.md`/`AGENTS.md` every spawn (system-prompt tier, any provider) | **Yes** |
-| `context/*.md` (others) | Extra context, referenced from `instructions.md` by relative path (`context/<file>`) | No |
+| `context/additional_context/*.md` | Extra context, referenced from `instructions.md` by relative path (`additional_context/<file>`) | No |
 | `.mcp.json` → `mcpServers` | MCP tool servers | No |
 | `skills/<name>/` | A skill (folder copied whole) | No |
 
@@ -89,10 +90,13 @@ Notes for template authors:
 - **Keep `instructions.md` focused (under ~200 lines).** It is always in the
   agent's prompt, and some providers cap that doc (Codex ~32 KB), so an
   over-long persona gets truncated. Put bulk material in `skills/` or
-  `context/*.md`.
-- **Reference extra `context/*.md` by plain relative path** from
-  `instructions.md` (e.g. `` `context/pricing.md` ``), not `@context/...`. A
-  plain path works under any provider.
+  `context/additional_context/`.
+- **Put extra context under `context/additional_context/` and reference it by
+  plain relative path** from `instructions.md` (e.g.
+  `` `additional_context/pricing.md` ``), not `@...`. Extras are copied with the
+  `context/` prefix stripped, so `context/additional_context/pricing.md` becomes
+  `additional_context/pricing.md` in the agent's workspace — the same path you
+  reference. A plain path works under any provider.
 - Each immediate subfolder of `skills/` is **one skill**, named after the folder.
   The entire folder is copied, so place `SKILL.md` and any `references/*.md`
   inside it per the skills convention.

--- a/sales/sdr/README.md
+++ b/sales/sdr/README.md
@@ -45,8 +45,15 @@ and injects them into outbound HTTPS calls at the proxy boundary, so the
 HubSpot/Exa MCP servers reach their APIs authenticated without the token
 ever sitting in `.mcp.json`, the container env, or chat context.
 
-That is why `.mcp.json` here carries only `command` + `args`. Do not add an `env`
-block with real keys.
+That is why `.mcp.json` here carries `command` + `args` and never a real key.
+
+**Exception — HubSpot's placeholder env (leave it as-is).** `@hubspot/mcp-server`
+refuses to start unless `PRIVATE_APP_ACCESS_TOKEN` is *present*, so `.mcp.json`
+sets it to the dummy value `"placeholder"`. It is not the credential: once you
+connect HubSpot (either setup path below), the real key is injected
+automatically for `api.hubapi.com` at request time. Keep the placeholder, and
+**never** replace it with a real token. Exa needs no such placeholder and gets
+none.
 
 
 ### 1. Register each credential in the OneCLI vault (manual route)

--- a/sales/sdr/README.md
+++ b/sales/sdr/README.md
@@ -24,8 +24,9 @@ sdr/
 └── README.md                       # this file
 ```
 
-Optional, if you need them: extra `context/*.md` files, referenced from
-`instructions.md` by plain relative path (e.g. `context/<file>.md`).
+Optional, if you need them: extra `context/additional_context/*.md` files,
+referenced from `instructions.md` by plain relative path (e.g.
+`additional_context/<file>.md`).
 
 ## Stamp an agent from this template
 


### PR DESCRIPTION
## Summary

Aligns the templates-repo docs with the extra-context contract from
[nanoclaw#2890](https://github.com/nanocoai/nanoclaw/pull/2890). The earlier
doc pass (#3) dropped git-URL/`agent.json`/provider staleness but missed the
`additional_context/` layout.

The loader copies extra context files with the `context/` prefix **stripped**,
so `context/additional_context/pricing.md` is read by the agent as
`additional_context/pricing.md`. The docs still told authors to reference
extras as `context/<file>`, which does **not** resolve in the agent's
workspace — a correctness bug for any future template shipping extra context.

## Changes (docs only)

- `README.md` — tree shows `context/additional_context/*.md`; anatomy table +
  authors' note corrected to `additional_context/<file>`; note now explains the
  prefix-stripping mechanic; "keep instructions.md focused" bullet points bulk
  at `context/additional_context/`.
- `CONTRIBUTING.md` — anatomy table row corrected.
- `sales/sdr/README.md` — optional-extras note corrected; document the HubSpot
  `PRIVATE_APP_ACCESS_TOKEN: "placeholder"` env (added in #3): it satisfies the
  server's boot check and must stay, the real key is injected once HubSpot is
  connected. Fixes the stale "only command + args, never add env" line.

No template currently ships extra context files, so nothing runtime-broken
today; this fixes the authoring guidance before someone follows it.