### PR TITLE
Add finops-cost-sentinel template (data/)

### DIFF
--- a/data/finops-cost-sentinel/README.md
+++ b/data/finops-cost-sentinel/README.md
@@ -1,0 +1,145 @@
+# Cost Sentinel
+
+A NanoClaw agent template that watches your AWS bill for anomalies, tag
+gaps, and rightsizing waste; researches unfamiliar charges; and calls a
+human when something is genuinely critical.
+
+Built for the [NanoClaw Agent Templates Hackathon](https://nanoclaw.dev/hackathon)
+(Sep 4-6, 2026).
+
+## What it does
+
+- **Weekly digest** (Monday 08:00, agent-local time): anomaly scan, spend
+  breakdown by service, tag hygiene report, rightsizing opportunities,
+  month-end forecast.
+- **Hourly critical-spike check**: silent unless a spend spike crosses a
+  high, explicit bar - then places one voice call to an on-call number.
+- **Never guesses**: unfamiliar service/SKU names are looked up via
+  Tavily before being reported.
+- **Read-only**: this agent never modifies, stops, resizes, or deletes
+  any AWS resource. It analyzes and recommends only.
+
+## Required services and credentials
+
+### AWS (required) - via a small proxy you deploy yourself
+
+**This is not a stdio MCP server with env-var credentials, and that's
+deliberate.** NanoClaw's credential vault injects secrets by rewriting
+the `Authorization` header of outbound HTTPS requests, matched by
+hostname - a model built for single bearer tokens. AWS SigV4 signs a
+request with the real access key + secret key *before* it leaves the
+process; a header-rewriting proxy can't repair a signature that was
+computed against a placeholder value. NanoClaw's mount-security policy
+also blocks mounting `~/.aws` into a container by default, closing the
+other obvious route.
+
+So `aws-cost-explorer` in `mcp.json` is a `streamable-http` server
+pointed at a small Cloudflare Worker (in `proxy/`) that you deploy with
+your own AWS credentials. The Worker holds your real keys, signs
+requests to AWS Cost Explorer itself, and exposes a plain
+bearer-token-gated MCP endpoint - exactly the shape the vault is built
+for. Your AWS credentials never enter the NanoClaw container.
+
+Setup: see `proxy/README.md`. In short - deploy the Worker
+(`cd proxy && pnpm install && pnpm wrangler login && pnpm wrangler secret
+put ...` for each secret, then `pnpm run deploy`), then update this
+template's `mcp.json` with your Worker's URL and grant its bearer token
+through the vault:
+
+```bash
+onecli secrets create \
+  --name aws-cost-explorer-proxy \
+  --type api_key \
+  --value "<your PROXY_AUTH_TOKEN>" \
+  --host-pattern <your-worker>.workers.dev \
+  --header-name Authorization \
+  --value-format 'Bearer {value}'
+```
+
+The `--value-format` matters: `mcp.json` ships the bare literal
+`"placeholder"` (required for the stamp-time secret lint to pass), and
+this is what tells the vault to actually send `Bearer <token>` on the
+wire.
+
+Minimum IAM policy for the credentials you give the Worker (read-only,
+Cost Explorer):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "ce:GetCostAndUsage",
+      "ce:GetCostForecast",
+      "ce:GetAnomalies",
+      "ce:GetRightsizingRecommendation"
+    ],
+    "Resource": "*"
+  }]
+}
+```
+
+AWS Cost Explorer is a metered API - see
+[AWS Cost Explorer pricing](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/pricing/)
+for current rates. This template's call volume (one digest per week, one
+lightweight check per hour) is low. The Worker itself runs on
+[Cloudflare Workers' free plan](https://developers.cloudflare.com/workers/platform/pricing/)
+at this volume.
+
+### Tavily (required for unknown-service-lookup)
+
+Sign up at [tavily.com](https://tavily.com) for an API key. Tavily has a
+free tier sufficient for this template's usage pattern (a handful of
+lookups per digest, only when a service name isn't already known).
+
+### Dial (required for critical-spike-alert) - paid service
+
+This skill requires a [Dial](https://getdial.ai) account with a
+registered, OTP-verified phone number **to call from**
+(`DIAL_FROM_NUMBER`) - Dial's API rejects calls with no `fromNumber` set,
+there's no account-level default. This is separate from
+`DIAL_ALERT_PHONE_NUMBER`, the destination the alert calls **to**.
+**Paid service - bring your own account:**
+
+- See [Dial's pricing](https://getdial.ai/pricing) for current plans;
+  this skill needs at least one phone number provisioned on either the
+  flat-rate or metered/pay-as-you-go plan
+- No sandbox/test mode exists - testing this skill uses your real
+  account balance
+
+If you don't want the phone-call escalation, you can stamp this template
+and simply leave `critical-spike-check` paused - the rest of the agent
+(digest, tag hygiene, forecast) works fully without it.
+
+`mcp.json`'s `dial-alert` server is a small custom script
+(`scripts/dial-call.mjs`), not Dial's own packaged MCP server - see the
+comment at the top of that file for why.
+
+## Tuning
+
+Edit `ai.nanoco.nanoclaw/context/additional_context/thresholds.md` after
+stamping to adjust: anomaly thresholds, which cost allocation tags are
+checked, and the monthly budget used by `forecast-watch` (unset by
+default on purpose - it will not compare against $0).
+
+## Local testing
+
+```bash
+mkdir -p <nanoclaw>/templates/data
+cp -R . <nanoclaw>/templates/data/finops-cost-sentinel
+ncl groups create --template data/finops-cost-sentinel --name "Test Sentinel"
+ncl tasks list --status paused
+ncl tasks run <task-id>
+ncl groups delete --id <agent-group-id>
+```
+
+Check the `templateReport` in the creation response for any skipped
+components before relying on a run.
+
+## Scope and safety
+
+This agent is advisory-only. It reads AWS Cost Explorer data, performs
+web lookups, and - only for critical findings - places one outbound
+voice call. It does not have write access to any cloud resource and
+cannot take remediation actions.

--- a/data/finops-cost-sentinel/ai.nanoco.nanoclaw/context/additional_context/thresholds.md
+++ b/data/finops-cost-sentinel/ai.nanoco.nanoclaw/context/additional_context/thresholds.md
@@ -1,0 +1,23 @@
+# Tunable thresholds
+
+Edit these per-account after stamping. Values below are the shipped
+defaults.
+
+## Anomaly detection (`anomaly-detective`)
+
+- Notable deviation: 20% vs. 7-day trailing baseline
+- Critical deviation: 75% vs. baseline AND >= $50/day absolute delta
+- Baseline window: 7 days trailing
+- Lookback window for the full digest: 30 days
+
+## Tag hygiene (`tag-hygiene`)
+
+- Tag keys checked: `Team`, `Environment`, `Project`
+- Add or remove keys here to match this account's actual cost allocation
+  tags in Billing.
+
+## Forecast watch (`forecast-watch`)
+
+- Monthly budget: **set this before first use** - forecast-watch cannot
+  flag budget risk without it. No default is shipped on purpose; an
+  unset budget should never silently compare against $0.

--- a/data/finops-cost-sentinel/ai.nanoco.nanoclaw/context/instructions.md
+++ b/data/finops-cost-sentinel/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,44 @@
+# Cost Sentinel
+
+You are Cost Sentinel, a FinOps analyst for this AWS account. Your job is
+to watch spend, explain what changed, and flag genuine risk - not to
+generate noise.
+
+## Scope
+
+- Read-only, advisory-only. You analyze cost data and recommend action.
+  You never modify, stop, resize, or delete any live AWS resource.
+- Your domain is AWS Cost Explorer data, plus web lookups (Tavily) for
+  identifying unfamiliar services, plus one narrow escalation channel
+  (a Dial voice call) for genuine critical spikes.
+
+## Thresholds (tune per account in `additional_context/thresholds.md`)
+
+- **Notable** spend deviation: >= 20% vs. the 7-day baseline. Goes in the
+  weekly digest.
+- **Critical** spend deviation: >= 75% deviation AND >= $50/day absolute
+  delta. Triggers a phone call via `critical-spike-alert`. This bar is
+  intentionally high - most weeks should have zero critical findings.
+
+## How to work
+
+1. When running the weekly digest, work through skills in this order:
+   `anomaly-detective` first (most urgent), then `service-breakdown`,
+   `tag-hygiene`, and `rightsizing-advisor` (waste and attribution),
+   then `forecast-watch` last (forward-looking).
+2. Never report a service or SKU name you don't recognize without first
+   using `unknown-service-lookup` - never guess.
+3. Only use `critical-spike-alert` for findings `anomaly-detective` has
+   explicitly classified critical. If you're unsure, it isn't critical -
+   use the digest instead. A phone call is a last resort, not a
+   convenience.
+4. Every finding must cite a $ amount and a % where applicable - no vague
+   statements like "costs increased."
+5. When a skill's data source isn't available (rightsizing opt-in, tag
+   activation, AWS anomaly monitors), report that plainly as "not yet
+   available" rather than treating it as a zero or an error.
+
+## Tone
+
+Numbers-first, no fluff. Write for someone who has 30 seconds to read
+this, not someone who wants a narrative.

--- a/data/finops-cost-sentinel/ai.nanoco.nanoclaw/tasks/critical-spike-check.md
+++ b/data/finops-cost-sentinel/ai.nanoco.nanoclaw/tasks/critical-spike-check.md
@@ -1,0 +1,29 @@
+---
+schedule: "0 * * * *"
+script: |
+  # Gate for the hourly frequency limit: NanoClaw caps ungated tasks at
+  # 4 fires/24h to stop wasteful full-agent invocations, and this task
+  # fires 24x/day. /critical-check on the AWS bridge proxy answers
+  # {"wakeAgent": bool} cheaply (raw cost data, no LLM) so the agent is
+  # only ever woken for the rare genuinely-critical case.
+  #
+  # ASSUMPTION NOT YET VERIFIED LIVE: this relies on NanoClaw's egress
+  # vault rewriting the Authorization header on this plain curl the same
+  # way it does for the agent's own MCP calls (both are just outbound
+  # HTTPS from the container, hostname-matched) - confirm this against a
+  # real run before trusting it, and replace the URL below with your
+  # deployed proxy's real address.
+  RESULT=$(curl -s -H "Authorization: Bearer placeholder" \
+    https://finops.realcy.app/critical-check)
+  if echo "$RESULT" | grep -q '"wakeAgent":true'; then
+    echo '{"wakeAgent": true}'
+  else
+    echo '{"wakeAgent": false}'
+  fi
+---
+
+Run anomaly-detective's critical-threshold check only, over the last 3
+days vs. the 7-day baseline. Do not run the other skills and do not
+produce a digest. If a finding is classified critical, hand off to
+critical-spike-alert to place the call. If nothing is critical, do
+nothing - no output, no digest, no call.

--- a/data/finops-cost-sentinel/ai.nanoco.nanoclaw/tasks/weekly-cost-digest.md
+++ b/data/finops-cost-sentinel/ai.nanoco.nanoclaw/tasks/weekly-cost-digest.md
@@ -1,0 +1,11 @@
+---
+schedule: "0 8 * * MON"
+---
+
+Run anomaly-detective, service-breakdown, tag-hygiene, rightsizing-advisor,
+and forecast-watch in that order over the trailing 30 days. Produce one
+digest: anomalies first, then the top tag-hygiene gaps, then the top
+rightsizing opportunities by savings, then the month-end forecast with
+variance vs. last month. Keep it under 300 words. Do not place any phone
+calls from this task - critical findings are handled by the separate
+critical-spike-check task.

--- a/data/finops-cost-sentinel/mcp.json
+++ b/data/finops-cost-sentinel/mcp.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "aws-cost-explorer": {
+      "type": "streamable-http",
+      "url": "https://finops.realcy.app",
+      "headers": {
+        "Authorization": "placeholder"
+      }
+    },
+    "tavily": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./scripts/tavily-search.mjs"],
+      "env": {
+        "TAVILY_API_KEY": "placeholder"
+      }
+    },
+    "dial-alert": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./scripts/dial-call.mjs"],
+      "env": {
+        "DIAL_API_KEY": "placeholder",
+        "DIAL_ALERT_PHONE_NUMBER": "placeholder",
+        "DIAL_FROM_NUMBER": "placeholder"
+      }
+    }
+  }
+}

--- a/data/finops-cost-sentinel/plugin.json
+++ b/data/finops-cost-sentinel/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "finops-cost-sentinel",
+  "version": "1.0.0",
+  "description": "Watches your AWS bill for anomalies, tag gaps, and rightsizing waste - researches unfamiliar charges and calls you for genuine P1s.",
+  "homepage": "https://github.com/adamorad/finops-cost-sentinel",
+  "repository": "https://github.com/adamorad/finops-cost-sentinel",
+  "license": "MIT",
+  "author": {
+    "name": "Adam Morad",
+    "email": "adammor17@gmail.com",
+    "url": "https://github.com/adamorad"
+  },
+  "keywords": ["finops", "aws", "cost", "cloud-spend", "tavily", "dial"],
+  "extensions": {
+    "ai.nanoco.nanoclaw": {
+      "agentName": "Cost Sentinel"
+    }
+  }
+}

--- a/data/finops-cost-sentinel/proxy/.gitignore
+++ b/data/finops-cost-sentinel/proxy/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.wrangler/
+.dev.vars
+.dev.vars.*

--- a/data/finops-cost-sentinel/proxy/README.md
+++ b/data/finops-cost-sentinel/proxy/README.md
@@ -1,0 +1,91 @@
+# Cost Sentinel AWS bridge
+
+A small Cloudflare Worker that holds your real AWS credentials and speaks
+plain bearer-token-authenticated MCP to the `finops-cost-sentinel`
+template. See the comment at the top of `src/worker.js` for why this
+exists instead of talking to AWS Cost Explorer directly from inside
+NanoClaw's container.
+
+## Deploy your own instance
+
+You need your own deployment - this is not a shared service, and the
+AWS credentials you set are yours alone.
+
+```bash
+cd proxy
+pnpm install
+pnpm wrangler login          # opens a browser, authorizes Wrangler against your Cloudflare account
+pnpm wrangler secret put AWS_ACCESS_KEY_ID
+pnpm wrangler secret put AWS_SECRET_ACCESS_KEY
+pnpm wrangler secret put PROXY_AUTH_TOKEN   # generate with: openssl rand -hex 32
+pnpm run deploy
+```
+
+`wrangler deploy` prints your Worker's URL
+(`https://finops-cost-sentinel-proxy.<your-subdomain>.workers.dev`).
+
+## IAM policy for the credentials you set
+
+Same minimum policy as documented in the template's top-level README:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "ce:GetCostAndUsage",
+      "ce:GetCostForecast",
+      "ce:GetAnomalies",
+      "ce:GetRightsizingRecommendation"
+    ],
+    "Resource": "*"
+  }]
+}
+```
+
+## Wire it into the template
+
+In the template's `mcp.json`, set the `aws-cost-explorer` server's `url`
+to your deployed Worker's URL. Leave its `Authorization` header value as
+the bare literal `"placeholder"` - that's required for the stamp-time
+secret lint to pass, not a mistake. Grant the real token through the
+vault instead:
+
+```bash
+onecli secrets create \
+  --name aws-cost-explorer-proxy \
+  --type api_key \
+  --value "<your PROXY_AUTH_TOKEN>" \
+  --host-pattern <your-worker-subdomain>.workers.dev \
+  --header-name Authorization \
+  --value-format 'Bearer {value}'
+```
+
+`--value-format` is what actually puts `Bearer ` on the wire - the vault
+sends `Bearer <token>`, matching this Worker's auth check
+(`Authorization: Bearer ${PROXY_AUTH_TOKEN}`) in `src/worker.js`.
+
+Also update `ai.nanoco.nanoclaw/tasks/critical-spike-check.md`'s
+`script:` field with your real Worker URL (the placeholder domain is
+hardcoded there too, separately from `mcp.json` - see the comment in
+that file).
+
+## Local testing before deploying
+
+```bash
+pnpm run dev
+```
+
+This runs the Worker locally via Wrangler's dev server. You can exercise
+the `initialize` / `tools/list` / `tools/call` JSON-RPC methods with
+`curl` against `http://localhost:8787` before pointing a real agent at
+it - useful for checking the protocol envelope independently of whether
+your AWS credentials are set yet.
+
+## Status
+
+Written directly from the MCP Streamable HTTP transport spec and the AWS
+Cost Explorer JSON API reference - not yet run against a live NanoClaw
+agent or a live AWS account. Verify both before relying on this for a
+demo recording.

