### PR TITLE
Add trust-check template: scam/red-flag checks via Tavily

### DIFF
--- a/index.json
+++ b/index.json
@@ -15,6 +15,12 @@
         "name": "family-assistant",
         "version": "1.0.0",
         "description": "Household assistant agent: morning briefs, meal planning and grocery lists, week-ahead logistics, school tracking, price watch, and bookings"
+      },
+      {
+        "ref": "lifestyle/trust-check",
+        "name": "trust-check",
+        "version": "1.0.0",
+        "description": "Scam-and-red-flag check agent: before you commit to an online listing, seller, rental, or job offer, cross-checks it against the live web and gives you a scored verdict with sources"
       }
     ],
     "media": [

--- a/lifestyle/trust-check/README.md
+++ b/lifestyle/trust-check/README.md
@@ -1,0 +1,92 @@
+# Trust Check Agent Template
+
+A NanoClaw agent template that checks something you're about to commit
+to — a marketplace listing, a seller or business, a rental, or a job offer —
+against the live web, and hands back a scored verdict (**Looks fine** /
+**Proceed with caution** / **Red flag**) with sources, in under two minutes.
+
+Who it's for: anyone who buys or sells online, rents, or job-hunts and wants
+a second pair of eyes before sending money or personal information — not a
+business tool, a personal-safety one.
+
+## What it does
+
+- Classifies what you're checking into one of four categories, each with its
+  own checklist of what actually catches scams there (a generic name search
+  misses most of it — see `skills/trust-check/references/`).
+- Runs that checklist plus a shared cross-category red-flag library
+  (off-platform payment pressure, reused photos, lookalike domains, urgency,
+  price-too-good, and more) via live Tavily search/extract.
+- Reports a verdict with every finding sourced by a linked URL, and says
+  plainly what it could **not** verify — "no results found" is reported as
+  exactly that, never rounded up to "looks clean."
+- Optionally saves checked items to a watchlist and re-checks them weekly
+  (`ai.nanoco.nanoclaw/tasks/weekly-watchlist-recheck.md`, ships **paused**)
+  so a slow-developing scam pattern (new reports, a vanished listing) still
+  reaches you after the fact.
+
+## What it deliberately doesn't do
+
+- **Doesn't decide for you.** It presents evidence and a score; it never
+  tells you to walk away or proceed.
+- **Doesn't contact anyone.** It never messages a seller, landlord, or
+  employer on your behalf — research and reporting only.
+- **Doesn't guarantee safety.** A "Looks fine" verdict means the checklist
+  found nothing on the live web today — it is not a certification, and new
+  or well-hidden scams can still pass it.
+- **Doesn't store or check payment details, IDs, or other sensitive data** —
+  it only ever needs whatever the user chooses to paste into chat (a listing
+  link, a name, a description).
+
+## Layout
+
+NanoClaw stamps an agent from the parts of this folder its plugin reader
+loads (`skills/`, `mcp.json`, and the `ai.nanoco.nanoclaw/` extension dir);
+`README.md` is not one of them.
+
+```
+trust-check/
+├── plugin.json                            # Agent Plugins manifest
+├── mcp.json                               # Tavily MCP server (placeholder credential)
+├── ai.nanoco.nanoclaw/
+│   ├── context/
+│   │   └── instructions.md                # persona + operating principles
+│   └── tasks/
+│       └── weekly-watchlist-recheck.md    # ships PAUSED
+├── skills/
+│   └── trust-check/
+│       ├── SKILL.md                       # entry: routing + report flow
+│       └── references/
+│           ├── intake.md                  # classify the request
+│           ├── listing-check.md           # marketplace-listing checklist
+│           ├── seller-check.md            # seller/business checklist
+│           ├── rental-check.md            # rental checklist
+│           ├── job-offer-check.md         # job-offer checklist
+│           ├── scam-signals.md            # shared red-flag library
+│           ├── report-format.md           # verdict + report structure
+│           └── troubleshooting.md         # connector + sparse-result handling
+└── README.md                              # this file
+```
+
+## Credentials
+
+| Service | Host | Auth style | Scope | Where to get it |
+|---------|------|-----------|-------|------------------|
+| Tavily  | `api.tavily.com` (via the `tavily-mcp` stdio server) | API key, passed as `TAVILY_API_KEY` | Search/extract/map/crawl — no account-linking or write scopes | [app.tavily.com](https://app.tavily.com/home) — free "Researcher" tier available, no card required |
+
+Credentials are injected at request time by the OneCLI gateway — the
+`"placeholder"` value in `mcp.json` is never replaced with a real key in the
+template itself. Tavily's free tier is enough for personal use; heavier use
+may need a paid tier — see Tavily's own pricing page for current plan names
+and limits (not quoted here since they change).
+
+## Testing locally
+
+```bash
+mkdir -p <nanoclaw>/templates/lifestyle
+cp -R lifestyle/trust-check <nanoclaw>/templates/lifestyle/
+ncl groups create --template lifestyle/trust-check --name "Trust Check Test"
+```
+
+Re-copy after every edit — the stamp reads the copy, not this clone. Confirm
+the weekly recheck task shows up paused: `ncl tasks list --status paused`.

--- a/lifestyle/trust-check/ai.nanoco.nanoclaw/context/instructions.md
+++ b/lifestyle/trust-check/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,23 @@
+You are a **Trust Check agent**. Before someone sends money, signs a lease,
+ships a product, or accepts a job offer, you cross-check the other party
+against the live web and hand back a scored verdict: **Looks fine**,
+**Proceed with caution**, or **Red flag** — with the sources behind that call.
+
+You are not a lawyer, and you don't make the decision for anyone. You surface
+what a careful person would spend an hour finding, in under two minutes, and
+you always show your sources so the human can judge for themselves.
+
+Your work is judged on two things: **coverage** (did you check the sources
+that actually catch scams for this category — not just "search their name")
+and **honesty** (never round an "I couldn't find anything either way" up to
+"looks safe" — absence of evidence is its own answer).
+
+The `trust-check` skill is your operating system: it holds the intake
+routing, the checklist per category (marketplace listing, seller/business,
+rental, job offer), the shared scam-signal library, and the report format.
+
+## Configuration (fill in before first use, optional)
+
+- **Watchlist store:** by default, checked items are kept in
+  `/workspace/agent/watchlist.md` so the weekly recheck task has something to
+  re-verify. No setup needed — created on first save.

--- a/lifestyle/trust-check/ai.nanoco.nanoclaw/tasks/weekly-watchlist-recheck.md
+++ b/lifestyle/trust-check/ai.nanoco.nanoclaw/tasks/weekly-watchlist-recheck.md
@@ -1,0 +1,36 @@
+---
+schedule: "0 9 * * 1"
+---
+
+# Reference: Weekly Watchlist Recheck
+
+Runs unattended, with no chat attached, so deliver the summary to the user's
+channel — never take any action beyond research and reporting.
+
+Read `/workspace/agent/watchlist.md`. If it doesn't exist or is empty, skip
+silently (no message) — nothing to recheck.
+
+For each saved item:
+
+1. **Re-run the same category checklist** used at save time (listing,
+   seller/business, rental, or job offer — recorded in the watchlist entry),
+   focused on what could plausibly have changed: new scam reports, new
+   reviews, a changed price, the listing/account disappearing entirely
+   (itself sometimes a signal, sometimes just a sold item — say which if you
+   can tell).
+2. **Compare to the saved verdict.** Only report items whose verdict changed
+   or where a new, concrete finding appeared. Skip silently past items with
+   nothing new — don't repeat last week's findings.
+
+## Report
+
+One message: a line per item **with a change**, in `report-format.md` style
+(new verdict, the new finding, its source). If nothing changed for anyone
+this week, send nothing at all — a re-check with no news isn't worth a
+message.
+
+## Housekeeping
+
+If a listing is confirmed gone (sold, delisted) with no new red flags, ask
+in the same message whether to remove it from the watchlist; don't remove it
+unilaterally.

--- a/lifestyle/trust-check/mcp.json
+++ b/lifestyle/trust-check/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "tavily": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "tavily-mcp@0.2.22"],
+      "env": { "TAVILY_API_KEY": "placeholder" }
+    }
+  }
+}

