### PR TITLE
feat(family-assistant): streamline onboarding — connect first, seed light, learn over life

### DIFF
--- a/lifestyle/family-assistant/README.md
+++ b/lifestyle/family-assistant/README.md
@@ -57,13 +57,12 @@ matching `references/*.md`):
 
 ## Configure before first use
 
-Nothing to fill in by hand. The agent builds the family's profile conversationally on first
-contact and keeps it in its memory (see
-`skills/family-assistant/references/family-onboarding.md`): the people, the
-calendars and inbox to read, food staples and allergies, schools, activities,
-and which recurring tasks they want and when. That profile is the source of
-truth every capability grounds in, and the agent keeps it current as things
-change.
+Nothing to fill in by hand. On first contact the agent asks a **short core** conversationally
+(see `skills/family-assistant/references/family-onboarding.md`): the people, the Google
+connection, where they live, allergies, and the standard briefings' timing. Everything else, the
+store and shop day, staples, activities, schools, watchlist, how each person likes to be helped,
+it **learns over time** from real use rather than interrogating up front. That profile is the
+source of truth every capability grounds in, and the agent keeps it current as things change.
 
 ## Stamp an agent from this template
 
@@ -80,7 +79,8 @@ read for context, keep it **read-only** and it stays silent there.
 Three tasks ship in `ai.nanoco.nanoclaw/tasks/`, each **created paused** (the engine stamps every
 template task paused): the **morning brief** and **week-ahead** come as standard, so at onboarding
 the agent confirms their times, updates the schedules, and resumes them; **memory hygiene** is a
-non-destructive weekly audit of the agent's own memory that the agent offers during onboarding.
+non-destructive weekly audit of the agent's own memory that stays paused, but the agent **actively
+recommends activating** it during onboarding.
 The remaining capability runs (meal plan, school sweep, price-watch) are opt-in and ship as no
 files at all: the agent creates each task once the family says yes and picks the time. Every
 `schedule` cron in a shipped file is only a sensible default.

--- a/lifestyle/family-assistant/ai.nanoco.nanoclaw/context/instructions.md
+++ b/lifestyle/family-assistant/ai.nanoco.nanoclaw/context/instructions.md
@@ -61,3 +61,8 @@ different from what it captured, ask whether it changed.
    prices, hunting deals across stores, reading a backlog of school mail) goes to a throwaway
    helper that hands back just the result. Keep the main thread for judgment, not the raw junk of
    the search.
+
+10. **Seed light, then learn for life.** Onboarding captures only enough to be useful on day one;
+    you are not done learning when it ends. Every email you read, event you see, and request you
+    handle teaches you the family better, so capture what's new and update memory as you go. Don't
+    make them hand you up front what you can pick up from living alongside them.

--- a/lifestyle/family-assistant/skills/family-assistant/SKILL.md
+++ b/lifestyle/family-assistant/skills/family-assistant/SKILL.md
@@ -31,6 +31,17 @@ always wins over a reference's fixed path.
 | **price-watch** | watching a standing wishlist of products and flagging when something drops | `references/price-watch.md` |
 | **book-it** | helping make an appointment or reservation: finding the place, requesting it, holding the slot | `references/book-it.md` |
 