--- a/data/finops-cost-sentinel/proxy/package.json
+++ b/data/finops-cost-sentinel/proxy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "finops-cost-sentinel-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "description": "AWS credential bridge for the finops-cost-sentinel NanoClaw template - see src/worker.js for why this exists.",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "dependencies": {
+    "aws4fetch": "^1.0.20"
+  },
+  "devDependencies": {
+    "wrangler": "^4.0.0"
+  }
+}

--- a/data/finops-cost-sentinel/proxy/src/worker.js
+++ b/data/finops-cost-sentinel/proxy/src/worker.js
@@ -1,0 +1,393 @@
+// Cost Sentinel AWS bridge - a minimal MCP Streamable HTTP server.
+//
+// WHY THIS EXISTS: NanoClaw's credential vault works by rewriting the
+// Authorization header of outbound HTTPS requests, matched by hostname
+// (see nanocoai/nanoclaw src/gateway-providers/onecli.ts). That model
+// only supports single-value bearer tokens / API keys. AWS SigV4 signs
+// a canonical request with the real secret key before it leaves the
+// process - a header-rewriting proxy cannot repair a signature that was
+// computed against a placeholder. NanoClaw's mount-security policy also
+// blocks mounting ~/.aws into a container by default, closing the other
+// obvious workaround.
+//
+// So this Worker holds the real AWS credentials OUTSIDE the NanoClaw
+// container entirely (as Cloudflare Worker secrets), does the SigV4
+// signing itself via aws4fetch, and exposes a plain bearer-token-gated
+// MCP server to the template. The container's mcp.json only ever needs
+// one static token to reach THIS Worker - exactly the shape the vault
+// is built for.
+//
+// STATUS: written directly from the public MCP Streamable HTTP transport
+// spec and the AWS Cost Explorer JSON API reference, not the official
+// @modelcontextprotocol/sdk server classes (their StreamableHTTPServerTransport
+// assumes a Node http.IncomingMessage/ServerResponse pair, which a Workers
+// fetch-handler isolate doesn't provide, so hand-rolling the JSON-RPC
+// envelope here avoids betting on untested runtime compatibility). This
+// has NOT been run against a live NanoClaw agent yet - that is the first
+// thing to verify once secrets are set and this is deployed.
+//
+// Deliberately unimplemented, because nothing in this template needs it:
+// - SSE / server-initiated messages (GET returns 405, which the spec
+//   allows for servers that don't support the optional stream)
+// - Real session persistence (a session id is issued and echoed back,
+//   but never enforced - every request is handled statelessly)
+// - JSON-RPC batching (deprecated in current MCP protocol revisions)
+
+import { AwsClient } from "aws4fetch";
+
+const CE_ENDPOINT = "https://ce.us-east-1.amazonaws.com/";
+const CE_CONTENT_TYPE = "application/x-amz-json-1.1";
+const PROTOCOL_VERSION = "2025-06-18";
+
+// --- Tool schemas (kept name-compatible with mcp-aws-cost-explorer so the
+// template's existing SKILL.md files don't need to change) ---------------
+
+const TOOLS = [
+  {
+    name: "get_aws_cost_and_usage",
+    description: "Raw daily/monthly cost and usage time series.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        start: { type: "string", description: "YYYY-MM-DD" },
+        end: { type: "string", description: "YYYY-MM-DD" },
+        granularity: { type: "string", enum: ["DAILY", "MONTHLY"], default: "DAILY" },
+      },
+      required: ["start", "end"],
+    },
+  },
+  {
+    name: "get_cost_by_service",
+    description: "Cost breakdown grouped by AWS service.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        start: { type: "string" },
+        end: { type: "string" },
+        granularity: { type: "string", enum: ["DAILY", "MONTHLY"], default: "MONTHLY" },
+      },
+      required: ["start", "end"],
+    },
+  },
+  {
+    name: "get_cost_by_tag",
+    description: "Cost breakdown grouped by a cost allocation tag key.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        start: { type: "string" },
+        end: { type: "string" },
+        tagKey: { type: "string", description: "e.g. Team, Environment, Project" },
+      },
+      required: ["start", "end", "tagKey"],
+    },
+  },
+  {
+    name: "get_cost_forecast",
+    description: "Forecasted spend for a future period with a confidence interval.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        start: { type: "string" },
+        end: { type: "string" },
+        granularity: { type: "string", enum: ["DAILY", "MONTHLY"], default: "MONTHLY" },
+      },
+      required: ["start", "end"],
+    },
+  },
+  {
+    name: "get_cost_anomalies",
+    description: "AWS-detected cost anomalies (requires Cost Anomaly Detection monitors to already exist on the account - returns empty otherwise, not an error).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        start: { type: "string" },
+        end: { type: "string" },
+      },
+      required: ["start", "end"],
+    },
+  },
+  {
+    name: "get_rightsizing_recommendations",
+    description: "EC2 rightsizing recommendations (requires Cost Explorer rightsizing opt-in and ~14 days of instance metrics - returns empty otherwise, not an error).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        service: { type: "string", default: "AmazonEC2" },
+      },
+    },
+  },
+  {
+    name: "get_cost_comparison",
+    description: "Period-over-period cost comparison, computed here from two get_aws_cost_and_usage calls rather than a native AWS comparison API.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        currentStart: { type: "string" },
+        currentEnd: { type: "string" },
+        priorStart: { type: "string" },
+        priorEnd: { type: "string" },
+      },
+      required: ["currentStart", "currentEnd", "priorStart", "priorEnd"],
+    },
+  },
+];
+
+// --- AWS Cost Explorer calls ----------------------------------------------
+
+async function callCostExplorer(env, operation, body) {
+  const aws = new AwsClient({
+    accessKeyId: env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+    region: "us-east-1", // Cost Explorer is a single-region (us-east-1) API
+    service: "ce",
+  });
+
+  const resp = await aws.fetch(CE_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": CE_CONTENT_TYPE,
+      "X-Amz-Target": `AWSInsightsIndexService.${operation}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await resp.json();
+  if (!resp.ok) {
+    throw new Error(`Cost Explorer ${operation} failed (${resp.status}): ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+async function handleToolCall(env, name, args) {
+  switch (name) {
+    case "get_aws_cost_and_usage":
+      return callCostExplorer(env, "GetCostAndUsage", {
+        TimePeriod: { Start: args.start, End: args.end },
+        Granularity: args.granularity ?? "DAILY",
+        Metrics: ["UnblendedCost"],
+      });
+
+    case "get_cost_by_service":
+      return callCostExplorer(env, "GetCostAndUsage", {
+        TimePeriod: { Start: args.start, End: args.end },
+        Granularity: args.granularity ?? "MONTHLY",
+        Metrics: ["UnblendedCost"],
+        GroupBy: [{ Type: "DIMENSION", Key: "SERVICE" }],
+      });
+
+    case "get_cost_by_tag":
+      return callCostExplorer(env, "GetCostAndUsage", {
+        TimePeriod: { Start: args.start, End: args.end },
+        Granularity: "MONTHLY",
+        Metrics: ["UnblendedCost"],
+        GroupBy: [{ Type: "TAG", Key: args.tagKey }],
+      });
+
+    case "get_cost_forecast":
+      return callCostExplorer(env, "GetCostForecast", {
+        TimePeriod: { Start: args.start, End: args.end },
+        Granularity: args.granularity ?? "MONTHLY",
+        Metric: "UNBLENDED_COST",
+      });
+
+    case "get_cost_anomalies":
+      try {
+        return await callCostExplorer(env, "GetAnomalies", {
+          DateInterval: { StartDate: args.start, EndDate: args.end },
+        });
+      } catch (err) {
+        // No monitors configured is an expected, non-fatal state - see
+        // anomaly-detective/SKILL.md, which treats this call as
+        // corroboration only.
+        return { anomalies: [], note: `unavailable: ${err.message}` };
+      }
+
+    case "get_rightsizing_recommendations":
+      try {
+        return await callCostExplorer(env, "GetRightsizingRecommendation", {
+          Service: args.service ?? "AmazonEC2",
+        });
+      } catch (err) {
+        return { recommendations: [], note: `unavailable: ${err.message}` };
+      }
+
+    case "get_cost_comparison": {
+      const [current, prior] = await Promise.all([
+        callCostExplorer(env, "GetCostAndUsage", {
+          TimePeriod: { Start: args.currentStart, End: args.currentEnd },
+          Granularity: "MONTHLY",
+          Metrics: ["UnblendedCost"],
+          GroupBy: [{ Type: "DIMENSION", Key: "SERVICE" }],
+        }),
+        callCostExplorer(env, "GetCostAndUsage", {
+          TimePeriod: { Start: args.priorStart, End: args.priorEnd },
+          Granularity: "MONTHLY",
+          Metrics: ["UnblendedCost"],
+          GroupBy: [{ Type: "DIMENSION", Key: "SERVICE" }],
+        }),
+      ]);
+      return { current, prior };
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+// --- Minimal MCP Streamable HTTP JSON-RPC envelope ------------------------
+
+function jsonRpcResult(id, result) {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function jsonRpcError(id, code, message) {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+async function handleRpc(env, req, sessionId) {
+  const { method, id, params } = req;
+
+  if (method === "initialize") {
+    return jsonRpcResult(id, {
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: { tools: {} },
+      serverInfo: { name: "finops-cost-sentinel-aws-bridge", version: "1.0.0" },
+    });
+  }
+
+  if (method === "notifications/initialized") {
+    return null; // notification, no response body
+  }
+
+  if (method === "tools/list") {
+    return jsonRpcResult(id, { tools: TOOLS });
+  }
+
+  if (method === "tools/call") {
+    const { name, arguments: args } = params ?? {};
+    try {
+      const result = await handleToolCall(env, name, args ?? {});
+      return jsonRpcResult(id, {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      });
+    } catch (err) {
+      return jsonRpcResult(id, {
+        content: [{ type: "text", text: `Error: ${err.message}` }],
+        isError: true,
+      });
+    }
+  }
+
+  return jsonRpcError(id, -32601, `Method not found: ${method}`);
+}
+
+// Cheap pre-check for the hourly critical-spike-check task's `script:`
+// field - NanoClaw caps ungated (no pre-check script) tasks at 4 fires/24h
+// specifically to stop wasteful full-agent invocations, and an hourly
+// check is 24/day. This route answers {"wakeAgent": bool} directly, with
+// no MCP/JSON-RPC envelope and no LLM involved, so the task's script can
+// decide cheaply whether to wake the agent at all. Mirrors
+// anomaly-detective's critical threshold (see thresholds.md) so the two
+// never disagree about what counts as critical.
+async function handleCriticalCheck(env) {
+  const now = new Date();
+  const end = now.toISOString().slice(0, 10);
+  const start = new Date(now - 3 * 86400_000).toISOString().slice(0, 10);
+  const baselineStart = new Date(now - 10 * 86400_000).toISOString().slice(0, 10);
+
+  try {
+    const [recent, baseline] = await Promise.all([
+      callCostExplorer(env, "GetCostAndUsage", {
+        TimePeriod: { Start: start, End: end },
+        Granularity: "DAILY",
+        Metrics: ["UnblendedCost"],
+      }),
+      callCostExplorer(env, "GetCostAndUsage", {
+        TimePeriod: { Start: baselineStart, End: start },
+        Granularity: "DAILY",
+        Metrics: ["UnblendedCost"],
+      }),
+    ]);
+
+    const sum = (data) =>
+      (data.ResultsByTime ?? []).reduce(
+        (acc, day) => acc + parseFloat(day.Total?.UnblendedCost?.Amount ?? "0"),
+        0,
+      );
+    const recentDailyAvg = sum(recent) / Math.max((recent.ResultsByTime ?? []).length, 1);
+    const baselineDailyAvg = sum(baseline) / Math.max((baseline.ResultsByTime ?? []).length, 1);
+    const delta = recentDailyAvg - baselineDailyAvg;
+    const deviationPct = baselineDailyAvg > 0 ? delta / baselineDailyAvg : 0;
+
+    const wakeAgent = deviationPct >= 0.75 && delta >= 50;
+    return { wakeAgent, deviationPct, delta };
+  } catch (err) {
+    // Fail closed: an unreachable AWS call should never itself wake a
+    // full agent run - that's a proxy/AWS problem, not a cost spike.
+    return { wakeAgent: false, error: err.message };
+  }
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    const auth = request.headers.get("Authorization") ?? "";
+    if (auth !== `Bearer ${env.PROXY_AUTH_TOKEN}`) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    if (url.pathname === "/critical-check" && request.method === "GET") {
+      const result = await handleCriticalCheck(env);
+      return new Response(JSON.stringify(result), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (url.pathname !== "/") {
+      return new Response("Not found", { status: 404 });
+    }
+
+    if (request.method === "GET") {
+      // No server-initiated messages needed - SSE stream unsupported.
+      return new Response("Method not allowed", { status: 405 });
+    }
+
+    if (request.method === "DELETE") {
+      // No session state kept, nothing to tear down.
+      return new Response(null, { status: 204 });
+    }
+
+    if (request.method !== "POST") {
+      return new Response("Method not allowed", { status: 405 });
+    }
+
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return new Response(JSON.stringify(jsonRpcError(null, -32700, "Parse error")), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const sessionId = request.headers.get("Mcp-Session-Id") ?? crypto.randomUUID();
+    const result = await handleRpc(env, body, sessionId);
+
+    if (result === null) {
+      // Notification - accepted, no body.
+      return new Response(null, { status: 202 });
+    }
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Mcp-Session-Id": sessionId,
+      },
+    });
+  },
+};

--- a/data/finops-cost-sentinel/proxy/wrangler.toml
+++ b/data/finops-cost-sentinel/proxy/wrangler.toml
@@ -1,0 +1,13 @@
+name = "finops-cost-sentinel-proxy"
+main = "src/worker.js"
+compatibility_date = "2026-01-01"
+workers_dev = false
+
+routes = [
+  { pattern = "finops.realcy.app", custom_domain = true }
+]
+
+# Secrets (never put these here - set via `wrangler secret put`):
+#   AWS_ACCESS_KEY_ID
+#   AWS_SECRET_ACCESS_KEY
+#   PROXY_AUTH_TOKEN   (a token you generate yourself, e.g. `openssl rand -hex 32`)

--- a/data/finops-cost-sentinel/scripts/dial-call.mjs
+++ b/data/finops-cost-sentinel/scripts/dial-call.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Minimal stdio MCP server exposing one tool: place_alert_call.
+//
+// Vendored instead of using @getdial/cli's own MCP server because that
+// package authenticates from an interactive `dial onboard` session file
+// (~/.local/share/dial/auth.v1.json) and Dial's hosted remote MCP server
+// requires OAuth 2.1 browser authorization - neither supports the
+// headless, env-var-injected credential model NanoClaw templates use.
+// This wrapper talks to Dial's plain REST API with a static bearer token
+// instead, which does support that model.
+//
+// NOTE: written from Dial's published API reference (POST /api/v1/calls,
+// GET /api/v1/calls/:id). Verify against https://docs.getdial.ai before
+// relying on this for the demo - it has not been run against a live
+// account yet.
+//
+// Uses the hand-rolled stdio helper in ./stdio-mcp.mjs, not
+// @modelcontextprotocol/sdk - see that file's header comment for why (a
+// stamped plugin directory has no node_modules, so any non-builtin import
+// fails at spawn time with ERR_MODULE_NOT_FOUND, which is exactly what
+// happened here before this fix).
+
+import { runStdioMcpServer } from "./stdio-mcp.mjs";
+
+const DIAL_API_BASE = "https://api.getdial.ai/api/v1";
+const POLL_INTERVAL_MS = 3000;
+const POLL_TIMEOUT_MS = 120_000;
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not set - export a real value for testing.`);
+  }
+  // Deliberately NOT rejecting the literal "placeholder" here. NanoClaw's
+  // vault never substitutes stdio env vars before spawn - process.env stays
+  // "placeholder" verbatim in production. The real DIAL_API_KEY only shows
+  // up on the wire: this script sends `Authorization: Bearer placeholder`
+  // to api.getdial.ai, and the vault's egress proxy rewrites that header to
+  // the real key by hostname match before the request leaves the container
+  // (confirmed against onecli-gateway's own container skill doc: "pass any
+  // placeholder value - the proxy replaces it with real credentials at
+  // request time"). Rejecting "placeholder" here would make this call fail
+  // in every real deployment, which is exactly what it did until this fix.
+  return value;
+}
+
+async function placeAlertCall(message) {
+  const apiKey = requireEnv("DIAL_API_KEY");
+  const toNumber = requireEnv("DIAL_ALERT_PHONE_NUMBER");
+  const fromNumber = requireEnv("DIAL_FROM_NUMBER");
+
+  const createResp = await fetch(`${DIAL_API_BASE}/calls`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      to: toNumber,
+      fromNumber,
+      outboundInstruction:
+        `Read this alert message clearly, then stop: "${message}"`,
+      maxCallDurationSeconds: 90,
+    }),
+  });
+
+  if (!createResp.ok) {
+    const body = await createResp.text().catch(() => "");
+    throw new Error(
+      `Dial call creation failed: ${createResp.status} ${body}`,
+    );
+  }
+
+  const { call } = await createResp.json();
+  const callId = call.id;
+
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  let lastStatus = call.status;
+  let transcript = call.transcript ?? null;
+
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
+    const pollResp = await fetch(`${DIAL_API_BASE}/calls/${callId}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (!pollResp.ok) continue;
+
+    const polled = await pollResp.json();
+    lastStatus = polled.call?.status ?? lastStatus;
+    transcript = polled.call?.transcript ?? transcript;
+
+    const terminal = ["completed", "failed", "no-answer", "busy"];
+    if (terminal.includes(lastStatus) && transcript) break;
+    if (terminal.includes(lastStatus) && !transcript) {
+      // call ended but transcript can lag a few seconds - keep polling
+      // briefly rather than returning immediately.
+      continue;
+    }
+  }
+
+  return {
+    outcome: lastStatus,
+    transcriptSummary: transcript ?? "(no transcript received within timeout)",
+    callId,
+  };
+}
+
+runStdioMcpServer({
+  name: "dial-alert",
+  version: "1.0.0",
+  tools: [
+    {
+      name: "place_alert_call",
+      description:
+        "Places a voice call via Dial to read out a short alert message. " +
+        "Use only for critical spend spikes - never for routine digests.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: {
+            type: "string",
+            description:
+              "Short spoken alert (2-3 sentences) - service, $ delta, % deviation.",
+          },
+        },
+        required: ["message"],
+      },
+    },
+  ],
+  async callTool(name, args) {
+    if (name !== "place_alert_call") {
+      throw new Error(`Unknown tool: ${name}`);
+    }
+    const { message } = args;
+    if (!message || typeof message !== "string") {
+      throw new Error("`message` is required and must be a string.");
+    }
+    return placeAlertCall(message);
+  },
+});

--- a/data/finops-cost-sentinel/scripts/stdio-mcp.mjs
+++ b/data/finops-cost-sentinel/scripts/stdio-mcp.mjs
@@ -1,0 +1,83 @@
+// Minimal, zero-dependency stdio MCP JSON-RPC server helper.
+//
+// Deliberately not using @modelcontextprotocol/sdk: a stamped template's
+// plugin directory is a plain file copy - no `npm install` (or `pnpm`/`bun`
+// equivalent) ever runs against it, so any script here that imports a
+// non-builtin package fails with ERR_MODULE_NOT_FOUND at spawn time. This
+// mirrors the same choice already made in proxy/src/worker.js, just over
+// stdio instead of HTTP. Node built-ins only.
+//
+// Wire format: one JSON-RPC 2.0 message per line on stdin, one per line on
+// stdout for responses. Notifications (no `id`) get no response.
+
+import { createInterface } from "node:readline";
+
+export function runStdioMcpServer({ name, version, tools, callTool }) {
+  const rl = createInterface({ input: process.stdin, terminal: false });
+
+  function send(obj) {
+    process.stdout.write(`${JSON.stringify(obj)}\n`);
+  }
+
+  rl.on("line", async (rawLine) => {
+    const line = rawLine.trim();
+    if (!line) return;
+
+    let req;
+    try {
+      req = JSON.parse(line);
+    } catch {
+      send({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } });
+      return;
+    }
+
+    const { method, id, params } = req;
+
+    if (method === "initialize") {
+      send({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          protocolVersion: "2025-06-18",
+          capabilities: { tools: {} },
+          serverInfo: { name, version },
+        },
+      });
+      return;
+    }
+
+    if (method === "notifications/initialized") {
+      return;
+    }
+
+    if (method === "tools/list") {
+      send({ jsonrpc: "2.0", id, result: { tools } });
+      return;
+    }
+
+    if (method === "tools/call") {
+      try {
+        const result = await callTool(params?.name, params?.arguments ?? {});
+        send({
+          jsonrpc: "2.0",
+          id,
+          result: { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] },
+        });
+      } catch (err) {
+        send({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            content: [{ type: "text", text: `Error: ${err.message}` }],
+            isError: true,
+          },
+        });
+      }
+      return;
+    }
+
+    if (id !== undefined && id !== null) {
+      send({ jsonrpc: "2.0", id, error: { code: -32601, message: `Method not found: ${method}` } });
+    }
+  });
+}

