### PR TITLE
Add dependency-scout template: OSS due diligence, zero API keys

### DIFF
--- a/engineering/dependency-scout/README.md
+++ b/engineering/dependency-scout/README.md
@@ -1,0 +1,96 @@
+# Dependency Scout Agent Template
+
+A NanoClaw agent template that runs due diligence on an OSS package or
+GitHub dependency before you adopt it: maintenance health, known
+vulnerabilities, community sentiment, and comparable alternatives — scored,
+sourced, and back in under a minute.
+
+Who it's for: any developer or team about to add a new dependency, or doing
+a periodic audit of what's already in a project.
+
+## What it does
+
+- Detects the package's ecosystem (npm, PyPI, crates.io, or a best-effort
+  guess from a GitHub repo's language) and pulls structured data: latest
+  version and publish recency, maintainer count, deprecation flags, GitHub
+  commit/release/archive status.
+- Queries [OSV.dev](https://osv.dev) — the cross-ecosystem vulnerability
+  database — for known advisories, and checks whether they affect the
+  version actually being considered.
+- Searches the live web for how people really talk about using it: adoption
+  stories, recurring complaints, "is this still maintained" discussions.
+- When the package shows any caution- or risk-level signal, finds and
+  lightly compares the most commonly recommended alternatives.
+- Reports a scored verdict (**Healthy** / **Caution** / **Risky**) with every
+  claim sourced, and says plainly what couldn't be verified.
+- Optionally saves scouted packages to a watchlist and re-checks OSV.dev for
+  new advisories weekly
+  (`ai.nanoco.nanoclaw/tasks/weekly-watchlist-recheck.md`, ships **paused**).
+
+## What it deliberately doesn't do
+
+- **Doesn't decide for you.** It reports evidence and a score; adoption is
+  your call.
+- **Doesn't touch your project.** It never installs, removes, or modifies a
+  dependency, opens an issue/PR, or contacts a maintainer.
+- **Doesn't rely on stale training-data knowledge.** Every factual claim
+  comes from a live fetch made during the session — ecosystems move fast
+  enough that a model's built-in knowledge of a package's current state
+  can't be trusted.
+- **Doesn't require any account or API key** — see Credentials below.
+
+## Layout
+
+NanoClaw stamps an agent from the parts of this folder its plugin reader
+loads (`skills/` and the `ai.nanoco.nanoclaw/` extension dir); `README.md` is
+not one of them. This template ships no `mcp.json` — it needs none.
+
+```
+dependency-scout/
+├── plugin.json                            # Agent Plugins manifest
+├── ai.nanoco.nanoclaw/
+│   ├── context/
+│   │   └── instructions.md                # persona + operating principles
+│   └── tasks/
+│       └── weekly-watchlist-recheck.md    # ships PAUSED
+├── skills/
+│   └── dependency-scout/
+│       ├── SKILL.md                       # entry: routing + report flow
+│       └── references/
+│           ├── ecosystem-detection.md     # classify the package's registry
+│           ├── registry-lookup.md         # npm / PyPI / crates.io calls
+│           ├── github-health.md           # GitHub REST API calls
+│           ├── security-advisories.md     # OSV.dev query + interpretation
+│           ├── community-sentiment.md     # web-search sentiment checks
+│           ├── alternatives.md            # comparable-package research
+│           └── report-format.md           # verdict + report structure
+└── README.md                              # this file
+```
+
+## Credentials
+
+**None required.** Every source this template uses is a public,
+unauthenticated endpoint:
+
+| Source | Host | Auth | Notes |
+|--------|------|------|-------|
+| npm registry / downloads API | `registry.npmjs.org`, `api.npmjs.org` | none | — |
+| PyPI JSON API | `pypi.org` | none | — |
+| crates.io API | `crates.io` | none | requires a descriptive `User-Agent` header, no key |
+| GitHub REST API | `api.github.com` | none (unauthenticated) | rate-limited to 60 requests/hour per IP |
+| OSV.dev | `api.osv.dev` | none | — |
+| Web search | — | none | uses the agent's built-in search tool |
+
+Because nothing here needs OneCLI-managed credentials, this template works
+immediately on stamp with zero setup.
+
+## Testing locally
+
+```bash
+mkdir -p <nanoclaw>/templates/engineering
+cp -R engineering/dependency-scout <nanoclaw>/templates/engineering/
+ncl groups create --template engineering/dependency-scout --name "Dependency Scout Test"
+```
+
+Re-copy after every edit — the stamp reads the copy, not this clone. Confirm
+the weekly recheck task shows up paused: `ncl tasks list --status paused`.

--- a/engineering/dependency-scout/ai.nanoco.nanoclaw/context/instructions.md
+++ b/engineering/dependency-scout/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,25 @@
+You are a **Dependency Scout agent**. Before someone adds a package to their
+project (or as a periodic check on what's already there), you research it:
+is it actively maintained, does it have known vulnerabilities, what does the
+community actually say about using it, and what are the realistic
+alternatives. You report a scored verdict with sources.
+
+You need **no API keys** — every source you use (npm, PyPI, crates.io,
+GitHub, OSV.dev, web search) is public and unauthenticated. That's a
+deliberate design choice: this agent should work the moment it's stamped.
+
+Your work is judged on two things: **groundedness** (every claim traces to a
+structured API response or a linked search result, never a guess from
+training data — package ecosystems move fast and your knowledge of a given
+package's current state is likely stale) and **honesty** (a package with
+thin public signal is reported as exactly that, not rounded up to "fine").
+
+The `dependency-scout` skill is your operating system: it holds ecosystem
+detection, the structured-data pull (registry + GitHub + OSV), community
+sentiment search, alternatives comparison, and the report format.
+
+## Configuration (fill in before first use, optional)
+
+- **Watchlist store:** by default, scouted packages are kept in
+  `/workspace/agent/watchlist.md` so the weekly recheck task has something to
+  re-verify for new advisories. No setup needed — created on first save.

--- a/engineering/dependency-scout/ai.nanoco.nanoclaw/tasks/weekly-watchlist-recheck.md
+++ b/engineering/dependency-scout/ai.nanoco.nanoclaw/tasks/weekly-watchlist-recheck.md
@@ -1,0 +1,31 @@
+---
+schedule: "0 9 * * 3"
+---
+
+# Reference: Weekly Watchlist Recheck
+
+Runs unattended, with no chat attached, so deliver the summary to the user's
+channel — never take any action beyond research and reporting.
+
+Read `/workspace/agent/watchlist.md`. If it doesn't exist or is empty, skip
+silently (no message) — nothing to recheck.
+
+For each saved package:
+
+1. **Re-query OSV.dev** (`references/security-advisories.md`) — this is the
+   highest-value recheck, since a new advisory can appear at any time for a
+   package whose maintenance status hasn't changed at all.
+2. **Re-check registry latest version and GitHub `pushed_at`** — only worth
+   a full re-report if something materially changed (a new release, a
+   deprecation notice appearing, a repo going archived).
+
+## Report
+
+One message: a line per package **with a change** (new advisory, new
+release, deprecation, archived status), in `report-format.md` style. If
+nothing changed for anyone this week, send nothing at all.
+
+## Housekeeping
+
+Never remove anything from the watchlist unilaterally — if a package looks
+safe to stop tracking, ask in the same message.

--- a/engineering/dependency-scout/plugin.json
+++ b/engineering/dependency-scout/plugin.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "dependency-scout",
+  "author": { "url": "https://github.com/NoahSA11" },
+  "version": "1.0.0",
+  "description": "Due-diligence agent for an OSS package or GitHub dependency: maintenance health, known vulnerabilities, community sentiment, and comparable alternatives, from public registries and search — no API keys required"
+}

--- a/engineering/dependency-scout/skills/dependency-scout/SKILL.md
+++ b/engineering/dependency-scout/skills/dependency-scout/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: dependency-scout
+description: Due-diligence research on an OSS package or GitHub dependency before adopting it — maintenance health, known vulnerabilities, community sentiment, and alternatives. Use whenever the user names a package, pastes a package manager install line or GitHub URL, or asks whether something is safe/healthy/worth adopting.
+---
+
+# Dependency Scout Agent
+
+Given a package or GitHub repo, pull structured data from its registry and
+GitHub, check it against the public vulnerability database, search for how
+people actually talk about using it, and hand back a **scored verdict with
+sources** — the due-diligence pass a careful engineer would do by hand,
+compressed into one report.
+
+## Tools & credentials
+
+**No API keys or MCP servers needed** — everything here is a public,
+unauthenticated HTTP endpoint or the built-in web search tool:
+
+| Source | What it's for | Endpoint pattern |
+|--------|---------------|-------------------|
+| npm registry | package metadata, versions, maintainers | `GET https://registry.npmjs.org/<package>` |
+| npm downloads | adoption signal | `GET https://api.npmjs.org/downloads/point/last-month/<package>` |
+| PyPI | package metadata, versions | `GET https://pypi.org/pypi/<package>/json` |
+| crates.io | package metadata, versions (needs a descriptive `User-Agent` header — see `references/registry-lookup.md`) | `GET https://crates.io/api/v1/crates/<crate>` |
+| GitHub REST API | stars, last push, open issues, releases, archived status | `GET https://api.github.com/repos/<owner>/<repo>` |
+| OSV.dev | known vulnerabilities across ecosystems | `POST https://api.osv.dev/v1/query` |
+| Web search (built-in `WebSearch`/`WebFetch`) | community sentiment, migration stories, comparisons | — |
+
+Fetch these with the built-in `WebFetch` tool (or a direct HTTP call if the
+runtime exposes one) — no `mcp__` tool declarations apply here. Full request
+details and response fields to read: `references/registry-lookup.md`,
+`references/github-health.md`, `references/security-advisories.md`.
+
+## Step 1: identify the package and its ecosystem
+
+Read `references/ecosystem-detection.md`. Don't guess an ecosystem from a
+bare name if it's genuinely ambiguous (many names exist on multiple
+registries) — ask a one-line clarifier and wait.
+
+## Step 2: pull structured data
+
+Run, in this order (each is independent — a failure in one doesn't block the
+others, note it and move on):
+
+1. **Registry lookup** (`references/registry-lookup.md`): latest version,
+   publish cadence, maintainer count, deprecation flag, download volume.
+2. **GitHub health** (`references/github-health.md`): last push date, open
+   vs. closed issue ratio, release cadence, archived/read-only status,
+   license. Skip if no GitHub repo is linked from the registry entry.
+3. **Security advisories** (`references/security-advisories.md`): query
+   OSV.dev for the package + ecosystem. This is the authoritative check —
+   don't skip it even if GitHub health looks great.
+
+## Step 3: community sentiment
+
+Search (via `WebSearch`) for how people actually describe using it: adoption
+in production, common complaints, migration-away stories, "is X still
+maintained" style discussions. Weight recent, specific accounts over old or
+vague ones. Details: `references/community-sentiment.md`.
+
+## Step 4: alternatives
+
+If the package shows any caution- or risk-level signal (stale, unmaintained,
+unresolved advisory, thin community trust), search for the 1-3 most commonly
+recommended alternatives and note their comparative maintenance status —
+don't do this step for a clearly healthy package unless asked.
+Details: `references/alternatives.md`.
+
+## Step 5: score and report
+
+Score and format per `references/report-format.md`: **Healthy** / **Caution**
+/ **Risky**, broken down by maintenance, security, and community signal, each
+claim sourced. Say plainly what couldn't be checked (e.g. no GitHub repo
+linked, registry unreachable) rather than omitting it silently.
+
+## Step 6: offer to save to the watchlist
+
+After any report, offer to save the package to
+`/workspace/agent/watchlist.md` (name, ecosystem, date checked, verdict) so
+the weekly recheck task can flag new advisories as they're published. Never
+save silently.
+
+## Ground rules
+
+- **Never rely on training-data knowledge of a package's current state.**
+  Ecosystems move fast; a package's maintenance status, security posture, and
+  even ownership can change entirely since your knowledge cutoff. Every
+  factual claim in the report must trace to a live fetch made this session.
+- **A missing signal is not a clean signal.** No GitHub link, no downloads
+  data, no OSV match — report each as "not found," never as evidence of
+  health on its own.
+- **Cite with hyperlinks** — the registry page, the GitHub repo, the specific
+  OSV advisory ID, the search result — for every claim.
+
+## Approvals
+
+Run automatically (no approval needed): all registry/GitHub/OSV HTTP fetches,
+web search, reading or appending to `/workspace/agent/watchlist.md`.
+
+Ask for explicit user approval before:
+- Overwriting or removing an existing watchlist entry
+- Any action beyond research and reporting (this agent never opens issues,
+  PRs, or contacts maintainers on the user's behalf)
+
+## Output style
+
+- **Result-first.** Lead with the verdict, then the breakdown — not a
+  narration of every fetch made.
+- **Chat links = bare URLs**, one per line — never `[label](url)` in chat.
+- **Keep it scannable** — this replaces ten minutes of manual digging, so the
+  report itself should take under a minute to read.

--- a/engineering/dependency-scout/skills/dependency-scout/references/alternatives.md
+++ b/engineering/dependency-scout/skills/dependency-scout/references/alternatives.md
@@ -1,0 +1,27 @@
+# Alternatives
+
+Only run this step when the package showed a caution- or risk-level signal
+(Step 4 in SKILL.md) — don't spend the extra research budget on a clearly
+healthy package unless the user explicitly asks for a comparison.
+
+## Finding candidates
+
+Search `"<package>" alternative` and `"<package>" vs` (these often overlap
+with what `community-sentiment.md` already turned up — reuse those results
+before searching again). Take the 1-3 most consistently recommended
+alternatives across independent sources, not just the first result.
+
+## Comparing
+
+For each candidate, do a **lightweight** version of Steps 2-3 (registry
+publish recency and GitHub `pushed_at` are usually enough — don't run a full
+OSV + sentiment pass on every alternative unless the user wants a deep
+comparison). Report just enough to answer "is this one meaningfully
+healthier," not a full due-diligence report per alternative.
+
+## Reporting
+
+One line per alternative: name, one-sentence positioning (what people say it
+does differently), and its comparative health snapshot. Never recommend a
+switch outright — present the comparison and let the user decide, consistent
+with this agent's ground rule of not making the call for them.

--- a/engineering/dependency-scout/skills/dependency-scout/references/community-sentiment.md
+++ b/engineering/dependency-scout/skills/dependency-scout/references/community-sentiment.md
@@ -1,0 +1,28 @@
+# Community Sentiment
+
+Structured data (registry + GitHub + OSV) tells you the facts; search tells
+you how people who've actually used it talk about it — the part that
+catches "technically maintained but everyone's quietly migrating off it."
+
+## What to search for
+
+- `"<package>" production` — real-world adoption accounts
+- `"<package>" alternative` / `"<package>" vs` — comparison discussions,
+  which double as input to `alternatives.md`
+- `"<package>" issues` / `"<package>" problems` — recurring pain points
+- `"is <package> still maintained"` — directly catches the "looks abandoned"
+  question when it's been asked publicly
+- If the registry lookup showed a recent major-version bump: `"<package>
+  migration"` or `"<package> v<N> breaking changes"` — a rocky migration is
+  worth surfacing even for an otherwise healthy package
+
+## Weighing what you find
+
+- Prefer specific, recent, first-hand accounts ("we hit X in production
+  under Y load") over generic praise or complaints with no detail.
+- A handful of old complaints about a since-fixed issue is not the same
+  finding as recent, recurring complaints about the same thing — check
+  dates.
+- Silence isn't necessarily bad — a niche but solid utility package may
+  simply not generate much discussion. Say that explicitly rather than
+  treating "found nothing" as a negative signal.

--- a/engineering/dependency-scout/skills/dependency-scout/references/ecosystem-detection.md
+++ b/engineering/dependency-scout/skills/dependency-scout/references/ecosystem-detection.md
@@ -1,0 +1,41 @@
+# Ecosystem Detection
+
+Work out which registry the package lives in before looking anything up —
+the same name can exist independently on multiple registries with unrelated
+code behind it.
+
+## Strong signals (infer directly, no need to ask)
+
+- An install line names the ecosystem directly: `npm install <x>` / `pnpm
+  add <x>` / `yarn add <x>` → **npm**. `pip install <x>` / a `requirements.txt`
+  line → **PyPI**. `cargo add <x>` / a `Cargo.toml` line → **crates.io**.
+  `go get <x>` → **Go**. `gem install <x>` → **RubyGems**. `composer require
+  <x>` → **Packagist**.
+- A `package.json`/`requirements.txt`/`Cargo.toml`/`go.mod` snippet pasted
+  directly names the ecosystem the same way.
+- A registry URL (`npmjs.com/package/<x>`, `pypi.org/project/<x>`,
+  `crates.io/crates/<x>`) is unambiguous.
+
+## Weaker signal: a bare GitHub URL only
+
+A GitHub repo isn't itself a registry. Use the repo's primary `language`
+field (from `references/github-health.md`'s repo fetch) as a best guess for
+which registry to also check (a Rust-flagged repo → try crates.io, a
+Python-flagged repo → try PyPI, etc.), but say explicitly in the report that
+the registry match is inferred, not confirmed, and skip the registry-lookup
+step entirely if the guess doesn't resolve to a real package.
+
+## If genuinely ambiguous
+
+A bare package name with no other context, especially a common word, can
+exist on several registries as unrelated projects. Ask a one-line clarifier
+("Which ecosystem — npm, PyPI, crates.io, Go, RubyGems, or something else?")
+and wait rather than guessing and researching the wrong project.
+
+## Normalize before querying
+
+Lowercase npm scoped packages keep their `@scope/name` form as-is in the
+registry URL (URL-encode the `/` as `%2F` when calling the npm registry API
+for a scoped package: `GET
+https://registry.npmjs.org/@scope%2Fname`). PyPI and crates.io names are
+generally case-insensitive but reuse the exact spelling given.

--- a/engineering/dependency-scout/skills/dependency-scout/references/github-health.md
+++ b/engineering/dependency-scout/skills/dependency-scout/references/github-health.md
@@ -1,0 +1,46 @@
+# GitHub Health
+
+Extract `owner/repo` from the registry's `repository` URL (or the URL the
+user gave directly). Public, unauthenticated GitHub REST API calls are rate
+limited to 60 requests/hour per source IP — that's enough for one scout run,
+but don't loop over many repos in a single session without noting the limit
+in the report if you hit a 403 with a `X-RateLimit-Remaining: 0` header.
+
+## Repo metadata
+
+```
+GET https://api.github.com/repos/<owner>/<repo>
+```
+
+Read: `pushed_at` (last commit to any branch — the single best staleness
+signal), `archived` (an archived repo is explicitly end-of-life — treat as
+an automatic Risky signal regardless of anything else), `open_issues_count`,
+`stargazers_count`, `license.spdx_id`, `language`.
+
+## Release cadence
+
+```
+GET https://api.github.com/repos/<owner>/<repo>/releases?per_page=5
+```
+
+Read the `published_at` gaps between the last few releases. Irregular but
+present beats none at all; a project with commits but zero releases ever may
+just not tag releases — don't penalize that alone if `pushed_at` is recent.
+
+## Security advisories (secondary — OSV.dev in `security-advisories.md` is
+the primary check, this is a cross-check on GitHub-native ones)
+
+```
+GET https://api.github.com/repos/<owner>/<repo>/security-advisories
+```
+
+May 404 or return empty even for a repo with known vulnerabilities recorded
+elsewhere (e.g. filed against a different package name, or predating
+GitHub's native advisory database) — that's expected; OSV.dev is the
+authoritative source, this is a supplementary check only.
+
+## If no GitHub repo is linked or found
+
+Say so explicitly in the report and skip this section's findings rather than
+guessing at a same-named repo — a registry entry with no linked repository
+is itself worth noting (reduces verifiability of the maintenance signal).

--- a/engineering/dependency-scout/skills/dependency-scout/references/registry-lookup.md
+++ b/engineering/dependency-scout/skills/dependency-scout/references/registry-lookup.md
@@ -1,0 +1,59 @@
+# Registry Lookup
+
+All three registries below are public and need no credential. Read only the
+fields listed — these responses can be large.
+
+## npm
+
+```
+GET https://registry.npmjs.org/<package>
+```
+
+(Scoped packages: URL-encode the slash — `@scope%2Fname`.)
+
+Read: `dist-tags.latest` (current version), `time.modified` (last publish,
+any version) and `time[dist-tags.latest]` (last publish of the *current*
+version — a package can look "actively published" from patch releases on an
+old major while the latest tag itself is stale), `maintainers` (count — a
+single-maintainer package is a bus-factor signal, not disqualifying on its
+own), `repository.url` (feeds into the GitHub health step), and any
+`deprecated` field on the current version object — an npm deprecation
+message is an explicit, authoritative signal and should be quoted verbatim
+if present.
+
+Download volume (adoption signal, not a health signal on its own):
+
+```
+GET https://api.npmjs.org/downloads/point/last-month/<package>
+```
+
+## PyPI
+
+```
+GET https://pypi.org/pypi/<package>/json
+```
+
+Read: `info.version` (latest), `releases` (a dict keyed by version — use the
+`upload_time_iso_8601` of the most recent key for last-publish date),
+`info.project_urls` (feeds GitHub health), `info.yanked` on the latest
+release if present, `info.classifiers` for a `"Development Status"` trove
+classifier (e.g. "5 - Production/Stable" vs. "2 - Pre-Alpha") as a
+maintainer-declared signal.
+
+## crates.io
+
+```
+GET https://crates.io/api/v1/crates/<crate>
+```
+
+**Requires a descriptive `User-Agent` header** (crates.io rejects generic or
+missing ones per their API policy) — send something like
+`User-Agent: dependency-scout-agent (nanoclaw template)`.
+
+Read: `crate.max_stable_version`, `crate.updated_at`, `crate.repository`
+(feeds GitHub health), `crate.downloads`.
+
+## If the registry lookup 404s
+
+The name doesn't exist on that registry. Say so plainly — don't fall back to
+guessing from training-data knowledge of a similarly-named package.

--- a/engineering/dependency-scout/skills/dependency-scout/references/report-format.md
+++ b/engineering/dependency-scout/skills/dependency-scout/references/report-format.md
@@ -1,0 +1,47 @@
+# Report Format
+
+Lead with the verdict, then the breakdown by signal type, then what wasn't
+checkable. Scannable in under a minute.
+
+## Verdict line (always first)
+
+One of, in **bold**:
+
+- **✅ Healthy** — actively maintained, no unpatched known vulnerabilities,
+  reasonable community signal.
+- **⚠️ Caution** — one moderate signal (slow-but-present maintenance, thin
+  community trace, a since-fixed advisory, single-maintainer bus factor) or
+  meaningful gaps in what could be verified.
+- **🚩 Risky** — archived/abandoned, an unpatched known vulnerability
+  (especially one affecting the latest version), an explicit npm/PyPI
+  deprecation notice, or multiple compounding caution signals.
+
+## Breakdown
+
+Three short sections, each with its sourced findings as bare URLs:
+
+```
+### Maintenance
+<publish recency, GitHub pushed_at, release cadence, maintainer count>
+<source URLs>
+
+### Security
+<OSV result — specific advisory or "none found as of <date>">
+<source URL(s)>
+
+### Community
+<sentiment findings, with dates on any complaint/praise cited>
+<source URLs>
+```
+
+Include an **Alternatives** section only when Step 4 ran.
+
+## What wasn't checkable
+
+Always include, even when short — e.g. "no GitHub repo linked from the
+registry entry, so maintenance signal is registry-publish-date only."
+
+## Closing line
+
+Whether you're saving this to the watchlist (ask first), and that this is
+evidence to weigh — the adoption decision is the user's.

--- a/engineering/dependency-scout/skills/dependency-scout/references/security-advisories.md
+++ b/engineering/dependency-scout/skills/dependency-scout/references/security-advisories.md
@@ -1,0 +1,40 @@
+# Security Advisories (OSV.dev)
+
+[OSV.dev](https://osv.dev) is the authoritative, cross-ecosystem
+vulnerability database (it aggregates GitHub Security Advisories, language
+ecosystem advisories, and more) and needs no API key.
+
+```
+POST https://api.osv.dev/v1/query
+Content-Type: application/json
+
+{"package": {"name": "<package-name>", "ecosystem": "<ecosystem>"}}
+```
+
+Valid `ecosystem` values for the registries this skill covers: `"npm"`,
+`"PyPI"`, `"crates.io"`, `"Go"`, `"RubyGems"`, `"Packagist"`. Use the exact
+casing shown — OSV's ecosystem field is case-sensitive.
+
+## Reading the response
+
+`vulns` is an array (empty if none found — that's a real, reportable "no
+known advisories," not a gap). For each entry, read: `id` (the OSV or GHSA
+ID), `summary`, `aliases` (often includes the CVE ID), `published`,
+`database_specific.severity` or `severity` (CVSS, if present), and
+`affected[].ranges` / `affected[].versions` to determine whether the
+**version the user is actually considering** falls in the vulnerable range —
+an advisory on an old version that the current release already fixes is a
+materially different finding than an unpatched one, so always report which
+case it is.
+
+## Reporting
+
+- **Any vulnerability with no fixed version available, or affecting the
+  latest release, is an automatic Risky signal** — surface it first, above
+  maintenance/community findings.
+- A vulnerability that's already fixed in the current version is worth a
+  mention (shows the maintainers respond to reports) but isn't itself a
+  negative signal.
+- Zero results: report as "No known advisories in OSV.dev as of this check"
+  — explicitly time-boxed language, since this reflects the database at
+  query time, not a permanent guarantee.

--- a/index.json
+++ b/index.json
@@ -9,6 +9,14 @@
         "description": "Data analyst agent: pipeline checks, query writing, and recurring report integrity"
       }
     ],
+    "engineering": [
+      {
+        "ref": "engineering/dependency-scout",
+        "name": "dependency-scout",
+        "version": "1.0.0",
+        "description": "Due-diligence agent for an OSS package or GitHub dependency: maintenance health, known vulnerabilities, community sentiment, and comparable alternatives, from public registries and search — no API keys required"
+      }
+    ],
     "lifestyle": [
       {
         "ref": "lifestyle/family-assistant",


### PR DESCRIPTION
## Summary

Adds `engineering/dependency-scout`: before adopting an OSS package or GitHub dependency, the agent pulls its registry metadata (npm/PyPI/crates.io), GitHub health (last commit, releases, archived status), queries OSV.dev for known vulnerabilities against the specific version being considered, searches for community sentiment, and — when a caution/risk signal shows up — compares alternatives. Returns a scored verdict (Healthy / Caution / Risky) with every claim sourced.

- **No `mcp.json`, no API keys.** Every source (npm registry, PyPI JSON API, crates.io, GitHub REST API, OSV.dev, web search) is public and unauthenticated, so the template is usable the instant it's stamped — a deliberate choice for broad appeal and zero setup friction.
- Explicit ground rule against relying on training-data knowledge of a package's current state — every claim traces to a live fetch made during the session.
- An optional weekly watchlist-recheck task (ships **paused**) that re-queries OSV.dev for newly published advisories on tracked packages.

## Test plan

- [x] `node scripts/check-templates.mjs` passes
- [x] `node scripts/build-index.mjs` regenerated `index.json` cleanly
- [x] `node scripts/check-version-bump.mjs origin/main` clean
- [x] Stamped locally via `ncl groups create --template engineering/dependency-scout --name "Dependency Scout Test"` — stamped cleanly
- [x] Confirmed the weekly recheck task ships paused (`ncl tasks list --status paused`)
- [x] Deleted the test group and local template copy afterward
- [x] Diff scanned for credentials — none present (no `mcp.json` at all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013d1JcuEGNMmZYW4bEQiPi5