### PR TITLE
docs(contributing): paid-service disclosure, CI/engine lint delta, persona fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,15 +99,21 @@ for its author.
 5. Run the registry checks: `node scripts/check-templates.mjs` (the same
    script CI runs).
 6. Test it end to end. `--template` resolves relative to your NanoClaw install's
-   templates directory, not your clone, so do one of:
+   templates directory, not your clone, so copy it across first. `templates/`
+   ships with only a README, so create the category directory too:
    ```bash
-   # Option A: point the templates dir at your clone, then stamp the bare ref
-   NANOCLAW_TEMPLATES_DIR="$(pwd)" ncl groups create --template <category>/<template> --name "Test"
-
-   # Option B: copy the template into your install's templates/ dir, then stamp
-   cp -R <category>/<template> <nanoclaw>/templates/<category>/<template>
+   mkdir -p <nanoclaw>/templates/<category>
+   cp -R <category>/<template> <nanoclaw>/templates/<category>/
    ncl groups create --template <category>/<template> --name "Test"
    ```
+   Re-copy after every edit — the stamp reads the copy, not your clone.
+
+   Prefixing the command with `NANOCLAW_TEMPLATES_DIR=…` does **not** work:
+   the host process reads that variable once at startup and `ncl` is only a
+   socket client, so the value never reaches template resolution. To point the
+   library at your clone instead of copying, set the variable in the host
+   service environment and restart the host.
+
    If the template defines tasks, confirm they appear paused with
    `ncl tasks list --status paused`. For a scripted task, also run it once
    with `ncl tasks run <task-id>` and inspect it with
@@ -137,6 +143,6 @@ for its author.
 - [ ] No affiliate or referral links, no baked-in billing, and no shared or
       author-owned credential anywhere in the template.
 - [ ] `node scripts/check-templates.mjs` passes.
-- [ ] Stamped and tested locally with a bare ref (via `NANOCLAW_TEMPLATES_DIR`
-      or a copy into `templates/`).
+- [ ] Stamped and tested locally with a bare ref, after copying the template
+      into the install's `templates/`.
 - [ ] No API keys, tokens, or other secrets anywhere in the diff.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,12 +42,42 @@ Templates are public. Never commit API keys, tokens, or any credential.
 
 - Credential-shaped `env` and `headers` values in `mcp.json` carry the literal
   `"placeholder"`, never a real value. NanoClaw rejects a template whose
-  values match known credential formats.
+  values match known credential formats. Only declare such a var where the
+  server refuses to boot without it (`sales/sdr` does for HubSpot, not Exa).
 - Task scripts may call external services, but must not contain credentials.
 - Credentials are injected at request time by the OneCLI gateway, not baked into
-  the template. If your template needs a service connected, document how to get
-  the key and which scopes it needs in the template's own `README.md` (see
-  `sales/sdr/README.md` for the pattern).
+  the template. If your template needs a service connected, document in the
+  template's own `README.md`, for each service: the API host, the auth style,
+  the exact scopes, and where to get the key (see `sales/sdr/README.md` for the
+  pattern).
+
+> **`check-templates.mjs` is stricter than NanoClaw here.** A credential-shaped
+> *key* (`TOKEN`, `SECRET`, `PASSWORD`, `API_KEY`, `CREDENTIAL`, `PRIVATE_KEY`,
+> `AUTH`) whose value is not `"placeholder"` **fails CI**, while NanoClaw's
+> stamp-time lint only warns. A template that stamps cleanly on your machine can
+> still be rejected here — use `"placeholder"` for every credential-shaped key.
+
+## Paid services and monetization
+
+A template may depend on paid MCP servers or paid API tiers (Exa, HubSpot's paid
+plans, and similar are all fine). What is not fine is a user discovering the cost
+after they have stamped it.
+
+The template's `README.md` must state, up front:
+
+- that the service is paid,
+- roughly what it costs,
+- and that the user supplies **their own key**.
+
+Never ship a shared key, a template-owner key, or any credential the contributor
+controls. If the template is usable on a free tier with reduced capability, say
+which parts need the paid tier — that is more useful than a blanket "requires a
+paid plan".
+
+**No monetization through the registry template.** No affiliate or referral
+links, no baked-in billing, no revenue share wired into the template. A registry
+template is a configuration people can read and fork, not a distribution channel
+for its author.
 
 ## Adding a template
 
@@ -84,12 +114,21 @@ Templates are public. Never commit API keys, tokens, or any credential.
 
 - [ ] Template lives under an appropriate `<category>/<template>/`.
 - [ ] `plugin.json` is present with the exact 1.0.0 `$schema` and a valid `name`.