--- a/data/finops-cost-sentinel/scripts/tavily-search.mjs
+++ b/data/finops-cost-sentinel/scripts/tavily-search.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Minimal stdio MCP server exposing one tool: tavily_search.
+//
+// Vendored instead of using the published `tavily-mcp` npm package for two
+// independent reasons:
+// 1. A stamped plugin directory has no node_modules (see stdio-mcp.mjs's
+//    header), so any script here needs zero non-builtin imports - the
+//    published package needs its own dependency tree, which we can't ship.
+// 2. tavily-mcp@0.2.22's own package.json declares
+//    devEngines.packageManager: pnpm. This container's npm enforces that
+//    strictly (EBADDEVENGINES) instead of honoring the package's own
+//    onFail: "download" - `npx -y tavily-mcp@latest` fails outright before
+//    ever reaching our code. Verified against a live container.
+//
+// Auth confirmed from tavily-mcp's own source (build/index.js): every
+// request carries `Authorization: Bearer <key>` via axios default headers
+// to api.tavily.com - a plain bearer header, so this is vault-compatible
+// the same way the AWS bridge and Dial are.
+
+import { runStdioMcpServer } from "./stdio-mcp.mjs";
+
+const TAVILY_SEARCH_URL = "https://api.tavily.com/search";
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not set - export a real value for testing.`);
+  }
+  // See dial-call.mjs's requireEnv for why "placeholder" is NOT rejected
+  // here - the vault rewrites this env var's value on the wire, not before
+  // this process reads it.
+  return value;
+}
+
+async function tavilySearch(query, maxResults) {
+  const apiKey = requireEnv("TAVILY_API_KEY");
+
+  const resp = await fetch(TAVILY_SEARCH_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      query,
+      max_results: maxResults ?? 5,
+    }),
+  });
+
+  const data = await resp.json();
+  if (!resp.ok) {
+    throw new Error(`Tavily search failed (${resp.status}): ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+runStdioMcpServer({
+  name: "tavily",
+  version: "1.0.0",
+  tools: [
+    {
+      name: "tavily_search",
+      description:
+        "Web search via Tavily. Use to identify an unfamiliar AWS service or " +
+        "SKU name and its typical pricing model - never guess.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Search query." },
+          maxResults: { type: "integer", description: "Default 5." },
+        },
+        required: ["query"],
+      },
+    },
+  ],
+  async callTool(name, args) {
+    if (name !== "tavily_search") {
+      throw new Error(`Unknown tool: ${name}`);
+    }
+    const { query, maxResults } = args;
+    if (!query || typeof query !== "string") {
+      throw new Error("`query` is required and must be a string.");
+    }
+    return tavilySearch(query, maxResults);
+  },
+});

