### PR TITLE
docs: document scheduled tasks in templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ directly to what the template parser reads:
 | `context/additional_context/*.md` | Extra context, referenced from `instructions.md` by relative path (`additional_context/<file>`) | No |
 | `.mcp.json` → `mcpServers` | MCP tool servers (command + args only) | No |
 | `skills/<name>/` | A skill (the whole folder is copied) | No |
+| `tasks/*.md` | Recurring scheduled tasks, created paused | No |
 | `README.md` | Human docs for the template | Recommended |
 
 The presence of `context/instructions.md` is what marks a folder as a template.
@@ -47,9 +48,10 @@ Templates are public. Never commit API keys, tokens, or any credential.
 2. Create your template at `<category>/<template>/`.
 3. Write `context/instructions.md`, the only required file.
 4. Add what the agent needs: `.mcp.json` (no secrets), any `skills/<name>/`
-   folders, and a per-template `README.md` covering what it does and which MCP
-   servers and credentials it expects. The provider is not set in the template;
-   it is chosen on the agent later.
+   folders, optional recurring tasks under `tasks/*.md`, and a per-template
+   `README.md` covering what it does and which MCP servers and credentials it
+   expects. The provider is not set in the template; it is chosen on the agent
+   later.
 5. Test it end to end. `--template` resolves relative to your NanoClaw install's
    templates directory, not your clone, so do one of:
    ```bash
@@ -60,14 +62,18 @@ Templates are public. Never commit API keys, tokens, or any credential.
    cp -R <category>/<template> <nanoclaw>/templates/<category>/<template>
    ncl groups create --template <category>/<template> --name "Test"
    ```
+   If the template defines tasks, confirm they appear paused with
+   `ncl tasks list --status paused`.
 6. Re-check the diff for any secret before you commit.
-7. Open a PR describing what the template does and which MCP servers it expects.
+7. Open a PR describing what the template does, including any predefined tasks
+   and MCP servers it expects.
 
 ## PR checklist
 
 - [ ] Template lives under an appropriate `<category>/<template>/`.
 - [ ] `context/instructions.md` is present.
 - [ ] `.mcp.json` has no secrets (command and args only).
