### PR TITLE
Machine-readable registry index + CI gates

### DIFF
--- a/.github/workflows/check-templates.yml
+++ b/.github/workflows/check-templates.yml
@@ -11,3 +11,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: node scripts/check-templates.mjs
+
+  index-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: node scripts/build-index.mjs
+      - name: index.json is up to date
+        run: git diff --exit-code index.json
+
+  version-bump:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: node scripts/check-version-bump.mjs ${{ github.event.pull_request.base.sha }}

--- a/index.json
+++ b/index.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "categories": {
+    "data": [
+      {
+        "ref": "data/analyst",
+        "name": "analyst",
+        "version": "1.0.0",
+        "description": "Data analyst agent: pipeline checks, query writing, and recurring report integrity"
+      }
+    ],
+    "lifestyle": [
+      {
+        "ref": "lifestyle/family-assistant",
+        "name": "family-assistant",
+        "version": "1.0.0",
+        "description": "Household assistant agent: morning briefs, meal planning and grocery lists, week-ahead logistics, school tracking, price watch, and bookings"
+      }
+    ],
+    "media": [
+      {
+        "ref": "media/journalist",
+        "name": "journalist",
+        "version": "1.0.0",
+        "description": "Journalist agent: beat monitoring, pitch evaluation, source finding, and interview prep"
+      }
+    ],
+    "product": [
+      {
+        "ref": "product/competitor-analysis",
+        "name": "competitor-analysis",
+        "version": "1.0.0",
+        "description": "Competitor research agent producing structured docs, news logs, and a tracking spreadsheet"
+      }
+    ],
+    "sales": [
+      {
+        "ref": "sales/sdr",
+        "name": "sdr",
+        "version": "1.0.0",
+        "description": "Outbound SDR agent: prospecting, enrichment, sequencing, and CRM hygiene on HubSpot and Exa"
+      }
+    ]
+  }
+}

--- a/scripts/build-index.mjs
+++ b/scripts/build-index.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Generates index.json: the registry listing NanoClaw fetches to show templates
+ * in chat (`ncl templates list --registry`).
+ *
+ * A template is any directory containing plugin.json; its ref is the
+ * repo-relative path. The output is advisory only — an install re-validates
+ * everything at stamp time — so this never needs to be hand-edited, and CI
+ * fails if it drifts from the tree.
+ *
+ * Zero dependencies by design — plain node. Run: node scripts/build-index.mjs
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const SKIP_DIRS = new Set(['scripts', 'node_modules']);
+
+function findTemplates(dir, rel = '') {
+  const refs = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+    const entryRel = rel ? `${rel}/${entry.name}` : entry.name;
+    const entryDir = path.join(dir, entry.name);
+    if (fs.existsSync(path.join(entryDir, 'plugin.json'))) refs.push(entryRel);
+    else refs.push(...findTemplates(entryDir, entryRel));
+  }
+  return refs;
+}
+
+function entryFor(ref) {
+  const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, ref, 'plugin.json'), 'utf8'));
+  return {
+    ref,
+    name: ref.split('/').pop(),
+    version: typeof manifest.version === 'string' ? manifest.version : '0.0.0',
+    description: typeof manifest.description === 'string' ? manifest.description : '',
+  };
+}
+
+const refs = findTemplates(ROOT).sort();
+const categories = {};
+for (const ref of refs) {
+  const cut = ref.indexOf('/');
+  if (cut === -1) throw new Error(`Template "${ref}" is not under a category directory (<category>/<template>)`);
+  (categories[ref.slice(0, cut)] ??= []).push(entryFor(ref));
+}
+const index = { schema: 1, categories };
+fs.writeFileSync(path.join(ROOT, 'index.json'), `${JSON.stringify(index, null, 2)}\n`);
+console.log(`build-index: ${refs.length} template(s) in ${Object.keys(categories).length} categories written to index.json`);

--- a/scripts/check-version-bump.mjs
+++ b/scripts/check-version-bump.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Fails a PR that changes a template without bumping its plugin.json version.
+ * Installs cache templates by ref, so an unbumped edit is invisible downstream.
+ *
+ * Exempt: index.json (generated), scripts/, .github/, and templates added by
+ * this PR (no base version to compare against).
+ *
+ * Zero dependencies by design — plain node.
+ * Run: node scripts/check-version-bump.mjs <base-ref>
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const EXEMPT_PREFIXES = ['scripts/', '.github/'];
+const EXEMPT_FILES = new Set(['index.json']);
+
+const base = process.argv[2];
+if (!base) {
+  console.error('usage: node scripts/check-version-bump.mjs <base-ref>');
+  process.exit(2);
+}
+
+const git = (args) => execFileSync('git', args, { cwd: ROOT, encoding: 'utf8' });
+
+function templateRefFor(file) {
+  const segments = file.split('/');
+  for (let i = segments.length - 1; i > 0; i--) {
+    const ref = segments.slice(0, i).join('/');
+    if (fs.existsSync(path.join(ROOT, ref, 'plugin.json'))) return ref;
+  }
+  return undefined;
+}
+
+function versionAt(ref, revision) {
+  try {
+    const source =
+      revision === undefined
+        ? fs.readFileSync(path.join(ROOT, ref, 'plugin.json'), 'utf8')
+        : git(['show', `${revision}:${ref}/plugin.json`]);
+    return JSON.parse(source).version;
+  } catch {
+    return undefined;
+  }
+}
+
+const changed = git(['diff', '--name-only', `${base}...HEAD`]).split('\n').filter(Boolean);
+const touched = new Set();
+for (const file of changed) {
+  if (EXEMPT_FILES.has(file) || EXEMPT_PREFIXES.some((p) => file.startsWith(p))) continue;
+  const ref = templateRefFor(file);
+  if (ref) touched.add(ref);
+}
+
+const errors = [];
+for (const ref of [...touched].sort()) {
+  const baseVersion = versionAt(ref, base);
+  if (baseVersion === undefined) continue; // new template in this PR
+  const headVersion = versionAt(ref);
+  if (headVersion === baseVersion) {
+    errors.push(`${ref}: changed without a plugin.json version bump (still ${baseVersion})`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`check-version-bump: ${errors.length} problem(s)\n`);
+  for (const err of errors) console.error(`  - ${err}`);
+  process.exit(1);
+}
+console.log(
+  touched.size === 0
+    ? 'check-version-bump: no template changes'
+    : `check-version-bump: ${touched.size} template(s) bumped: ${[...touched].sort().join(', ')}`,
+);


### PR DESCRIPTION
## What

A machine-readable registry index plus the CI gates that keep it honest:

- `index.json` (`schema: 1`): templates grouped by category (the ref's first segment), category keys and entries sorted, each entry `{ref, name, version, description}` derived from the template's own `plugin.json`.
- `scripts/build-index.mjs`: zero-dependency generator; skips dot-directories; rejects any template not under a category directory.
- `scripts/check-version-bump.mjs` + CI: a PR whose committed `index.json` is stale fails, and a PR that changes a template's files without bumping that template's `version` fails.

## Why

NanoClaw is gaining `ncl templates list --registry` (nanocoai/nanoclaw#3396): the host fetches this one file to list templates in chat, instead of cloning or walking the tree. The index is advisory only; installs re-validate every fetched template at stamp time.

## Verification

- `node scripts/check-templates.mjs` → 5 template(s) OK
- `node scripts/build-index.mjs` + `git diff --exit-code index.json` → no drift
- `node scripts/check-version-bump.mjs origin/main` → no template changes (gate exercises clean)