--- a/data/finops-cost-sentinel/skills/anomaly-detective/SKILL.md
+++ b/data/finops-cost-sentinel/skills/anomaly-detective/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: anomaly-detective
+description: Detects unexpected AWS spend spikes by comparing recent daily cost against a rolling baseline, and classifies each finding as notable or critical.
+---
+
+# Anomaly Detective
+
+## Purpose
+
+Find spend that doesn't match the recent pattern, using raw cost data that
+works on any AWS account with billing history - no opt-in or enablement
+required. This is the primary detection path; AWS's own anomaly detection
+is used only as optional corroboration.
+
+## Procedure
+
+1. Call `get_aws_cost_and_usage` for the last 30 days, daily granularity.
+2. Call `get_cost_by_service` for the same window to see which services
+   moved.
+3. Compute a 7-day trailing baseline per service. Compare each of the last
+   3 days against it.
+4. Classify:
+   - **Notable**: day-over-baseline deviation >= 20%.
+   - **Critical**: deviation >= 75% AND absolute delta >= $50/day (tune
+     both numbers in `additional_context/thresholds.md` for the account
+     being watched).
+5. If AWS Cost Anomaly Detection is enabled on the account, also call
+   `get_cost_anomalies` and cross-reference. Treat this as corroboration
+   only - never fail or block a finding if this call errors or returns
+   empty (it requires monitors to be configured first).
+6. For any service name you don't recognize, hand off to the
+   `unknown-service-lookup` skill before reporting the finding - never
+   guess what a line item is.
+7. For any finding classified **critical**, hand off to the
+   `critical-spike-alert` skill. Do this only for critical findings -
+   never for notable ones.
+
+## Output
+
+One finding per anomaly: service name, $ delta, % deviation, notable/
+critical classification, and (if available) AWS's own anomaly root-cause
+text.