+- [ ] Every `tasks/*.md` file has only `schedule` frontmatter and a prompt body.
 - [ ] A per-template `README.md` explains the template and its credentials.
 - [ ] Stamped and tested locally with a bare ref (via `NANOCLAW_TEMPLATES_DIR`
       or a copy into `templates/`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ Templates are public. Never commit API keys, tokens, or any credential.
 
 - `.mcp.json` carries `command` and `args` only. Do not add an `env` block with
   real keys.
+- Task scripts may call external services, but must not contain credentials.
 - Credentials are injected at request time by the OneCLI gateway, not baked into
   the template. If your template needs a service connected, document how to get
   the key and which scopes it needs in the template's own `README.md` (see
@@ -63,7 +64,9 @@ Templates are public. Never commit API keys, tokens, or any credential.
    ncl groups create --template <category>/<template> --name "Test"
    ```
    If the template defines tasks, confirm they appear paused with
-   `ncl tasks list --status paused`.
+   `ncl tasks list --status paused`. For a scripted task, also run it once
+   with `ncl tasks run <task-id>` and inspect it with
+   `ncl tasks get <task-id>`.
 6. Re-check the diff for any secret before you commit.
 7. Open a PR describing what the template does, including any predefined tasks
    and MCP servers it expects.
@@ -73,7 +76,8 @@ Templates are public. Never commit API keys, tokens, or any credential.
 - [ ] Template lives under an appropriate `<category>/<template>/`.
 - [ ] `context/instructions.md` is present.
 - [ ] `.mcp.json` has no secrets (command and args only).
-- [ ] Every `tasks/*.md` file has only `schedule` frontmatter and a prompt body.
+- [ ] Every `tasks/*.md` file has a nonempty `schedule`, an optional nonempty
+      `script`, no other frontmatter fields, and a prompt body.
 - [ ] A per-template `README.md` explains the template and its credentials.
 - [ ] Stamped and tested locally with a bare ref (via `NANOCLAW_TEMPLATES_DIR`
       or a copy into `templates/`).

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Prebuilt agent templates for [NanoClaw](https://github.com/nanocoai/nanoclaw),
 an AI assistant that runs agents securely in their own containers.
 
 A **template** is a folder you can stamp into a working NanoClaw agent. It
-carries the agent's standing instructions, its MCP tool servers, and its skills,
-but **no secrets and no provider**. Templates are provider-neutral; you pick the
-runtime separately, so one template works on any provider. Point `ncl` at one and
-you get a configured agent group in seconds.
+carries the agent's standing instructions, its MCP tool servers, its skills, and
+optional recurring tasks, but **no secrets and no provider**. Templates are
+provider-neutral; you pick the runtime separately, so one template works on any
+provider. Point `ncl` at one and you get a configured agent group in seconds.
 
 > New to NanoClaw? Start at the [main repo](https://github.com/nanocoai/nanoclaw)
 > or [docs.nanoclaw.dev](https://docs.nanoclaw.dev).
@@ -73,6 +73,7 @@ defaults sensibly.
 ├── .mcp.json             # optional: MCP servers (command/args/env), NO secrets
 ├── skills/
 │   └── <name>/           # optional: one folder per skill (SKILL.md + any references/)
+├── tasks/*.md            # optional: recurring tasks, created paused
 └── README.md             # recommended: docs for this template
 ```
 
@@ -82,6 +83,7 @@ defaults sensibly.
 | `context/additional_context/*.md` | Extra context, referenced from `instructions.md` by relative path (`additional_context/<file>`) | No |
 | `.mcp.json` → `mcpServers` | MCP tool servers | No |
 | `skills/<name>/` | A skill (folder copied whole) | No |
+| `tasks/*.md` | Recurring scheduled tasks, created paused pending user activation | No |
 
 Notes for template authors:
 
@@ -100,6 +102,22 @@ Notes for template authors:
 - Each immediate subfolder of `skills/` is **one skill**, named after the folder.
   The entire folder is copied, so place `SKILL.md` and any `references/*.md`
   inside it per the skills convention.
+- Each immediate Markdown file under `tasks/` defines one recurring task. The
+  filename becomes the task name, `schedule` is a cron expression, and the body
+  is the prompt:
+
+  ```markdown
+  ---
+  schedule: "0 9 * * 1-5"
+  ---
+
+  Review the pipeline and prepare the weekday sales briefing.
+  ```
+
+  Only `schedule` is accepted in the frontmatter. Tasks are validated when the
+  template is stamped, use the NanoClaw install timezone, and start paused. List
+  them with `ncl tasks list --group <agent-group-id> --status paused` and enable
+  one with `ncl tasks resume <task-id>`.
 - **Never commit secrets.** `.mcp.json` carries `command` + `args` only.
   Credentials are injected at request time by the OneCLI gateway. See a
   template's own README (e.g. [`sales/sdr/README.md`](sales/sdr/README.md)) for

--- a/README.md
+++ b/README.md
@@ -103,21 +103,33 @@ Notes for template authors:
   The entire folder is copied, so place `SKILL.md` and any `references/*.md`
   inside it per the skills convention.
 - Each immediate Markdown file under `tasks/` defines one recurring task. The
-  filename becomes the task name, `schedule` is a cron expression, and the body
-  is the prompt:
+  filename becomes the task name, `schedule` is a cron expression, an optional
+  `script` can decide whether to wake the agent, and the body is the prompt:
 
   ```markdown
   ---
-  schedule: "0 9 * * 1-5"
+  schedule: "*/15 * * * *"
+  script: |
+    if [ -f /workspace/agent/wake-next-task ]; then
+      echo '{"wakeAgent": true}'
+    else
+      echo '{"wakeAgent": false}'
+    fi
   ---
 
-  Review the pipeline and prepare the weekday sales briefing.
+  Handle the condition reported by the script.
   ```
 
-  Only `schedule` is accepted in the frontmatter. Tasks are validated when the
-  template is stamped, use the NanoClaw install timezone, and start paused. List
-  them with `ncl tasks list --group <agent-group-id> --status paused` and enable
-  one with `ncl tasks resume <task-id>`.
+  `schedule` is required. `script` is optional and may be a single-line or
+  multiline YAML string. No other frontmatter fields are accepted. Scripts use
+  NanoClaw's normal scheduled-task behavior; see
+  [Scheduled Tasks](https://github.com/nanocoai/nanoclaw/blob/main/docs/scheduled-tasks.md#script-gates)
+  for the contract, testing workflow, limits, and failure behavior.
+
+  Tasks are validated when the template is stamped, use the NanoClaw install
+  timezone, and start paused. List them with
+  `ncl tasks list --group <agent-group-id> --status paused` and enable one with
+  `ncl tasks resume <task-id>`.
 - **Never commit secrets.** `.mcp.json` carries `command` + `args` only.
   Credentials are injected at request time by the OneCLI gateway. See a
   template's own README (e.g. [`sales/sdr/README.md`](sales/sdr/README.md)) for


### PR DESCRIPTION
## What

Documents how registry templates can define recurring scheduled tasks in `tasks/*.md`, including optional script gates.

## Why

Template authors need the supported file format, paused activation behavior, and local testing steps documented beside the template catalog. Detailed task and script behavior should stay in NanoClaw's canonical guide instead of being taught twice.

This documentation accompanies nanocoai/nanoclaw#3022.

## How

- Add `tasks/*.md` to the template anatomy and contribution guide.
- Show YAML frontmatter with the required `schedule` and optional multiline `script`.
- Explain that the Markdown body is the agent prompt.
- Explain that template tasks are validated when stamped and created paused.
- Recommend keeping credentials out of template scripts.
- Link to NanoClaw's scheduled-tasks guide for script output, execution, limits, testing, and runtime behavior.
- Add list, inspect, run, and resume commands plus contribution checklist coverage.

## How tested

- `git diff --check` passed.
- Confirmed the documented format matches nanocoai/nanoclaw#3022.
- The companion NanoClaw branch passes 93 host test files with 1,137 tests, build, formatting, touched-file lint, and 3 container script-gate tests.