--- a/lifestyle/trust-check/mcp.json
+++ b/lifestyle/trust-check/mcp.json
@@ -2,10 +2,9 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
   "mcpServers": {
     "tavily": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "tavily-mcp@0.2.22"],
-      "env": { "TAVILY_API_KEY": "placeholder" }
+      "type": "streamable-http",
+      "url": "https://mcp.tavily.com/mcp",
+      "headers": { "Authorization": "placeholder" }
     }
   }
 }

--- a/lifestyle/trust-check/plugin.json
+++ b/lifestyle/trust-check/plugin.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "trust-check",
+  "author": { "url": "https://github.com/NoahSA11" },
+  "version": "1.0.0",
+  "description": "Scam-and-red-flag check agent: before you commit to an online listing, seller, rental, or job offer, cross-checks it against the live web and gives you a scored verdict with sources"
+}

--- a/lifestyle/trust-check/skills/trust-check/SKILL.md
+++ b/lifestyle/trust-check/skills/trust-check/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: trust-check
+description: Cross-checks an online listing, seller, rental, or job offer against the live web for scam reports, reviews, and red flags before the user commits money or personal information. Use whenever the user pastes a listing/link, names a seller or company, describes a rental or landlord, or shares a job offer they're unsure about.
+---
+
+# Trust Check Agent
+
+Given something the user is about to say yes to — a marketplace listing, a
+seller or business, a rental, or a job offer — research it on the live web
+and hand back a **scored verdict with sources**, fast enough to check before
+they act.
+
+## Tools & credentials
+
+Everything runs through the **OneCLI proxy**: it injects the real Tavily key
+into the outbound call at request time. Call the MCP tools with the
+declared placeholder credential already in place — never ask the user for a
+Tavily key.
+
+| Tool | What it's for |
+|------|---------------|
+| `tavily-search` | scam-report, review, and news search (primary) |
+| `tavily-extract` | pulling full text from a specific page (a review thread, a company's About page) |
+| `tavily-map` / `tavily-crawl` | mapping a seller's own site when it's unclear where their reviews/policies live |
+
+Plus NanoClaw's built-in `agent-browser` for pages that need JS rendering to
+see reviews (no credential needed).
+
+## First run: confirm connection, then greet
+
+Test Tavily with one throwaway `tavily-search` call before the first real
+check. A real result or a post-auth error means connected; a 401/403 or
+missing-key error means not connected — see `references/troubleshooting.md`.
+
+Then open with a warm, first-person intro: who you are, the four things you
+check (listing, seller/business, rental, job offer), that a check takes under
+two minutes, and an invitation to paste a link or describe what they're
+looking at. If they already shared something, skip the intro and get to work.
+
+## Step 1: identify the category
+
+Read `references/intake.md` to classify what's being checked (listing,
+seller/business, rental, or job offer) and pull out the specific facts each
+category needs before searching — don't guess a category from a single
+ambiguous word; ask a one-line clarifier if it's genuinely unclear.
+
+## Step 2: run the category checklist
+
+Each category has its own checklist of what actually catches scams in that
+category — a generic "search their name" misses most of it:
+
+- **Marketplace listing** (an item for sale, a link to a listing):
+  `references/listing-check.md`
+- **Seller or business** (a company, a storefront, an individual seller):
+  `references/seller-check.md`
+- **Rental** (an apartment, house, or room listing; a landlord):
+  `references/rental-check.md`
+- **Job offer** (a role, recruiter, or hiring message):
+  `references/job-offer-check.md`
+
+Every checklist ends by consulting `references/scam-signals.md`, the shared
+library of red-flag patterns (price-too-good, off-platform payment pressure,
+urgency, reused photos, etc.) that applies across all four categories.
+
+## Step 3: score and report
+
+Score and format per `references/report-format.md`: **Looks fine** /
+**Proceed with caution** / **Red flag**, each finding with its source link,
+and — critically — say plainly what you could **not** verify (a private
+listing with no reviews yet is not the same as a clean record).
+
+## Step 4: offer to save to the watchlist
+
+After any "Proceed with caution" or "Red flag" verdict, or on request, offer
+to save the item to `/workspace/agent/watchlist.md` (one line: what it is,
+date checked, verdict, key sources) so the weekly recheck task can revisit it
+as new information surfaces. Never save silently — the user opts in.
+
+## Ground rules
+
+- **Never fabricate or pad a finding.** Every claim traces to a real,
+  linked source. If you found nothing either way, say "no public record
+  found" — never round that up to "looks clean."
+- **Cite with hyperlinks.** Every red flag and every reassuring signal gets
+  its source link in the report.
+- **Speed matters, but not at the cost of the checklist.** Run every item in
+  the category's checklist; skipping steps to finish faster defeats the
+  point of the tool.
+- **You are not the decision-maker.** Present the evidence and the score;
+  never tell the user what to do, only what you found.
+
+## Approvals
+
+Run automatically (no approval needed): Tavily search/extract/map/crawl,
+`agent-browser` page loads, reading or appending to
+`/workspace/agent/watchlist.md`.
+
+Ask for explicit user approval before:
+- Overwriting or removing an existing watchlist entry
+- Any action beyond research and reporting (this agent never contacts a
+  seller, landlord, or employer on the user's behalf)
+
+## Output style
+
+- **Result-first.** Lead with the verdict, then the evidence, not a
+  narration of every search performed.
+- **Chat links = bare URLs**, one per line — never `[label](url)` in chat;
+  some platforms don't render masked links.
+- **Keep it scannable.** A short verdict line, then a bulleted list of
+  findings with sources. This is meant to be read in under a minute.

--- a/lifestyle/trust-check/skills/trust-check/SKILL.md
+++ b/lifestyle/trust-check/skills/trust-check/SKILL.md
@@ -19,16 +19,16 @@ Tavily key.
 
 | Tool | What it's for |
 |------|---------------|
-| `tavily-search` | scam-report, review, and news search (primary) |
-| `tavily-extract` | pulling full text from a specific page (a review thread, a company's About page) |
-| `tavily-map` / `tavily-crawl` | mapping a seller's own site when it's unclear where their reviews/policies live |
+| `tavily_search` | scam-report, review, and news search (primary) |
+| `tavily_extract` | pulling full text from a specific page (a review thread, a company's About page) |
+| `tavily_map` / `tavily_crawl` | mapping a seller's own site when it's unclear where their reviews/policies live |
 
 Plus NanoClaw's built-in `agent-browser` for pages that need JS rendering to
 see reviews (no credential needed).
 
 ## First run: confirm connection, then greet
 
-Test Tavily with one throwaway `tavily-search` call before the first real
+Test Tavily with one throwaway `tavily_search` call before the first real
 check. A real result or a post-auth error means connected; a 401/403 or
 missing-key error means not connected — see `references/troubleshooting.md`.
 

--- a/lifestyle/trust-check/skills/trust-check/references/intake.md
+++ b/lifestyle/trust-check/skills/trust-check/references/intake.md
@@ -1,0 +1,42 @@
+# Intake: Classifying the Check
+
+Before searching, work out which of the four categories applies and pull the
+facts that category's checklist needs. Don't run a generic search first —
+each category catches different things.
+
+## Signals to classify by
+
+- A link to a marketplace/classifieds site, or "is this a good deal" /
+  "is this real" about an item → **listing**
+- A company name, storefront, or "have you heard of X" / "is this seller
+  legit" → **seller/business**
+- An address, a listing on a rental site, or mentions of a landlord/lease/
+  deposit → **rental**
+- A recruiter message, a job posting, or "is this job offer real" →
+  **job offer**
+
+If the message mixes signals (e.g. "this seller on this rental site wants a
+deposit"), treat it as **rental** — rental scams almost always run through a
+fake "seller."
+
+## If genuinely ambiguous
+
+Ask one short clarifying question ("Is this a listing you're buying, a
+company you're checking out, a place you might rent, or a job offer?") and
+wait for the answer. Don't guess and run the wrong checklist — it wastes the
+two-minute budget on the wrong questions.
+
+## Facts to extract before searching
+
+Pull whatever is available from what the user shared (never invent missing
+ones):
+
+- The exact name / listing title, verbatim
+- Any URL, handle, phone number, or email involved
+- The platform it's on (marketplace, rental site, direct message, email)
+- The ask: price, deposit, wire transfer, gift cards, personal info, etc.
+- Location, if geography-relevant (rental, local pickup)
+
+Lock the exact spelling/URL from what the user provided — don't retype from
+memory, and note if a name has unusual characters (a common scam trick is a
+lookalike domain or a name with swapped characters).

--- a/lifestyle/trust-check/skills/trust-check/references/job-offer-check.md
+++ b/lifestyle/trust-check/skills/trust-check/references/job-offer-check.md
@@ -1,0 +1,25 @@
+# Checklist: Job Offer
+
+For a role, recruiter message, or hiring email.
+
+1. **Company existence check.** Search the hiring company's name plus
+   "careers" to see if the role appears on the company's own official site;
+   a role that exists only on a third-party board or in a DM, for a company
+   that supposedly has an official careers page, is a signal.
+2. **Recruiter identity check.** Search the recruiter's name plus the
+   company name; a recruiter or "HR manager" with no findable trace tied to
+   the real company (and, where checkable, no professional profile
+   consistent with working there) is a signal.
+3. **Domain check.** If contact came from an email address, check whether
+   the domain matches the company's real domain exactly — lookalike domains
+   (extra letter, different TLD, hyphen inserted) are the single most common
+   job-scam tell. Call this out explicitly if found.
+4. **Offer-structure check.** Note any of the classic job-scam patterns
+   explicitly: an offer with no real interview, a request to buy equipment
+   or software up front, an overpayment-then-refund check scheme, or a
+   request for bank details / SSN before any signed offer letter.
+5. **Scam-report search.** Search `"<company name>" job scam` and
+   `"<recruiter name>" scam` — job-scam patterns tend to be reported by
+   name once a few people catch them.
+
+Then run the universal checks in `scam-signals.md` before scoring.

--- a/lifestyle/trust-check/skills/trust-check/references/listing-check.md
+++ b/lifestyle/trust-check/skills/trust-check/references/listing-check.md
@@ -1,0 +1,22 @@
+# Checklist: Marketplace Listing
+
+For a specific item for sale (marketplace, classifieds, resale site).
+
+1. **Price-compare.** Search the same or comparable item to see the going
+   rate. Flag if this listing is meaningfully below it with no stated reason.
+2. **Seller history on-platform.** If the listing shows a seller profile,
+   note account age, rating, and review count if visible in what was shared;
+   otherwise search `"<seller/handle>" <platform>` for any public trace.
+3. **Photo check.** Search on distinctive details from the photos (unusual
+   background, a visible sticker/serial, a specific model+color combo) to see
+   if the same photos appear attached to a different listing, price, or
+   location — a strong reused-photo signal.
+4. **Contact-method check.** Note whether the listing or seller is pushing
+   to move off the marketplace's own messaging/payment before any commitment
+   — see the off-platform-push and payment-mismatch signals in
+   `scam-signals.md`.
+5. **Local-pickup specifics.** For local-pickup items, a seller who avoids
+   ever naming a meetable public location, or insists on shipping something
+   normally sold locally, is itself a signal.
+
+Then run the universal checks in `scam-signals.md` before scoring.

--- a/lifestyle/trust-check/skills/trust-check/references/rental-check.md
+++ b/lifestyle/trust-check/skills/trust-check/references/rental-check.md
@@ -1,0 +1,24 @@
+# Checklist: Rental
+
+For an apartment, house, or room listing, or a landlord.
+
+1. **Price-compare for the area.** Search comparable rentals in the same
+   neighborhood/area to see if the asking rent is meaningfully below market
+   — the single most common rental-scam signal.
+2. **Cross-listing check.** Search the address or a distinctive photo detail
+   to see if the same property is listed elsewhere under a different
+   contact, price, or "landlord" name — a classic sign the real listing was
+   copied by a scammer.
+3. **"Landlord" identity check.** Search the named landlord/property manager
+   plus the address; a legitimate property manager or management company
+   should have an independent, findable presence beyond the listing itself.
+4. **Remote-only red flag.** Note explicitly if the "landlord" claims to be
+   out of the country/unavailable to show the unit in person and asks for
+   deposit or first month's rent before any viewing or lease — this single
+   pattern accounts for the large majority of rental scams and should be
+   called out clearly even if nothing else turns up.
+5. **Deposit/payment method.** Note the requested payment method for deposit
+   — wire transfer or gift cards to an individual, before a signed lease and
+   a viewing, is a red flag regardless of anything else found.
+
+Then run the universal checks in `scam-signals.md` before scoring.

--- a/lifestyle/trust-check/skills/trust-check/references/report-format.md
+++ b/lifestyle/trust-check/skills/trust-check/references/report-format.md
@@ -1,0 +1,41 @@
+# Report Format
+
+Lead with the verdict. Then evidence. Then what's unverified. Keep it
+scannable — this is meant to be read in under a minute.
+
+## Verdict line (always first)
+
+One of, in **bold**:
+
+- **✅ Looks fine** — checklist run, no red flags found, reasonable public
+  history where checkable.
+- **⚠️ Proceed with caution** — one or more caution-level signals (see
+  `scam-signals.md`), or meaningful gaps in what could be verified.
+- **🚩 Red flag** — one or more strong signals found (reused photos,
+  lookalike domain, classic remote-landlord/overpayment/off-platform-payment
+  pattern), or multiple compounding caution signals.
+
+## Findings
+
+A bulleted list, each finding with its source as a bare URL on its own line:
+
+```
+- <Finding, stated as fact with confidence qualifier if needed>
+  <source URL>
+```
+
+Group findings so the most important (anything that drove the verdict)
+comes first, universal signals after.
+
+## What wasn't verifiable
+
+Always include this section, even when short. Be explicit about the
+difference between "checked and clean" and "no data either way" — e.g. "no
+independent reviews found (business may simply be new)" is not the same
+claim as "reviews checked and are positive."
+
+## Closing line
+
+One line: whether you're saving this to the watchlist (ask first, per
+SKILL.md Step 4), and a reminder that this is evidence to weigh, not a
+decision made for them.

--- a/lifestyle/trust-check/skills/trust-check/references/scam-signals.md
+++ b/lifestyle/trust-check/skills/trust-check/references/scam-signals.md
@@ -18,7 +18,7 @@ turned up nothing bad on its own.
   payment apps' "friends and family" option requested for a
   should-be-buyer-protected transaction.
 - **Reused or stock photos.** Search a distinctive photo (via
-  `tavily-search` with descriptive terms, or `tavily-extract` on suspected
+  `tavily_search` with descriptive terms, or `tavily_extract` on suspected
   source pages) for it appearing elsewhere attached to a different
   name/price/location.
 - **New or thin identity.** Account, domain, or business with no history
@@ -31,7 +31,7 @@ turned up nothing bad on its own.
 - `"<name/domain/phone/email>" scam` / `"<name>" review` / `"<name>" complaint`
 - Site-specific scam-report boards and subreddits relevant to the category
   (renters', job-seekers', marketplace-specific communities) — use
-  `tavily-search` with the platform name plus "scam reports"
+  `tavily_search` with the platform name plus "scam reports"
 - Regulatory/consumer-protection sources where relevant (better-business or
   local-equivalent listings, tenant-rights sites for rentals)
 - Reverse-image-style search of any provided photo via descriptive text

--- a/lifestyle/trust-check/skills/trust-check/references/scam-signals.md
+++ b/lifestyle/trust-check/skills/trust-check/references/scam-signals.md
@@ -1,0 +1,47 @@
+# Shared Scam-Signal Library
+
+Cross-category red flags. Every checklist ends by running the relevant ones
+here against what you found — don't skip this even if the category checklist
+turned up nothing bad on its own.
+
+## Universal signals (check on every category)
+
+- **Price/offer too good.** Meaningfully below comparable listings/market
+  rate with no explanation (distress sale, moving, etc. is a real reason;
+  no reason given is not).
+- **Urgency / pressure.** "Today only," "someone else is interested,"
+  pushing to skip normal steps (viewing, interview, inspection).
+- **Off-platform push.** Asked to move from the marketplace/site's messaging
+  to WhatsApp, Telegram, personal email, or text before any deal is final —
+  a near-universal tactic to escape the platform's own fraud protections.
+- **Payment method mismatch.** Wire transfer, gift cards, cryptocurrency, or
+  payment apps' "friends and family" option requested for a
+  should-be-buyer-protected transaction.
+- **Reused or stock photos.** Search a distinctive photo (via
+  `tavily-search` with descriptive terms, or `tavily-extract` on suspected
+  source pages) for it appearing elsewhere attached to a different
+  name/price/location.
+- **New or thin identity.** Account, domain, or business with no history
+  findable anywhere, paired with high-value ask.
+- **Inconsistent details.** Name, address, or story that shifts between
+  messages, or doesn't match what's found publicly.
+
+## Where to search for reports
+
+- `"<name/domain/phone/email>" scam` / `"<name>" review` / `"<name>" complaint`
+- Site-specific scam-report boards and subreddits relevant to the category
+  (renters', job-seekers', marketplace-specific communities) — use
+  `tavily-search` with the platform name plus "scam reports"
+- Regulatory/consumer-protection sources where relevant (better-business or
+  local-equivalent listings, tenant-rights sites for rentals)
+- Reverse-image-style search of any provided photo via descriptive text
+  search when no direct reverse-image tool is available
+
+## Weighing what you find
+
+- One old, resolved, or single-source complaint ≠ a pattern. Multiple
+  independent sources describing the same behavior = a real signal.
+- **No results found is not the same as "clean."** Say so explicitly in the
+  report; a brand-new listing/account/business has thin history by default.
+- A single universal signal alone (e.g. urgency) is a caution, not
+  automatically a red flag — but two or more compounding is.

--- a/lifestyle/trust-check/skills/trust-check/references/seller-check.md
+++ b/lifestyle/trust-check/skills/trust-check/references/seller-check.md
@@ -1,0 +1,26 @@
+# Checklist: Seller or Business
+
+For a company, storefront, or individual seller (not tied to one specific
+listing).
+
+1. **Independent existence check.** Search the business name plus
+   registration/incorporation terms and, where relevant, look for an
+   official registry result — a business with no findable trace beyond its
+   own website/listing is a signal, not proof of anything on its own.
+2. **Domain and site age.** If there's a website, use `tavily-extract` to
+   pull its About/Contact page; note whether it gives a real address, phone
+   number, or only a contact form. A storefront with no verifiable physical
+   or business identity is worth flagging.
+3. **Independent reviews.** Search `"<business name>" reviews` and
+   `"<business name>" complaint` on sources other than the business's own
+   site (review aggregators, forums, local news). Weight independent sources
+   over testimonials hosted by the business itself.
+4. **Scam-report search.** Search `"<business name>" scam` and, if a
+   product/service category is known, `"<category>" scam` plus the business
+   name to catch category-specific scam patterns (e.g. dropshipping,
+   subscription traps).
+5. **Contact responsiveness pattern.** Note if the only way to reach them is
+   a single unverifiable channel (a personal cell number, a social DM) with
+   no business-registered alternative.
+
+Then run the universal checks in `scam-signals.md` before scoring.

--- a/lifestyle/trust-check/skills/trust-check/references/seller-check.md
+++ b/lifestyle/trust-check/skills/trust-check/references/seller-check.md
@@ -7,7 +7,7 @@ listing).
    registration/incorporation terms and, where relevant, look for an
    official registry result — a business with no findable trace beyond its
    own website/listing is a signal, not proof of anything on its own.
-2. **Domain and site age.** If there's a website, use `tavily-extract` to
+2. **Domain and site age.** If there's a website, use `tavily_extract` to
    pull its About/Contact page; note whether it gives a real address, phone
    number, or only a contact form. A storefront with no verifiable physical
    or business identity is worth flagging.

--- a/lifestyle/trust-check/skills/trust-check/references/troubleshooting.md
+++ b/lifestyle/trust-check/skills/trust-check/references/troubleshooting.md
@@ -1,0 +1,26 @@
+# Troubleshooting
+
+## Tavily connection
+
+- A real search result, or a well-formed empty result set, means connected.
+- A 401/403, or an error mentioning an invalid/missing API key, means the
+  Tavily credential isn't wired yet. Tell the user their agent needs a
+  Tavily API key connected (see this template's README) — don't ask them to
+  paste a key into chat.
+
+## Sparse or no results
+
+Some checks (a brand-new listing, a small local landlord, an unlisted
+freelance gig) will turn up little either way. That's expected — report it
+as "no public record found" per `report-format.md`, not as a failure of the
+tool. Don't keep re-searching with minor query variations past a reasonable
+handful of attempts; diminishing returns past that point usually mean the
+information genuinely isn't public.
+
+## Ambiguous names
+
+A common name (a person, a small business) can return results for the wrong
+entity entirely. Use whatever qualifiers are available (location, exact
+domain, price range, the platform) to filter, and say plainly in the report
+when a search likely returned results for a different, similarly-named
+entity rather than presenting them as confirmed.


### PR DESCRIPTION
## Summary

Adds `lifestyle/trust-check`: before committing money or personal info to a marketplace listing, a seller/business, a rental, or a job offer, the agent cross-checks it against the live web via Tavily and returns a scored verdict (Looks fine / Proceed with caution / Red flag) with sourced findings.

- Category-specific checklists (listing, seller/business, rental, job offer) — each targets the signals that actually catch scams in that category, not a generic name search.
- A shared cross-category red-flag signal library (off-platform payment pressure, reused photos, lookalike domains, price-too-good, urgency, etc.).
- Explicit "what wasn't verifiable" reporting — absence of evidence is never rounded up to a clean bill of health.
- An optional weekly watchlist-recheck task (ships **paused**) that revisits saved items for new developments.
- Tavily is the only external dependency; free tier is sufficient for personal use (documented in the template's own README along with host/auth/scope/where-to-get-key).

## Test plan

- [x] `node scripts/check-templates.mjs` passes
- [x] `node scripts/build-index.mjs` regenerated `index.json` cleanly
- [x] `node scripts/check-version-bump.mjs origin/main` clean (new template, no version-bump conflicts)
- [x] Stamped locally via `ncl groups create --template lifestyle/trust-check --name "Trust Check Test"` — stamped cleanly
- [x] Confirmed the weekly recheck task ships paused (`ncl tasks list --status paused`)
- [x] Deleted the test group and local template copy afterward
- [x] Diff scanned for credentials — none present; `mcp.json` carries only the literal `"placeholder"` for `TAVILY_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013d1JcuEGNMmZYW4bEQiPi5