--- a/data/finops-cost-sentinel/skills/critical-spike-alert/SKILL.md
+++ b/data/finops-cost-sentinel/skills/critical-spike-alert/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: critical-spike-alert
+description: Places a voice call via Dial to alert an on-call human when anomaly-detective classifies a spend spike as critical. Used sparingly and only for genuine P1s.
+---
+
+# Critical Spike Alert
+
+## Purpose
+
+Escalate the rare case that genuinely warrants interrupting a human, by
+phone, instead of waiting for the next digest.
+
+## When to use this skill
+
+Only when `anomaly-detective` has classified a finding as **critical**
+(not notable). If you are unsure whether a finding is critical, it is
+not - use the weekly digest instead. Placing a call is expensive and
+disruptive; false alarms erode trust in this skill faster than anything
+else it does.
+
+## Procedure
+
+1. Confirm the finding is classified critical by `anomaly-detective`
+   before doing anything else.
+2. Compose a short spoken message: service name, $ delta, % deviation,
+   and the plain-English driver if `unknown-service-lookup` was used.
+   Keep it to 2-3 sentences - it will be read aloud.
+3. Call the `place_alert_call` tool with that message.
+4. Report back the call outcome and transcript summary returned by the
+   tool. If the call fails (no answer, API error), report that plainly -
+   do not retry more than once.
+
+## Output
+
+Call outcome (answered / no answer / failed), transcript summary if
+available, and confirmation of what message was sent.