-- [ ] `ai.nanoco.nanoclaw/context/instructions.md` is present (registry policy).
+- [ ] If the template ships `ai.nanoco.nanoclaw/context/instructions.md`, it is
+      nonempty. A persona is optional — without one, the stamped agent uses
+      NanoClaw's default project doc.
 - [ ] `mcp.json` servers declare `type` and carry `"placeholder"` for any
       credential-shaped `env`/`headers` value — no real keys anywhere.
+- [ ] Any `"placeholder"` env var is there because the server will not boot
+      without it, and the README says never to replace it with a real key.
 - [ ] Every `ai.nanoco.nanoclaw/tasks/*.md` file has a nonempty `schedule`, an
       optional nonempty `script`, no other frontmatter fields, and a prompt body.
-- [ ] A per-template `README.md` explains the template and its credentials.
+- [ ] A per-template `README.md` explains the template and, for every service it
+      needs, gives the API host, auth style, exact scopes, and where to get the key.
+- [ ] Every paid service is declared up front in the README: that it is paid,
+      roughly what it costs, and that the user brings their own key.
+- [ ] No affiliate or referral links, no baked-in billing, and no shared or
+      author-owned credential anywhere in the template.
 - [ ] `node scripts/check-templates.mjs` passes.
 - [ ] Stamped and tested locally with a bare ref (via `NANOCLAW_TEMPLATES_DIR`
       or a copy into `templates/`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,19 +60,25 @@ Templates are public. Never commit API keys, tokens, or any credential.
 ## Paid services and monetization
 
 A template may depend on paid MCP servers or paid API tiers (Exa, HubSpot's paid
-plans, and similar are all fine). What is not fine is a user discovering the cost
-after they have stamped it.
+plans, and similar are all fine). What is not fine is a user discovering the
+paywall after they have stamped it.
 
 The template's `README.md` must state, up front:
 
 - that the service is paid,
-- roughly what it costs,
+- a link to the tool,
+- which plan or tier the template needs, where the vendor gates the required
+  capability behind one,
 - and that the user supplies **their own key**.
+
+**Name the tier, do not quote the price.** Prices change and a stale figure in a
+README is worse than none, so link the vendor's pricing page and name the plan
+instead — tier names are far more stable than dollar amounts.
 
 Never ship a shared key, a template-owner key, or any credential the contributor
 controls. If the template is usable on a free tier with reduced capability, say
-which parts need the paid tier — that is more useful than a blanket "requires a
-paid plan".
+which parts need the paid plan — that is more useful than a blanket "requires a
+paid subscription".
 
 **No monetization through the registry template.** No affiliate or referral
 links, no baked-in billing, no revenue share wired into the template. A registry
@@ -125,8 +131,9 @@ for its author.
       optional nonempty `script`, no other frontmatter fields, and a prompt body.
 - [ ] A per-template `README.md` explains the template and, for every service it
       needs, gives the API host, auth style, exact scopes, and where to get the key.