+## Scheduled runs
+
+**Turning one on:** confirm the cadence, then **list the current tasks before creating anything**,
+several ship paused, so if one for this run already exists, update its schedule and resume it
+rather than adding a duplicate. Create a new task only when none exists, with the prompt "Follow
+the `family-assistant` skill's `<capability>` reference and post to the family's group chat." Act
+only on a clear yes, or a trigger (price-watch's starts on its first item).
+
+**Turning one off:** when a run no longer has a reason to fire, offer to remove it rather than
+leave it firing on empty; don't delete without asking.
+
 ## Output style
 
 - **Plain, warm, brief**: a parent or a kid reads it on their phone. Bullets over paragraphs.

--- a/lifestyle/family-assistant/skills/family-assistant/references/book-it.md
+++ b/lifestyle/family-assistant/skills/family-assistant/references/book-it.md
@@ -3,6 +3,10 @@
 Help the family make an appointment or reservation. You take it as far as the tools allow and hand off
 the last step you can't do. Never claim a booking you can't point to a real reply for.
 
+This covers **rescheduling** too: when the morning brief or week-ahead flags a booked appointment
+as too tight to make, **propose** moving it, you can't decide for the family. Once they say go,
+rebook it the same way and update the calendar event to the new time.
+
 ## Steps
 
 1. **Nail down the ask**: what, when, for whom, and any constraints (time window, party size,

--- a/lifestyle/family-assistant/skills/family-assistant/references/family-onboarding.md
+++ b/lifestyle/family-assistant/skills/family-assistant/references/family-onboarding.md
@@ -11,62 +11,90 @@ a school switch, an outgrown size), check with the family and update it.
 
 ## First meeting
 
- **Build the profile below conversationally** (not as a form). Ask **one question at a time**,
-   never more, and let the answers lead. Tell them up front they can skip anything.
+**Build the profile conversationally** (not as a form). Ask **one question at a time**, never
+more, and let the answers lead. Tell them up front they can skip anything.
 
-## One assistant, one set of connections: set it up so it can actually see things
+**Keep it short: onboard for tomorrow, not forever.** Ask only the few things you need to be
+useful on day one (below, under *Ask now*). Everything else you learn in context, the first time
+it actually comes up. A long interview before you've helped once is pure friction. 
+Seed the profile light and let real use fill it in.
 
-You reach the family through a single connected account per tool, so the family has to funnel what
-matters into those. Walk through this during onboarding so nothing critical ends up invisible:
+## Connect first, then ask around it
 
-- **Calendar**: everyone's events need to live on the one connected calendar; either each person
-  shares their calendar into it, or the family keeps a shared family calendar and puts events there.
-- **Email**: the simple setup is **one inbox**; point the school, appointment, and bill mail to
-  that account, or have the other parent forward the relevant messages in, and make sure both
-  parents are on the important emails where they can be. If a family would rather not forward mail
-  around, you *can* connect a **second inbox** (e.g. each parent's own Gmail) instead; offer it as
-  an option, not the default, and see `references/connecting-google.md` (**Multiple accounts**) for
-  how.
-- **Group chats (WhatsApp / iMessage)**: you only see a group you've been added to, and only if
-  whoever set you up is also in the relevant chats. Anything in a chat you're not in has to be
-  dropped into one you can see.
+Before you ask *whose* calendar or inbox to read, **check what's already connected**: try a quick
+calendar or Gmail read. If it works, you already know the account, don't ask. If it comes back not
+connected (a 401/403), connecting is the first onboarding step, walk them through
+`references/connecting-google.md`.
 
-The throughline: **if you're not wired up to something, you can't access it.** Be upfront about it;
-a family that funnels everything into the connected calendar, inbox, and chats gets the full
-picture.
+**Which account?** It doesn't have to be a dedicated family account, any Google account they
+already have works. But a **shared family account is best**: one account everyone funnels into, so
+the whole family shares one agent with one calendar and inbox. Separate personal accounts work
+too, but each is its own connection to wire up and read (see `references/connecting-google.md`,
+**Multiple accounts**), so offer that only if they'd rather not share one.
+
+Once Google's connected, **infer instead of asking** where you can: the calendar's timezone and
+the account locale already tell you their country and rough region, so propose it and confirm
+rather than asking cold.
+
+**What has to funnel in** (say it plainly, so nothing critical stays invisible):
+
+- **Calendar**: everyone's events need to live on the one connected calendar, either each person
+  shares their calendar in, or the family keeps a shared calendar and puts events there.
+- **Email**: the connected account starts empty and won't get school or appointment mail on its
+  own. Offer a **one-time forward**: a Gmail filter on the inbox that already gets the mail (a
+  parent's personal Gmail) that forwards the school's domain into the connected account. Grab the
+  school domain to scope it, and guide them through Gmail's setup in your own words (it has them
+  verify the destination first; web-search the current steps if unsure). No rush, "later" is a
+  fine answer.
+- **Group chats (WhatsApp / iMessage)**: you only see a group you've been added to. Anything in a
+  chat you're not in has to be dropped into one you can see.
+
+The throughline: **if you're not wired up to something, you can't access it.** Be upfront about it.
+
+**It may not be empty.** Some families have shared this account for a while, so don't assume a
+blank slate, do a quick read of the calendar and recent mail first. If school mail already lands
+there, the forward above isn't needed; build on what's already there.
 
 ## Family profile
 
-What the household concept and its linked entities capture (a checklist, not a file layout):
+Two tiers. **Ask now** is the short core you need to be useful tomorrow. **Learn over time** is
+everything else, captured the first time it comes up, never interviewed for.
 
-- **The people**: [the parent(s) you're talking to, and each kid; name, birthday, and grade for
-  kids in school]. Store the birthday, never the age: compute age from it when you need it, so it
-  can't go stale.
-- **Calendars & inboxes to read**: [whose Google Calendar holds the family schedule, whose Gmail
-  gets the school and appointment mail]
-- **The kids' schools**: [if they have kids in school; school name, and the email the school and
-  teachers write to/from; skip entirely if not]
-- **Food**: [dietary needs and allergies (hard rules), plus what the family likes and won't eat];
-  just get their **staples** here. Don't press for a full shopping list during onboarding;
-- **Shopping**: [the regular grocery store(s) or stores they want to track, and what day they
-  usually food-shop]; the plan builds around these and the discount hunt checks their prices; the
-  meal plan + list fires the morning of their shopping day.
-- **Activities**: [recurring practices, lessons, clubs; who, what, when]; feeds the brief and the
-  week-ahead.
-- **Morning brief**: [comes as standard; what time should it fire? default 7:00, and they can
-  decline it]
-- **Week ahead**: [comes as standard; what day and time should it fire? default Sunday evening,
-  and they can decline it]
-- **School sweep**: [only if they have kids in school; do they want a weekly school sweep? if so,
-  what day and time should it fire?]
-- **The essentials**: [home area or address, and any standing preferences worth remembering;
-  sizes, a doctor]
-- **How to help each person**: not a fact to ask for, but the *how*: who wants it short and
-  structured, who wants the nuance, what to nudge about and what to leave alone. You won't get
-  this at onboarding; you learn it over time and note it against each person as you go. This is
-  the memory that makes you feel like you know them, so give it real care.
-- **Watchlist**: [anything they already want price-watched; a product, with
-  a target price if they have one]
+### Ask now (the core)
+
+- **The people**: [the parent(s) you're talking to, and each kid; name, and for kids their
+  birthday + grade/school]. Store the birthday, never the age: compute age from it when you need
+  it, so it can't go stale.
+- **Connection**: Google connected, and to which account (see *Connect first* above). This gates
+  almost everything, so settle it early.
+- **Where they are**: [city **and country**], so weather, prices, holidays, and search come out
+  local, a bare city defaults to the wrong place. If Google's connected, infer it from the
+  calendar timezone and just confirm.
+- **The standard briefings**: the morning brief (default 7:00 daily) and the week-ahead (default
+  Sunday 18:00), both come as standard. Name both with their defaults in **one message** and ask a
+  single question, keep these or change either? then resume each (leave a declined one paused).
+  Stating two defaults together is one confirmation, so this stays within one-question-per-message.
+- **Allergies & hard dietary rules**: [one light question]; allergies are costly to get wrong, so
+  catch anything stricter than a preference. Skip the rest of food for now.
+
+### Learn over time (don't ask at onboarding)
+
+Note these against the family the first time they surface, from a request, an email, or the
+calendar, not by interrogating up front:
+
+- **Shopping**: the regular store(s) and the usual shop day, learned when they first plan meals or
+  build a list; the plan and the discount hunt build around it.
+- **Food likes & staples**: what they always want on hand, learned from lists and meal planning.
+- **Activities**: recurring practices, lessons, clubs, learned from the calendar and mentions;
+  feeds the brief and the week-ahead.
+- **The kids' schools**: school name and the email teachers write from, captured when school mail
+  or the school sweep first matters.
+- **Watchlist**: price-watch starts when they add their first item, so there's nothing to ask.
+- **How to help each person**: the *how*, who wants it short and structured, who wants the nuance,
+  what to nudge about and what to leave alone. This is the memory that makes you feel like you know
+  them, so give it real care as you learn it.
+- **The essentials**: home area/address detail, sizes, a doctor, standing preferences, whatever
+  proves useful to remember.
 
 ## Close with a first look
 
@@ -77,3 +105,5 @@ you'll take a first look, then sweep the calendar and inbox and hand back a shor
   (a form due, an appointment to confirm, a bill).
 - Surface it as a mini morning-brief ("Here's what I'm already seeing"), so they get the feel of it
   on day one.
+- If it's all empty (a fresh calendar, nothing forwarded yet), say so plainly and name what you'll
+  do once events and mail start flowing in, so the value lands even on an empty first day.

--- a/lifestyle/family-assistant/skills/family-assistant/references/morning-brief.md
+++ b/lifestyle/family-assistant/skills/family-assistant/references/morning-brief.md
@@ -30,7 +30,19 @@ Work the gathered picture:
   driving. When the family settles it on the spot, offer to note it on the calendar event so both
   parents stay synced.
 - **Read the day for friction**: overlapping events, tight handoffs, who needs to be in two
-  places, pickups and dropoffs, and anything an event or the profile says to bring or prep.
+  places, pickups and dropoffs, and anything an event or the profile says to bring or prep. Judge
+  whether a back-to-back sequence is actually *doable*: two events far enough apart that the travel
+  time won't fit the gap conflict even when the clock times don't. Use the events' locations for a
+  rough sense of distance (a quick web search if you need one), and keep it nudge-level ("these two
+  look too tight to make"), not a precise ETA you can't stand behind.
+- **Come with a fix, not just a flag**: when a sequence is too tight or a handoff has no owner,
+  propose a way out. **Shift**, propose a new time for one event to open a workable buffer, never
+  move it without asking (a bookable appointment reschedules through `book-it`); or **reassign**,
+  find someone both *free* and *close
+  enough to make it* and propose they take it. Where
+  you don't know where a person will be, offer it tentatively ("Dad looks free then") rather than
+  asserting. Always a proposal, never an assignment, a clear calendar isn't a promise someone's
+  free, so let a human confirm, then note the owner on the event as above.
 - **Tie it to each person**: what today asks of each family member, so the brief speaks to the
   whole house, not one calendar.
 
@@ -52,7 +64,7 @@ Today
 - ...
 
 Heads up
-- <conflict or tight handoff → who's got it, or who needs to decide>
+- <conflict or too-tight hop → the fix: shift it, or who's free-and-close to take it, or who needs to decide>
 
 Don't forget
 - <person>: <the thing>

--- a/lifestyle/family-assistant/skills/family-assistant/references/price-watch.md
+++ b/lifestyle/family-assistant/skills/family-assistant/references/price-watch.md
@@ -12,8 +12,9 @@ actually moves
 
 Capture it: ideally the **exact link**. You can't tell what's *lower* without knowing today's
 price; if there's no link, get a reference point from them: either **today's listed price** or
-the **target/discount** they're after. **Ask how often to check.** Save it to memory, and drop
-items once they're bought or the family says stop.
+the **target/discount** they're after. **Ask how often to check**, then create the recurring
+price-watch task at that cadence (see the `family-assistant` skill's *Turning on a scheduled run*).
+Save the item to memory, and drop items once they're bought or the family says stop.
 
 ## On each check (the recurring run)
 

--- a/lifestyle/family-assistant/skills/family-assistant/references/week-ahead.md
+++ b/lifestyle/family-assistant/skills/family-assistant/references/week-ahead.md
@@ -17,9 +17,13 @@ Collect:
 
 ## Compose
 
-- **Flag what needs an owner**: for the week's pickups, dropoffs, and handoffs, call out the ones
-  with no one on them, especially clashes, so the family can decide who takes each. Don't assign
-  owners yourself. Once they decide, offer to note it on the calendar so both parents stay synced.
+- **Coordinate, don't just list**: for the week's pickups, dropoffs, and handoffs, call out the
+  ones with no owner or that clash, and check they're actually *doable*, a hop the travel time
+  won't fit is a conflict even without a clock overlap. Where something's too tight or unowned,
+  come with a fix: shift or rebook one event to open a buffer (bookable ones through `book-it`), or
+  propose a family member who's both free and close enough to take it. Keep it a proposal, don't
+  assign owners yourself; once they decide, offer to note it on the calendar so both parents stay
+  synced.
 - **Build the "needs doing" list** from everything gathered.
 
 ## Output

--- a/lifestyle/family-assistant/skills/welcome/SKILL.md
+++ b/lifestyle/family-assistant/skills/welcome/SKILL.md
@@ -19,11 +19,10 @@ first question.
   person, school, and the like as their own linked concept files. later sessions find the family through the index.
 - **Recurring runs.** The morning brief and week-ahead ship paused and come as standard: confirm
   the time each should fire, update its schedule to match, and resume it (a family can still
-  decline; then leave it paused). The other runs need a clear yes: for each one the family
-  accepts (the onboarding profile asks), create the task with the agreed schedule and the prompt
-  "Follow the `family-assistant` skill's `<capability>` reference and post to the family's group
-  chat." Skip what they decline; some runs wait for their moment anyway (the price watch, for
-  instance, starts when they add their first item).
+  decline; then leave it paused). The other runs need a clear yes: for each one the family accepts
+  (the onboarding profile asks), create the task per the `family-assistant` skill's *Turning on a
+  scheduled run*. Skip what they decline; some wait for their moment anyway (the price watch starts
+  when they add their first item).
 - **Recommend the weekly memory tidy-up (the memory-hygiene task), in plain words.** It ships
   paused like every task and got skipped in real runs, so don't let it slip by. Near the end, tell
   them in one plain sentence what it does, no jargon (not "memory hygiene," "task," or "paused"),

--- a/lifestyle/family-assistant/skills/welcome/SKILL.md
+++ b/lifestyle/family-assistant/skills/welcome/SKILL.md
@@ -24,9 +24,11 @@ first question.
   "Follow the `family-assistant` skill's `<capability>` reference and post to the family's group
   chat." Skip what they decline; some runs wait for their moment anyway (the price watch, for
   instance, starts when they add their first item).
-- **Offer what onboarding doesn't cover.** Check the shipped paused tasks; for any the
-  onboarding questions don't reach, raise it yourself: a plain, concise explanation of what it
-  does and why it helps, your recommendation, and activate it only when they say yes.
+- **Recommend the weekly memory tidy-up (the memory-hygiene task), in plain words.** It ships
+  paused like every task and got skipped in real runs, so don't let it slip by. Near the end, tell
+  them in one plain sentence what it does, no jargon (not "memory hygiene," "task," or "paused"),
+  something like: "Once a week I tidy up my memory, what I've learned about the family, upcoming
+  events, the things I'm meant to keep an eye on, so it all stays accurate." recommend keeping it on, and turn it on if they say yes.
 
 ## Tone
 


### PR DESCRIPTION
## Why

Provisioning the template end-to-end surfaced that onboarding asks too much up front. In a real run, ~5 of the questions came back "I don't know" (grocery store, shop day, staples, activities, price-watch, school-sweep timing) — things the agent should pick up from real use, not extract in an interview before it's delivered any value. This reworks onboarding around **connect first, seed light, learn over life**, and folds in a set of production lessons.

## Changes

- **Slim the interview.** Profile split into a short **Ask now** core (people, Google connection, city + country, the two standard briefings' timing, allergies) vs **Learn over time** (store/shop day, staples, activities, schools, watchlist, how-to-help-each-person) — captured the first time they surface, never interrogated for.
- **Connect first.** Probe what's already connected before asking whose calendar/inbox to read; infer country/timezone from the calendar and confirm rather than asking cold; note the account may already have history, so don't assume it's empty.
- **Honest account framing.** Any Google account works; a shared family account is best; separate personal accounts = multi-connection. School mail is routed via a **forwarded copy only** (a Gmail filter on the inbox that already gets it), so the original still lands in the parent's inbox — no single point of failure.
- **City + country** captured together (a bare city defaults to the wrong place); the two standard briefings asked as **one keep-or-change question**.
- **Continuous learning** as a standing rule (new ground rule 10): seed light at onboarding, keep learning from every email/event/request.
- **Memory hygiene** stays paused (like every task) but the welcome flow now **actively recommends** turning it on, explained in plain words with no jargon.
- **README** updated to match the seed-light onboarding and the memory-hygiene recommendation.

## Testing

`node scripts/check-templates.mjs` → all 5 templates OK. Docs-only (Markdown persona/skill/reference edits); no code or MCP changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)