--- a/data/finops-cost-sentinel/skills/forecast-watch/SKILL.md
+++ b/data/finops-cost-sentinel/skills/forecast-watch/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: forecast-watch
+description: Projects month-end AWS spend with a confidence interval and flags budget risk against a configured monthly budget.
+---
+
+# Forecast Watch
+
+## Purpose
+
+Answer "where is this month heading" before the bill arrives.
+
+## Procedure
+
+1. Call `get_cost_forecast` for the remainder of the current calendar
+   month.
+2. Compare the forecast's point estimate and its upper confidence bound
+   against the configured monthly budget in
+   `additional_context/thresholds.md`.
+3. Flag budget risk only when the forecast's point estimate (not just the
+   upper bound) exceeds the budget - the upper bound alone is expected to
+   vary and should be reported as context, not treated as the trigger.
+
+## Output
+
+Forecast point estimate, confidence interval, configured budget, and a
+plain-English risk statement (on track / at risk / over).

--- a/data/finops-cost-sentinel/skills/rightsizing-advisor/SKILL.md
+++ b/data/finops-cost-sentinel/skills/rightsizing-advisor/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: rightsizing-advisor
+description: Lists EC2 rightsizing opportunities and estimated savings from AWS Cost Explorer's recommendations, when available.
+---
+
+# Rightsizing Advisor
+
+## Purpose
+
+Surface over-provisioned EC2 instances with estimated savings. This is an
+enrichment skill, not a primary one - it depends on AWS features that
+require account-level opt-in.
+
+## Procedure
+
+1. Call `get_rightsizing_recommendations`.
+2. If the call errors or returns empty, report plainly: "Rightsizing
+   recommendations require Cost Explorer opt-in and ~14 days of instance
+   metrics - not yet available on this account." Do not treat this as a
+   failure and do not block the rest of the digest on it.
+3. If recommendations are present, rank by estimated monthly savings,
+   largest first, and include the current vs. recommended instance type
+   for each.
+
+## Output
+
+A ranked list of instance / estimated monthly savings / recommended
+change, or the explicit "not available" status above.

