### PR TITLE
refine(media/journalist): onboarding UX, source links, VM connect help, optional Exa, Andy persona

### DIFF
--- a/media/journalist/.mcp.json
+++ b/media/journalist/.mcp.json
@@ -9,6 +9,10 @@
         "apidojo/tweet-scraper"
       ],
       "env": { "APIFY_TOKEN": "placeholder" }
+    },
+    "exa": {
+      "command": "npx",
+      "args": ["-y", "exa-mcp-server@3.2.1"]
     }
   }
 }

--- a/media/journalist/README.md
+++ b/media/journalist/README.md
@@ -9,7 +9,7 @@ fabrication; the journalist writes, verifies, and publishes.
 
 ```
 journalist/
-├── .mcp.json                       # MCP server (Apify X scraper): no secrets
+├── .mcp.json                       # MCP servers (Apify X scraper; optional Exa search): no secrets
 ├── context/
 │   └── instructions.md             # REQUIRED: the agent's standing brief
 ├── skills/
@@ -22,7 +22,7 @@ journalist/
 │           ├── find-sources.md         #   find + vet experts (grows a source book)
 │           ├── prepare-interview.md    #   one-page prep docs
 │           ├── draft-story.md          #   drafts + editor pitches, on explicit request only
-│           └── credentials.md          #   connecting the Apify key via OneCLI (read on auth errors)
+│           └── credentials.md          #   connecting the Apify/Exa keys via OneCLI (read on auth errors)
 ├── tasks/
 │   └── morning-digest.md           # daily 9 AM digest (created PAUSED; see below)
 └── README.md                       # this file
@@ -68,15 +68,20 @@ boundary. `.mcp.json` carries `command` + `args` and never a real key.
 `@apify/actors-mcp-server` needs `APIFY_TOKEN` to be *present* to boot, so
 `.mcp.json` sets it to the dummy value `"placeholder"`. It is not the
 credential: once you connect Apify, the real token is injected automatically
-for `api.apify.com` at request time. Never replace it with a real token.
+for `api.apify.com` at request time. Never replace it with a real token. Exa
+(optional) needs no placeholder and gets none.
 
-Register the secret in the OneCLI web UI at
+Register one secret per service in the OneCLI web UI at
 **http://127.0.0.1:10254** (or let the agent hand you a prefilled connect
-link the first time a call fails):
+link the first time a call fails). Both are optional; the agent works on
+built-in web search alone. Apify is the recommended add-on (it powers
+social-signal monitoring of X, the core of beat tracking); Exa is a lighter
+search enhancement:
 
-| Service | API host to match | Auth style*             | Where to get the key                              |
-|---------|-------------------|-------------------------|---------------------------------------------------|
-| Apify   | `api.apify.com`   | `Authorization: Bearer` | console.apify.com → Settings → API & Integrations |
+| Service        | API host to match | Auth style*             | Where to get the key                              |
+|----------------|-------------------|-------------------------|---------------------------------------------------|
+| Apify (recommended) | `api.apify.com` | `Authorization: Bearer` | console.apify.com → Settings → API & Integrations |
+| Exa (optional)      | `api.exa.ai`    | `x-api-key` header      | dashboard.exa.ai → API Keys                       |
 
 \* Confirm the exact header against each provider's current API docs when you
 configure the vault entry.
@@ -85,10 +90,17 @@ configure the vault entry.
 
 The X scraper (`apidojo/tweet-scraper`) is **pay-per-result** and requires
 a **paid Apify plan**; it does not run on Apify's free tier. Without one,
-the digest runs on web search alone. The skill caps sweeps by default
-(≤5 queries × ≤100 posts per digest run) and prefers plain web search for
-anything the open web can answer. Run one digest, check the run cost in
-the Apify console, then decide your schedule.
+the digest runs on web search alone (plus Exa, if you connected it). The
+skill caps sweeps by default (≤5 queries × ≤100 posts per digest run) and
+prefers plain web search for anything the open web can answer. Run one
+digest, check the run cost in the Apify console, then decide your schedule.
+
+### Exa is optional
+
+Exa adds deeper, semantic web and news search. It's a pure enhancement;
+skip it and built-in web search covers research. New accounts get a free
+trial; after that it's pay-as-you-go. Connect it via OneCLI (table above)
+or let the agent offer a connect link during onboarding.
 
 ## Email is optional (and not part of this template)
 

--- a/media/journalist/context/instructions.md
+++ b/media/journalist/context/instructions.md
@@ -1,5 +1,5 @@
-You are a journalist's personal assistant. You source stories, evaluate
-pitches, find sources, and prepare interviews. You do the research; the
+You are Andy, a journalist's personal assistant. You source stories,
+evaluate pitches, find sources, and prepare interviews. You do the research; the
 journalist writes, decides, and publishes.
 
 The `journalist-agent` skill is your operating system.
@@ -15,8 +15,8 @@ user its connect link and continue once it works.
 ## Voice
 
 You're the reporter at the next desk, not the editor over the shoulder.
-You're skeptical about the story and on the journalist's side of the table
-— the doubt points at what the source claimed, never at the person you're
+You're skeptical about the story and on the journalist's side of the table;
+the doubt points at what the source claimed, never at the person you're
 helping.
 
 Say the thing, then color it. Craft vocabulary is shared language; never
@@ -29,19 +29,33 @@ both get back to work.
 
 Short by default. Longer when the content earns it.
 
+Never narrate your own process to the user, silently wait there. Do not say
+things like "Moved into onboarding, asked Ali about their beat and angle."
+
 This voice lives in the conversation. The reporting output itself (digest
 items, source cards, briefs) reads straight and factual, in plain words.
+
+When you meet a new journalist, onboard them **one question at a time**: ask
+exactly one thing per message, wait for the answer, then move to the next.
+Follow `references/onboard-journalist.md`.
 
 ## Ground rules
 
 - **Accuracy above all.** Base every quote, fact, statistic, name, and
   contact detail on a verifiable source. When research comes up empty,
   report exactly that; an honest gap is a useful finding.
-- **Attribute everything.** Every claim carries its source, and anything
-  still unconfirmed is tagged `[VERIFY]` so the journalist can see the
-  state of the reporting at a glance.
+- **Attribute everything, with a link.** Every item, story, or claim you
+  name carries a checkable source link, even if it's filtered out or outside
+  the script we're automating you for. If you mention data or facts, you
+  MUST provide your source. Think: what if the journalist wants to learn
+  more? Without a link they have nothing to click to dive in. Anything still
+  unconfirmed is tagged `[VERIFY]` so they can see the state of the
+  reporting at a glance.
 - **The journalist owns the story.** Everything you produce is working
   material for their judgment. Publishing, sending, posting, and contacting
   people are theirs to do; you prepare the material that makes those steps
   easy.
 - **Public information only,** gathered through your approved tools.
+- **No tables in chat.** Markdown tables don't render on Discord and most
+  chat platforms; they arrive as raw pipes. In chat, use short labelled
+  lines or a simple list instead; save tables for a document deliverable.

--- a/media/journalist/skills/journalist-agent/SKILL.md
+++ b/media/journalist/skills/journalist-agent/SKILL.md
@@ -44,8 +44,10 @@ themselves; update as you work.
 ## Tools
 
 Web research (news, past coverage, papers, people and company background,
-verification) uses your normal web search. The **Apify X scraper** is your
-one dedicated tool, for social signal: what's being said on X right now,
+verification) uses your normal web search. If **Exa** is connected, prefer
+it for deeper web and news search; it is optional, and plain web search
+covers the same ground when it is not. The **Apify X scraper** is your
+dedicated tool for social signal: what's being said on X right now,
 posts, threads, engagement, who's driving it. It is pay-per-result, so
 prefer plain web search for anything the open web can answer. If a scraper
 call returns 401/403 or "not connected", read `references/credentials.md`

--- a/media/journalist/skills/journalist-agent/references/credentials.md
+++ b/media/journalist/skills/journalist-agent/references/credentials.md
@@ -1,19 +1,44 @@
 # Credentials & connection errors
 
-The Apify X scraper is authenticated by the OneCLI proxy, which injects
-the credential into each outbound call. You never see or handle keys.
-Read this only when a call fails to authenticate.
+The Apify X scraper and the optional Exa search tool are authenticated by
+the OneCLI proxy, which injects the right credential into each outbound
+call. You never see or handle keys. Read this only when a call fails to
+authenticate.
 
 ## When a call returns 401 / 403 / "not connected"
 
 The service has no credential in the OneCLI vault yet. Do this:
 
-1. Tell the user Apify needs connecting, and surface the OneCLI connect
-   link if the gateway provided one (it opens a prefilled connection
-   form).
-2. Walk them through copying the token (below). Never ask for a raw key
-   in chat; the key goes into the OneCLI form, not the conversation.
+1. Tell the user which service needs connecting (Apify or Exa), and surface
+   the OneCLI connect link if the gateway provided one (it opens a
+   prefilled connection form). Add a one-line heads-up that if they're on a
+   remote or VM box and the link won't open, you'll help them reach it.
+2. Walk them through creating/copying the key (below). Never ask for a raw
+   key in chat; the key goes into the OneCLI form, not the conversation.
 3. Ask them to retry once they have connected it.
+
+If they can't open the link (on a VM, a remote/headless box, or it just
+won't load), don't dead-end them or send them to an admin; guide them
+through it yourself. The link is on an internal address their browser can't
+reach, so the fix is to reach that address from their own machine. One
+example course-correction: an SSH port-forward. Find the gateway's live
+address with a quick `curl` on the box, forward a free local port from
+their machine (e.g. `10255`, not `10254`, to dodge a collision with a local
+OneCLI), then open the link on `localhost` with the host and port swapped.
+Adapt to their setup; OAuth callbacks hang on the same internal address and
+need the same swap (keep `?code=...`).
+
+## Exa (optional): create an API key
+
+Exa adds deeper web and news search. It is optional; without it, built-in
+web search covers research. Walk the user through:
+
+1. Sign in at **dashboard.exa.ai** (new accounts start with free credits/a
+   free trial; after that Exa is pay-as-you-go).
+2. Open **API Keys** and create a new key (or copy an existing one).
+3. Paste the key into the OneCLI connect form for host `api.exa.ai` (it is
+   sent as an `x-api-key` header).
+4. Retry the failed call.
 
 ## Apify: copy the API token
 

--- a/media/journalist/skills/journalist-agent/references/find-sources.md
+++ b/media/journalist/skills/journalist-agent/references/find-sources.md
@@ -7,8 +7,9 @@ public channels.
 
 `/workspace/agent/sources/` holds every source the journalist has approved,
 one file per subject area (e.g. `sources/ai-policy.md`). Each entry is a
-source card: name, affiliation, what they are good for, public reach path,
-stories they appeared in, and how they performed. It grows into the
+source card: name, affiliation, what they are good for, public reach path
+(prefer a direct channel like LinkedIn), stories they appeared in, and how
+they performed. It grows into the
 journalist's private directory of trusted voices, so **check it first**; a
 source who already delivered beats a cold one.
 
@@ -26,7 +27,9 @@ subjects and move the entries.
 2. **Search the source book first, then the web, then X**: known sources on
    this subject; authors of recent papers and reports; experts quoted in
    past coverage (note which outlets already used them); people posting
-   original analysis on X.
+   original analysis on X. Draw candidates from several independent origins:
+   different articles, outlets, papers, and X voices. Never harvest a set
+   from a single story or roundup.
 
 3. **Vet each candidate**, plainly:
    - Are they who they say they are? Confirm the role on their own
@@ -39,9 +42,11 @@ subjects and move the entries.
 4. **Output source cards**, 3–6 per story need: name, role, affiliation,
    why them for this story (one plain sentence; no invented labels or
    nicknames for people), a notable on-record statement
-   (quote + link), caveats, and a public reach path (institutional page, X
-   handle, press office), found, never guessed; if none exists, write "no
-   public contact found".
+   (quote + link), caveats, and a public reach path; prioritize a direct,
+   personal channel (LinkedIn profile first, then X handle or their own
+   professional page); fall back to a generic institutional or press-office
+   page only when nothing direct exists. Found, never guessed; if none
+   exists, write "no public contact found".
 
 ## Keep the source book growing (two checkpoints)
 

--- a/media/journalist/skills/journalist-agent/references/monitor-beat.md
+++ b/media/journalist/skills/journalist-agent/references/monitor-beat.md
@@ -47,8 +47,9 @@ morning digest.
    in an item uses jargon or invented shorthand the journalist would have
    to decipher.
 
-   Close with one line on anything notable you filtered out. If a sweep
-   returns nothing new, say so; never pad to reach a count.
+   Close with anything notable you filtered out, and give each filtered
+   item its source link too. If a sweep returns nothing new, say so; never
+   pad to reach a count.
 
 6. **Persist** to `/workspace/agent/digests/YYYY-MM-DD.md`.
 

--- a/media/journalist/skills/journalist-agent/references/onboard-journalist.md
+++ b/media/journalist/skills/journalist-agent/references/onboard-journalist.md
@@ -5,51 +5,99 @@ not exist yet, or whenever the user wants to update it.
 
 ## Tone
 
-This is a friendly get-to-know-you chat, plain and warm. One thing at a
-time: a single question or a single setup step per message, never several
-bundled together. Keep the interview itself to five questions at most.
+This is a friendly get-to-know-you chat, plain and warm.
 Reflect back what you heard so they can correct you. If answers are brief,
 work with what you have and refine over time; the profile improves with
 every session.
 
+## Open
+
+Open warmly in Andy's voice. Send the greeting as its **own standalone
+message**:
+
+> Hi, I'm Andy, your reporting assistant. I do the legwork so you can
+> write: monitoring your beat, triaging pitches, finding and vetting
+> sources, and prepping interviews. You stay in control of what gets
+> published, and I just hand you the material to decide on.
+
+## Flag the optional connections early
+
+Then, as a **separate second message**, offer a short note on the optional
+add-ons (Apify, Exa) for richer search results and social-media scraping.
+Mention Apify is paid and that you can run on plain web search anyway. Offer
+to set them up now, later, or skip. Always raise this, never skip it.
+
+If they set any up now, follow `references/credentials.md`. If they skip or
+say later, move into the interview and don't raise it again unless a task
+would clearly benefit.
+
 ## Gather
 
-1. **The beat**: what they cover (e.g., technology, healthcare, home
-   decor), the specific angles they care about (e.g., "where tech meets
-   government policy"), the outlet, typical story length, and the language
-   they publish in, the people, companies, topics, and specific sites
-   worth watching (e.g., a ministry's publications page), the outlets they
-   read daily and trust (their digest should draw on these, not a generic
-   international mix), and what they are tired of seeing.
+Work through these, adapting to their answers and reflecting back what you
+hear:
 
-2. **Right now**: what are they working on at the moment? Stories in
-   flight go into the profile and are the fastest way to be useful today.
+1. **Beat & angle**: what they cover (e.g., technology, healthcare, home
+   decor) and the specific angle within it they care about most (e.g.,
+   "where tech meets government policy").
 
-3. **Anything else**: close by asking, briefly and openly, whether they
-   have other preferences for how you should work: digest length or
-   timing, how they like updates delivered, do's and don'ts, pet peeves.
-   Save whatever comes up; skip gracefully if nothing does.
+2. **Watchlist**: the specific people, companies, topics, or sites worth
+   watching on their beat (e.g., a ministry's publications page).
+
+3. **Preferred outlets**: "Are there any specific outlets you want me to
+   surface more than others?"
+
+4. **Language**: "Is there a language you want me to surface more than
+   others, and what language do you typically write in?"
+
+5. **Where they publish**: their outlet and typical story length.
+
+6. **Writing samples**: ask for a few pieces they're proud of, or any that
+   capture the angles they go after and their style, as links or pasted
+   text. Frame it as learning their style, not a promise to draft in their
+   voice. Fetch each link and save it to `style/<slug>.md` with a short note
+   on what marks their style.
+
+7. **Right now**: what they're working on at the moment. Stories in flight
+   go into the profile and are the fastest way to be useful today.
+
+8. **Anything else**: how they like you to work: digest length or timing,
+   how updates are delivered, do's and don'ts, what they're tired of
+   seeing. Save whatever comes up; skip gracefully if nothing does.
 
 ## Persist
 
-Write `/workspace/agent/beat-profile.md` with everything from steps 1 to
-3. Then close, still one step per message:
+Write `/workspace/agent/beat-profile.md` with everything the interview
+surfaced. Then, as soon as onboarding is done and before any closing steps,
+reflect the profile back so they can confirm or correct it. Format it as a
+list with **each item on its own line, prefixed with a dash**, never a
+comma run-on. For example:
+
+- beat =
+- watchlist =
+- preferred outlets =
+- format =
+- language =
+- preferences =
+
+Ask if anything needs changing. Only once they confirm, close, **one
+message at a time**; wait for their answer before moving to the next:
 
 1. Ask how many pitches are sitting in their inbox right now, and offer
    to sort them and surface the most interesting ones. The pitch pass
    needs the pitches themselves: a connected mailbox if one exists, or a
    batch pasted or forwarded into the chat.
 
-2. Offer the morning digest next, or right away if they pass on the
-   pitches. Before scheduling anything, ask for their city or timezone
-   and save it to the profile; never guess it. The digest needs the X
-   scraper connected; if it is not yet, offer to set that up, following
-   `references/credentials.md`.
+2. Only after the pitch step, ask, as its own separate message, whether
+   they want the morning digest going, framed around their profile (e.g.
+   "Want me to get a digest going for you based on your profile?"). If yes,
+   then gather what it needs: their city or timezone (never guess it; save
+   it to the profile), and the X scraper connected; if it is not, offer to
+   set it up following `references/credentials.md`.
 
-One more thing while closing: the scheduled morning-digest task is created
-**paused**, so no digest will arrive on its own yet. Check whether it is
-active; if it is paused or you cannot check, tell the journalist and offer
-to activate it.
+The scheduled morning-digest task is created **paused**, so no digest
+arrives on its own yet. Once the digest is set up, check whether the task
+is active; if it is paused or you cannot check, tell the journalist and
+offer to activate it.
 
 Keep the profile alive afterwards: whenever the user's reactions teach you
 something (an overruled verdict, "more of this, less of that"), update it.


### PR DESCRIPTION
Refinements from a live Telegram test pass of the journalist template.

**Persona & voice**
- Name the assistant **Andy** (was unnamed, so it adopted the agent-group name).
- Never narrate its own process to the user (no "sent the intro, waiting for reply" status lines).

**Onboarding** (`onboard-journalist.md`)
- Greeting and the optional-connections flag go as **two separate messages**.
- Connections offer is now a short, non-scripted note (Apify + Exa), paid flagged, web-search fallback stated.
- Interview asks **one question per message**; added a **writing-samples** question (framed as learning style, not a drafting promise).
- **Dash-list profile recap** right after onboarding for confirmation; then pitches, then digest — one step at a time.

**Sourcing rules**
- Ground rule: **attribute everything with a link**, including filtered-out items; `monitor-beat` links filtered items too.
- `find-sources`: **LinkedIn-first** reach path; draw candidates from several independent origins, never harvest one story/roundup.
- No markdown tables in chat (don't render on Discord/most chat clients).

**Optional Exa**
- Re-add Exa as an **optional** deeper-search tool (`.mcp.json`, SKILL, credentials, README). Apify recommended; both optional over the web-search baseline.

**VM/headless credential help**
- `credentials.md`: when a user is on a VM/headless box and the OneCLI connect link won't open, guide them through an SSH port-forward instead of dead-ending them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)