### PR TITLE
fix(sales/sdr): correct MCP tool names to match pinned servers

### DIFF
--- a/sales/sdr/skills/sdr-agent/references/contact-enrichment.md
+++ b/sales/sdr/skills/sdr-agent/references/contact-enrichment.md
@@ -8,9 +8,9 @@ research.
 
 ## Steps
 
-1. **Find the contacts in HubSpot**: `hubspot_search_contacts` by company or
-   domain. Tier them: Primary (exact ICP title match), Secondary (adjacent
-   titles). Limit to 3 per company for first-touch.
+1. **Find the contacts in HubSpot**: `hubspot-search-objects` (objectType
+   `contacts`) by company or domain. Tier them: Primary (exact ICP title match),
+   Secondary (adjacent titles). Limit to 3 per company for first-touch.
 
 2. **Research each Primary contact with Exa**: role, recent posts or news, and
    anything that sharpens personalization. Facts only, each with a source; never
@@ -20,7 +20,8 @@ research.
    - Contact exists → add the research as a note (do not overwrite the owner or
      any human-entered field).
    - Contact is genuinely new and the user supplied their details →
-     `hubspot_create_contact`, then attach the research note.
+     `hubspot-batch-create-objects` (objectType `contacts`), then attach the
+     research note.
 
 4. **Log provenance**: HubSpot note, e.g. "Researched via Exa [date]. Source: <link>".
 

--- a/sales/sdr/skills/sdr-agent/references/crm-hygiene.md
+++ b/sales/sdr/skills/sdr-agent/references/crm-hygiene.md
@@ -13,8 +13,9 @@ Account Executive.
 1. Confirm the pre-flight checklist from `references/outbound-sequencing.md` is complete.
 2. Show the user: contact name, email, sequence name, send-from address.
 3. Wait for an explicit "yes" / "confirmed" in chat.
-4. `hubspot_enroll_sequence` only after confirmation.
-5. Log: "Enrolled in [sequence name] by SDR agent on [date]. Approved by user."
+4. The pinned HubSpot MCP server exposes no sequence-enrolment tool — after
+   confirmation, ask the user to enrol the contact in HubSpot directly.
+5. Log: "Enrolled in [sequence name] on [date]. Approved by user."
 
 ## Handoff to AE
 When a prospect replies positively:

--- a/sales/sdr/skills/sdr-agent/references/outbound-sequencing.md
+++ b/sales/sdr/skills/sdr-agent/references/outbound-sequencing.md
@@ -11,7 +11,8 @@ Draft signal-led outreach and a 3-touch sequence. Never send without approval.
 
 ## Drafting a first-touch email
 
-1. Pull the prospect brief note from HubSpot (`hubspot_get_company` → notes).
+1. Pull the prospect brief note from HubSpot (`hubspot-list-associations`
+   companies → notes, then `hubspot-get-engagement`).
 2. Pick the single strongest signal from the brief.
 3. Draft using this structure:
    - **Line 1**: Specific signal reference ("Saw you just closed your Series B…")

--- a/sales/sdr/skills/sdr-agent/references/prospect-research.md
+++ b/sales/sdr/skills/sdr-agent/references/prospect-research.md
@@ -10,9 +10,9 @@ outreach.
    deeper Exa research.
 
 2. **Exa research sequence**:
-   - `exa_search`: "[company name] funding OR hiring OR product launch" (last 90 days)
-   - `exa_search`: "[company name] tech stack OR integrations"
-   - `exa_get_contents`: pull the top 2 results for detail
+   - `web_search_exa`: "[company name] funding OR hiring OR product launch category:news" (last 90 days)
+   - `web_search_exa`: "[company name] tech stack OR integrations"
+   - `web_fetch_exa`: pull the top 2 results for detail
 
 3. **Signal scoring**: rate the prospect High / Medium / Low based on:
    - Recent funding (High)


### PR DESCRIPTION
## Summary

The sdr template's play references named MCP tools that don't exist at the pinned server versions. Verified the real tool names by downloading the published npm packages (`exa-mcp-server@3.2.1`, `@hubspot/mcp-server@0.4.0`) and inspecting their tool-registration code:

- Exa 3.2.1 default-enables only `web_search_exa` and `web_fetch_exa`; everything else ships disabled and mostly deprecated. `web_search_exa` parses inline `category:(company|research paper|news|personal site|people)` hints out of the query string.
- HubSpot 0.4.0 exposes 21 generic kebab-case tools (objects/engagements/associations) — no contact-, company-, or sequence-specific tools.

## Corrections

- **prospect-research.md**: `exa_search` → `web_search_exa` (with `category:news` on the funding/hiring/launch query); `exa_get_contents` → `web_fetch_exa`
- **contact-enrichment.md**: `hubspot_search_contacts` → `hubspot-search-objects` (objectType `contacts`); `hubspot_create_contact` → `hubspot-batch-create-objects` (objectType `contacts`)
- **outbound-sequencing.md**: `hubspot_get_company` → `hubspot-list-associations` (companies → notes) + `hubspot-get-engagement`
- **crm-hygiene.md**: `hubspot_enroll_sequence` has no equivalent in the pinned server (zero sequence-related code in the package) — the step now surfaces the limitation and hands enrolment to the user; the confirmation gate and log step remain

Diff is tool-name corrections only: 4 files, +13/−10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)