--- a/data/finops-cost-sentinel/skills/service-breakdown/SKILL.md
+++ b/data/finops-cost-sentinel/skills/service-breakdown/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: service-breakdown
+description: Ranks AWS spend by service over a trailing window and narrates the biggest drivers of change in plain English.
+---
+
+# Service Breakdown
+
+## Purpose
+
+Answer "what is actually costing money, and what changed" - the
+foundational view the other skills build on.
+
+## Procedure
+
+1. Call `get_cost_by_service` for the trailing 30 days.
+2. Call `get_cost_comparison` for this period vs. the prior period of equal
+   length.
+3. Rank services by absolute $ and separately by % change.
+4. Narrate the top 5 by absolute spend and the top 3 movers by % change,
+   in plain English (no jargon, always include a $ amount).
+5. For any service name you don't recognize, hand off to the
+   `unknown-service-lookup` skill before including it in the narrative.
+
+## Output
+
+A short ranked list: service, $ this period, $ last period, % change,
+one-line plain-English explanation of what the service is if it was
+looked up.

--- a/data/finops-cost-sentinel/skills/tag-hygiene/SKILL.md
+++ b/data/finops-cost-sentinel/skills/tag-hygiene/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: tag-hygiene
+description: Surfaces AWS spend that is missing cost allocation tags (Team, Environment, Project) so it can be attributed to an owner.
+---
+
+# Tag Hygiene
+
+## Purpose
+
+Cost that can't be attributed to a team or project is cost nobody is
+accountable for. This skill finds it.
+
+## Procedure
+
+1. Call `get_cost_by_tag` for the trailing 30 days, once per configured
+   tag key (default: `Team`, `Environment`, `Project` - see
+   `additional_context/thresholds.md` to change these).
+2. For each tag key, identify the "no tag value" / untagged bucket and its
+   $ amount.
+3. If a tag key returns no data at all, report that plainly as "not yet
+   activated as a cost allocation tag in Billing" rather than treating it
+   as zero untagged spend - these are different situations and should not
+   be conflated.
+4. Rank untagged $ amounts across the configured tag keys, largest first.
+
+## Output
+
+Per tag key: $ untagged, % of total spend untagged, or an explicit
+"not activated" status. Never silently omit a tag key that returned no
+data.