-- [ ] Every paid service is declared up front in the README: that it is paid,
-      roughly what it costs, and that the user brings their own key.
+- [ ] Every paid service is declared up front in the README: that it is paid, a
+      link to the tool, the tier the template needs (if any), and that the user
+      brings their own key. No prices quoted.
 - [ ] No affiliate or referral links, no baked-in billing, and no shared or
       author-owned credential anywhere in the template.
 - [ ] `node scripts/check-templates.mjs` passes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,8 @@ main [README](README.md#anatomy-of-a-template) for the full anatomy.
 
 ## Where it goes: `<category>/<template>/`
 
-Group every template under a category folder, for example `sales/sdr/`.
+Group every template under a category folder, so the path is
+`<category>/<template>/`.
 
 Before adding a new category, check whether an existing one fits and reuse it. If
 you genuinely need a new one, keep it a single, lowercase, broadly-recognized
@@ -90,13 +91,14 @@ Templates are public. Never commit API keys, tokens, or any credential.
 - Credential-shaped `env` and `headers` values in `mcp.json` carry the literal
   `"placeholder"`, never a real value. NanoClaw rejects a template whose
   values match known credential formats. Only declare such a var where the
-  server refuses to boot without it (`sales/sdr` does for HubSpot, not Exa).
+  server refuses to boot without it; a server that authenticates purely
+  through the vault should not get one.
 - Task scripts may call external services, but must not contain credentials.
 - Credentials are injected at request time by the OneCLI gateway, not baked into
   the template. If your template needs a service connected, document in the
   template's own `README.md`, for each service: the API host, the auth style,
-  the exact scopes, and where to get the key (see `sales/sdr/README.md` for the
-  pattern).
+  the exact scopes, and where to get the key. The templates already in the
+  registry show the pattern.
 
 > **`check-templates.mjs` is stricter than NanoClaw here.** A credential-shaped
 > *key* (`TOKEN`, `SECRET`, `PASSWORD`, `API_KEY`, `CREDENTIAL`, `PRIVATE_KEY`,
@@ -106,9 +108,8 @@ Templates are public. Never commit API keys, tokens, or any credential.
 
 ## Paid services and monetization
 
-A template may depend on paid MCP servers or paid API tiers (Exa, HubSpot's paid
-plans, and similar are all fine). What is not fine is a user discovering the
-paywall after they have stamped it.
+A template may depend on paid MCP servers or paid API tiers. That is fine. What
+is not fine is a user discovering the paywall after they have stamped it.
 
 The template's `README.md` must state, up front:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,53 @@ Thanks for adding to the NanoClaw template catalog. Templates are accepted via
 pull request. This guide covers how a template is structured, where it goes, and
 how to test it before you open a PR.
 
+## Acceptance and ownership
+
+Please read this before you invest the work.
+
+**Acceptance is at NanoClaw's discretion.** The catalog is curated, not a
+free-for-all. A submission has to bring real value to the community: it should do
+a job people actually have, work out of the box, and be more than one team's
+internal configuration. A well-built template can still be declined — because it
+is too narrow, because it substantially duplicates one already in the catalog, or
+because the catalog does not need it yet. If you are unsure whether an idea fits,
+open an issue describing it before building the whole thing.
+
+**A merged template becomes NanoClaw's to maintain.** Once it is in the catalog,
+NanoClaw takes over responsibility for it, and may edit, restructure,
+recategorize, or retire it — bumping a pinned MCP server version, rewriting a
+persona, folding it into another template — **without asking first**, the same as
+any other file in this repo. That is not a formality: people stamp these
+templates expecting them to keep working, so the catalog has to stay
+maintainable as a whole.
+
+| | |
+|---|---|
+| Ongoing maintenance and support | NanoClaw |
+| Deciding when it changes, moves, or is retired | NanoClaw |
+| Fixing it when an upstream dependency breaks | NanoClaw |
+| Authorship credit | Yours, permanently |
+
+**You keep the credit.** Attribution survives every later edit. Record it in the
+manifest, which takes an `author` object (`name`, `email`, `url` — any subset)
+per the Agent Plugins spec:
+
+```json
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "sdr",
+  "author": { "name": "Your Name", "url": "https://github.com/your-handle" }
+}
+```
+
+Add a credit line to the template's own `README.md` too if you want it visible to
+anyone reading the folder. Neither is stripped when the template is later edited.
+
+> This repo is [MIT licensed](LICENSE) and your contribution is accepted under
+> that same license, so "ownership" here means stewardship and maintenance — not
+> a transfer of copyright. Your work stays MIT, attributed to you, and anyone may
+> fork it.
+
 ## What a template is
 
 A template is an [Agent Plugins](https://agent-plugins.org) 1.0.0 directory
@@ -120,7 +167,8 @@ for its author.
    `ncl tasks get <task-id>`.
 7. Re-check the diff for any secret before you commit.
 8. Open a PR describing what the template does, including any predefined tasks
-   and MCP servers it expects.
+   and MCP servers it expects. Set `author` in `plugin.json` so the credit lands
+   with the template.
 
 ## PR checklist
 
@@ -146,3 +194,6 @@ for its author.
 - [ ] Stamped and tested locally with a bare ref, after copying the template
       into the install's `templates/`.
 - [ ] No API keys, tokens, or other secrets anywhere in the diff.
+- [ ] You have read "Acceptance and ownership" above: acceptance is
+      discretionary, and a merged template is NanoClaw's to maintain, with your
+      authorship credited permanently.


### PR DESCRIPTION
Four registry-standards gaps in `CONTRIBUTING.md`, plus a broken test instruction. Docs-only — no template or script changes.

**Stacked on #19** (based on `feat/plugin-format`), since it edits the plugin-format version of this file. Retarget to `main` if #19 merges first.

## 0. Acceptance and ownership — new section

Placed first, before the structural guidance, so a contributor reads it before investing the work. Nothing in the repo stated either half of this before.

- **Acceptance is at NanoClaw's discretion.** The catalog is curated; a submission has to bring real value to the community, and a well-built template can still be declined for being too narrow, duplicating an existing one, or not being needed yet. Points at opening an issue first.
- **A merged template becomes NanoClaw's to maintain** — edit, restructure, recategorize, or retire, without asking first. The reason is stated rather than just the rule: people stamp these expecting them to keep working, so the catalog has to stay maintainable as a whole. A responsibility table makes the split explicit.
- **Authorship credit is permanent**, and concrete rather than a promise: `plugin.json` already takes an `author` object (`name`/`email`/`url`) per the spec, and **no template sets it today**, so the section shows the exact JSON. Step 8 and the checklist now point at it.

On the license: this repo is MIT and contributions are accepted under it, so the section says "ownership" means stewardship and maintenance, **not** a transfer of copyright. Writing it any other way would misdescribe what `LICENSE` does. If a legal assignment is intended, that needs a CLA rather than a `CONTRIBUTING.md` paragraph.

## 1. Paid services and monetization — new section

Templates may depend on paid MCP servers or paid API tiers (Exa, HubSpot paid plans). That stays allowed; the gap is disclosure. The template's `README.md` must now state up front that the service is paid, link the tool, and name the plan or tier the template needs — plus that the user supplies **their own key**, never a shared or template-owner key.

Deliberately **no price figures**: prices go stale and a wrong number in a README is worse than none, so the rule asks for the vendor's pricing link and the tier name instead. Tier names are far more stable than dollar amounts.

Also prohibits monetizing through the registry template itself: no affiliate or referral links, no baked-in billing, no revenue share.

Nothing in the repo covered this before.

## 2. `check-templates.mjs` is stricter than NanoClaw

A credential-shaped **key** (`TOKEN`, `SECRET`, `API_KEY`, …) whose value is not `"placeholder"`:

| | Behavior |
|---|---|
| `scripts/check-templates.mjs` (`SECRET_KEY_RE`) | **fails** the run |
| NanoClaw stamp-time lint (`src/templates/mcp.ts`, `lintSecrets`) | pushes a report line and proceeds |

So a template that stamps cleanly on a contributor's machine can still be rejected by CI here. That costs a round-trip and was documented nowhere. Added as a callout under the no-secrets section.

## 3. The persona is not required — checklist was wrong

The PR checklist said:

> - [ ] `ai.nanoco.nanoclaw/context/instructions.md` is present (registry policy).

That contradicts two other sources in this repo: the anatomy table says `No (recommended; non-empty if present)`, and `check-templates.mjs` has **no presence check** — it only validates non-emptiness when the file exists (the behavior #18 deliberately introduced).

It is genuinely optional. With no persona, `createAgentFromTemplate` skips `stageGroupPersona` entirely and the stamped agent uses NanoClaw's default project doc. Corrected the checklist to match.

## Also

- Only declare a `"placeholder"` env var where the server refuses to boot without it — `sales/sdr` does for HubSpot, not for Exa.
- Spell out the per-service README fields (API host, auth style, exact scopes, where to get the key) that `sales/sdr/README.md` already models but `CONTRIBUTING.md` only gestured at.

## 5. The local test instruction did not work

`NANOCLAW_TEMPLATES_DIR="$(pwd)" ncl groups create …` (step 6, Option A) has no effect. `TEMPLATES_DIR` is resolved in the **host** process, once at startup (`src/config.ts:63` — *"never an ncl flag, never runtime-mutable"*), and `ncl` is only a socket client. Run as written it either errors with `Template not found` or silently stamps whatever same-named copy is already in the install's `templates/`.

Replaced with the copy-across flow, including the `mkdir -p` it needs (`templates/` ships with only a README, so the category directory is absent), a note that a re-copy is required after every edit, and the host-service-environment route for anyone who wants to point the library at a clone.

Caught by a reviewer running the published instructions against a live install.

## 6. Named templates out of the guidance

Four places used a specific template or its vendors to illustrate a general rule: the category-structure example, the boot-placeholder exception, the README pattern pointer, and the paid-tier examples. The catalog churns, so each was a future stale claim — and the pointer at one template's `README.md` would break if that template were renamed or retired. Guidance is now general and points at the registry as a whole.

Matches the same treatment on docs.nanoclaw.dev, where template specifics are confined to the catalog listing.

## Verification

`node scripts/check-templates.mjs` → `4 template(s) OK: data/analyst, media/journalist, product/competitor-analysis, sales/sdr`

## Related

The matching user-facing docs are going up on docs.nanoclaw.dev in the same window as #19 / nanocoai/nanoclaw#3220.

One item **not** fixed here because it lives in the other repo: `docs/templates.md` on nanocoai/nanoclaw#3220 says the registry requires a persona and "its CI enforces it" — both halves are false per item 3 above. Worth a one-line fix on that branch.