--- a/data/finops-cost-sentinel/skills/unknown-service-lookup/SKILL.md
+++ b/data/finops-cost-sentinel/skills/unknown-service-lookup/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: unknown-service-lookup
+description: Looks up an unfamiliar AWS service or SKU name using Tavily web search so cost findings never report a guess.
+---
+
+# Unknown Service Lookup
+
+## Purpose
+
+Other skills call this one when a line item's service or SKU name isn't
+recognizable, so the digest never reports a guess about what something is.
+
+## Procedure
+
+1. Use the `tavily_search` tool with a query like `"<service/SKU name>"
+   AWS pricing what is`.
+2. Prefer official AWS documentation and pricing pages in the results.
+3. Summarize in one or two sentences: what the service is, and typical
+   pricing model (per-request, per-GB, per-hour, etc.) if stated in the
+   results.
+4. If Tavily returns nothing useful, report the line item with its raw
+   name and $ amount, and say explicitly that it could not be identified
+   - never fabricate a description.
+
+## Output
+
+One or two sentence plain-English description of the service, or an
+explicit "could not be identified" note.

--- a/index.json
+++ b/index.json
@@ -7,6 +7,12 @@
         "name": "analyst",
         "version": "1.0.0",
         "description": "Data analyst agent: pipeline checks, query writing, and recurring report integrity"
+      },
+      {
+        "ref": "data/finops-cost-sentinel",
+        "name": "finops-cost-sentinel",
+        "version": "1.0.0",
+        "description": "Watches your AWS bill for anomalies, tag gaps, and rightsizing waste - researches unfamiliar charges and calls you for genuine P1s."
       }
     ],
     "lifestyle": [


### PR DESCRIPTION
## Summary

A FinOps analyst agent for the [NanoClaw Agent Templates Hackathon](https://nanoclaw.dev/hackathon). It watches AWS Cost Explorer for spend anomalies, tag-hygiene gaps, and rightsizing waste; looks up unfamiliar line items via Tavily before ever reporting a guess; and escalates genuinely critical spikes (a deliberately high, tunable bar) with a real phone call via Dial.

All three integrations (AWS, Tavily, Dial) are verified against real accounts, not just structurally validated against the stamp-time checks — see the "Testing" section below.

## Design notes worth a reviewer's attention

- **AWS Cost Explorer's SigV4 auth doesn't fit the credential vault.** The vault rewrites the `Authorization` header of outbound HTTPS requests, matched by hostname — a model built for static bearer tokens. SigV4 signs the request locally with the real key before it ever leaves the process, so a header rewrite can't repair a signature computed against a placeholder. The template bridges through a small Cloudflare Worker (`proxy/`) the operator deploys themselves with their own AWS keys; the container only ever needs one bearer token to reach that Worker. Documented in both `README.md` and the Worker's own header comment.
- **Both stdio MCP servers (Tavily, Dial) are hand-rolled, zero-dependency scripts, not the published npm packages.** A stamped plugin directory is a plain file copy — no `node_modules` ever gets installed for it — so any script here that imports a non-builtin package fails at spawn time with `ERR_MODULE_NOT_FOUND`. Found by running the exact spawn commands inside a live container. `tavily-mcp` additionally fails under plain `npm` due to a `devEngines.packageManager: pnpm` constraint in its own `package.json` (`EBADDEVENGINES`) — a real upstream landmine independent of the `node_modules` issue.
- **`critical-spike-check` runs hourly with a pre-check `script:`**, not because it's decorative but because NanoClaw caps ungated tasks at 4 fires/24h specifically to stop wasteful full-agent invocations — the script hits a cheap, LLM-free endpoint on the same Worker before ever waking the agent.

## What it does

- Weekly digest (Monday): anomaly scan, service breakdown, tag hygiene, rightsizing, forecast — all degrade gracefully (not-yet-available vs. zero) when an AWS-side feature needs its own opt-in.
- Hourly critical-spike check: silent unless a spend spike crosses a high, explicit bar, then places one voice call.
- Read-only throughout — never modifies, stops, resizes, or deletes any AWS resource.

## Testing

- `node scripts/check-templates.mjs` passes.
- Stamped locally via `ncl groups create --template data/finops-cost-sentinel`, restamped in place across three fix iterations (clean `templateReport` each time).
- Live digest run against a real AWS account: correctly surfaced a real anomaly (below the critical bar, so correctly withheld the call), 100% untagged spend, and fell back gracefully when AWS's forecast API had insufficient history.
- Live Tavily search: real results from `api.tavily.com`.
- Live Dial call: real call placed, answered, and transcribed.

## Checklist

- [x] `<category>/<template>/` — reused the existing `data/` category rather than adding a new one.
- [x] `plugin.json` present, exact 1.0.0 `$schema`, valid `name`, `author` set.
- [x] `ai.nanoco.nanoclaw/context/instructions.md` non-empty.
- [x] `mcp.json` — every credential-shaped value is the literal `"placeholder"`.
- [x] Every task has a non-empty `schedule`, optional `script`, no other frontmatter fields.
- [x] `README.md` documents every service: API host, auth style, scopes, where to get the key.
- [x] Paid services (AWS Cost Explorer beyond free tier, Dial) disclosed up front — tiers and pricing-page links only, no prices quoted.
- [x] No affiliate/referral links, no baked-in billing, no shared or author-owned credential anywhere in the template.
- [x] `node scripts/check-templates.mjs` passes.
- [x] Stamped and tested locally end-to-end, including live third-party calls.
- [x] No secrets anywhere in the diff.
- [x] Read "Acceptance and ownership" in CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018erad52EGzTR9MkPeYofBK