### PR TITLE
feat(home-assistant): agent template on Home Assistant's built-in Model Context Protocol Server

### DIFF
--- a/index.json
+++ b/index.json
@@ -15,6 +15,12 @@
         "name": "family-assistant",
         "version": "1.0.0",
         "description": "Household assistant agent: morning briefs, meal planning and grocery lists, week-ahead logistics, school tracking, price watch, and bookings"
+      },
+      {
+        "ref": "lifestyle/home-assistant",
+        "name": "home-assistant",
+        "version": "1.0.0",
+        "description": "Smart-home agent for your own Home Assistant: reads and controls whatever you expose to Assist, and puts it on a schedule when asked"
       }
     ],
     "media": [

--- a/lifestyle/home-assistant/README.md
+++ b/lifestyle/home-assistant/README.md
@@ -1,0 +1,229 @@
+# Home Assistant Agent Template
+
+A NanoClaw agent template for a house running [Home Assistant](https://www.home-assistant.io/).
+It talks to your own HA instance through Home Assistant's built-in
+[**Model Context Protocol Server**](https://www.home-assistant.io/integrations/mcp_server/)
+integration, and reads and controls **what you have exposed to Assist** — that
+expose list, kept in Home Assistant, is the whole permission model. Connect a new
+device, expose it, tell the agent, and it is there.
+
+Anything it can do can also be put on a schedule — "boil the kettle every
+Friday morning" — which anyone in the chat can ask for, set up once with a
+confirmation, and pause or cancel later.
+
+## Layout
+
+NanoClaw stamps an agent from the parts of this folder its plugin reader loads
+(`skills/` and the `ai.nanoco.nanoclaw/` extension dir); README.md is not one of
+them.
+
+```
+home-assistant/
+├── plugin.json                       # Agent Plugins manifest (marks the folder as a plugin)
+├── ai.nanoco.nanoclaw/
+│   └── context/
+│       ├── instructions.md           # the agent's standing brief
+│       └── additional_context/
+│           ├── tasks.md              #   one yes at creation, `ncl tasks`, a self-contained prompt
+│           └── memory.md             #   which files live in `memory/`, flat beside index.md
+├── skills/
+│   ├── welcome/                      # first contact: intro, then run the onboarding
+│   │   └── SKILL.md
+│   └── homeassistant/                # the router + all mechanics
+│       ├── SKILL.md                  #   entry: capabilities → references, the tools, day-to-day control
+│       └── references/
+│           ├── connecting.md         #   the integration, the HTTPS URL, the token, every 401
+│           └── onboarding.md         #   probe first, then infer the house from the snapshot
+└── README.md                         # this file
+```
+
+No `mcp.json` (see below) and no predefined tasks — home control is
+request-driven. Schedules are created on request instead, against whatever that
+house actually has: the agent sets them up itself with `ncl tasks`, no admin
+approval involved.
+
+## Before you stamp
+
+Five prerequisites, all on your side. The agent walks you through them in chat,
+but nothing works until they are true.
+
+| # | Prerequisite | Where |
+|---|---|---|
+| 1 | Home Assistant **2025.2 or newer** | your instance |
+| 2 | The **Model Context Protocol Server** integration added, with the **Assist** API selected | Settings → Devices & services → Add integration → "Model Context Protocol Server" |
+| 3 | The entities you want it to see **exposed to Assist** | Settings → Voice assistants → Expose |
+| 4 | A **long-lived access token**, created by an **administrator** user | your HA profile → Security → Long-Lived Access Tokens → Create Token |
+| 5 | An **HTTPS** endpoint for HA, reachable from the container | see below |
+
+Nothing to install: the integration ships with Home Assistant core. Step 3 is
+where the agent's reach is actually decided — it can only read and control what
+is exposed, and nothing in the chat can widen that. Home Assistant exposes new
+lights, switches, covers, climate, fans, media players, scenes, scripts, vacuums
+and the common sensors by itself (the "Expose new entities" default), so a
+typical house is mostly visible on day one. **Locks are not auto-exposed** and
+stay invisible until you expose them on purpose. Multi-select on the Expose tab
+does the rest in one pass.
+
+### The URL has to be HTTPS
+
+NanoClaw only accepts plain `http://` for `localhost`, so
+`http://192.168.1.x:8123` will not stamp — a LAN address is neither localhost
+nor HTTPS, and it is rejected before the agent ever calls it. You need one of:
+
+- **Your own reverse proxy** — Caddy, nginx, or a Cloudflare Tunnel in front of
+  HA. Free, some setup.
+- **Home Assistant Cloud (Nabu Casa)** — the no-effort route. It is a **paid
+  subscription that you buy and hold yourself**; this template ships no account
+  and no key. Current plans and pricing:
+  <https://www.nabucasa.com/pricing/>. The plan is **Home Assistant Cloud**; it
+  gives you an `https://<id>.ui.nabu.casa` hostname, which is all the agent
+  needs.
+
+**HA on the same host is not a shortcut.** The URL check exempts `localhost`,
+`127.0.0.1` and `host.docker.internal` from the HTTPS rule, so
+`http://host.docker.internal:8123` stamps. It does not connect: the agent
+container's only route out is the OneCLI gateway, which sits on the agent's
+internal Docker network under the name `host.docker.internal` itself, so that
+address reaches the gateway, not your machine, and the dial fails before any
+header matters. A local HA needs an HTTPS hostname the gateway can resolve,
+same as a remote one.
+
+The endpoint the agent connects to is `https://<your-host>/api/mcp/assist` —
+the Assist API's own path, which Home Assistant serves whatever else the
+integration is configured with.
+
+## Stamp an agent from this template
+
+```bash
+ncl groups create --template lifestyle/home-assistant --name "Home"
+```
+
+Wire this group to its own messaging bot, separate from any other NanoClaw
+agent you run — a shared bot mixes this agent's house-control context and
+memory into another agent's chat history, and there is no way to unmix them
+afterwards.
+
+Then wire it to a chat as usual (`/manage-channels`) and say hi. The agent
+introduces itself, asks for the HTTPS URL, walks you through putting the token in
+the OneCLI vault, and only then calls `add_mcp_server` (which raises an **admin
+approval card** — approve it). **Then restart the group.** MCP servers only load
+at container start, so nothing connects until you do:
+
+```bash
+ncl groups restart --id <group-id> --message "connect home assistant"
+```
+
+New or newly exposed entities need no restart — the agent picks them up on its
+next read.
+
+**The vault entry has to exist before the server is wired**, and the agent is
+instructed to keep that order. Home Assistant's MCP server advertises OAuth
+metadata, so a first connect without the header does not just fail and retry: the
+client runs OAuth discovery, registers itself with an empty token, and
+permanently stops sending requests the gateway can inject into. Adding the secret
+afterwards does not fix it — recovery is an operator deleting the stale
+`mcpOAuth` entry from the group's `.claude-shared/.credentials.json` and
+restarting (see the connecting reference, section 6).
+
+## Why there is no `mcp.json`
+
+This is the non-obvious part, and the one a future maintainer will "fix" by
+copying the journalist template. Don't.
+
+The journalist can ship `{"APIFY_TOKEN": "placeholder"}` because `api.apify.com`
+is the same host for every user: the only per-user value is a **credential**, and
+the placeholder convention covers it. Home Assistant's per-user value is the
+**address**. A placeholder URL would stamp cleanly and fail at runtime — and once
+stamped it is unfixable from the agent side: `ncl groups config add-mcp-server`
+and `remove-mcp-server` both refuse a server name owned by a plugin and tell you
+to restamp the plugin instead. Fixing a wrong URL would then mean hand-editing
+`templates/lifestyle/home-assistant/mcp.json` on the host and restamping, and it
+would also close the `--headers` fallback below, which is blocked by the same
+guard.
+
+Wiring the server at onboarding keeps it **user-owned**: the URL is asked in
+chat, and both credential routes stay open.
+
+## Credentials: via OneCLI, not env vars
+
+**No token lives in this template.** NanoClaw never passes secrets into agent
+containers as env vars, and `add_mcp_server` has no way to set a header anyway.
+The token goes into the OneCLI vault, matched on your HA hostname, and the
+gateway injects it into outbound calls at the proxy boundary:
+
+| Field | Value |
+|---|---|
+| API host | your HA hostname (the `<host>` in `https://<host>/api/mcp/assist`) |
+| Auth style | `Authorization: Bearer <token>` |
+| Scopes | none to pick — a long-lived access token carries the full permissions of the HA user it was created under |
+| Header | `Authorization` |
+| Value format | `Bearer {value}` |
+| Where to get it | Home Assistant profile (bottom-left avatar) → Security → Long-Lived Access Tokens → Create Token |
+
+The agent hands you a prefilled OneCLI link during onboarding. The host-side
+equivalent:
+
+```bash
+onecli secrets create --name "Home Assistant" --type generic \
+  --host-pattern <host> --header-name Authorization \
+  --value-format "Bearer {value}"
+```
+
+**Fallback, if the gateway does not inject.** Injection on HTTP-transport MCP
+calls is verified: the gateway MITMs both `http://` and `https://` and applies a
+matching vault entry to either. If calls still `401` with a correct vault entry,
+an operator can put the header on the server directly — this works precisely
+because the server is not plugin-owned:
+
+```bash
+ncl groups config add-mcp-server --id <group-id> --name homeassistant \
+  --url https://<host>/api/mcp/assist \
+  --headers '{"Authorization":"Bearer <long-lived-token>"}'
+ncl groups restart --id <group-id> --message "reconnect Home Assistant"
+```
+
+## Where the connection lives
+
+- **The URL** is an identifier, so it goes on disk: the approved `add_mcp_server`
+  writes it to the central DB, which is materialized into the group's
+  `container.json` and mounted read-only in the container.
+- **The token** sits in the OneCLI vault on the host. It never reaches
+  `container.json`, the container env, or the chat.
+
+Neither is a file the agent maintains — which is why the restart after approval
+is needed before the server shows up.
+
+## What the agent writes
+
+Only notes in `memory/`, as flat files beside `index.md` and linked from its
+Map: `schedules.md` for standing tasks, `preferences.md` and `quirks.md` for
+what it picks up along the way — a usual temperature, a favourite scene, a
+sensor that lags. No subfolders, so the layout stays whatever NanoClaw's own
+memory system expects as it upgrades. It writes no skills and nothing into Home
+Assistant.
+
+## Security, honestly
+
+The agent sees a chat display name and nothing more — it cannot see roles or
+users — so **anyone who can message the chat can drive whatever is exposed**.
+Treat the chat's membership as the real access list, and the expose list as the
+ceiling on what that access reaches.
+
+The gates that are actually enforced sit outside the agent:
+
+- **The Assist expose list in Home Assistant.** The MCP server only serves
+  entities exposed to Assist, so an unexposed lock cannot be touched however the
+  chat argues. This is the permission model, it lives in HA, and the agent
+  cannot change it.
+- **Admin approval** on wiring changes: `add_mcp_server` cannot connect anything
+  without a human approving the card.
+- **OneCLI approval policies**, which can hold an outbound request by host and
+  path before it leaves the proxy.
+
+Inside the chat, the standing brief makes the agent read state before it acts and
+confirm anything physical and hard to undo — unlocking, opening, heating, running
+a motor. That is a good default, not a lock.
+
+---
+
+Template by [Amit Yanay](https://github.com/CrAzyScreamx).

--- a/lifestyle/home-assistant/ai.nanoco.nanoclaw/context/additional_context/memory.md
+++ b/lifestyle/home-assistant/ai.nanoco.nanoclaw/context/additional_context/memory.md
@@ -1,0 +1,34 @@
+# What this agent keeps in `memory/`
+
+[memory/system/definition.md](../memory/system/definition.md) says how memory works. This says only which files
+this agent writes, and what a line has to carry.
+
+**Flat files at the memory root, beside [index.md](../memory/index.md), linked from its Map.** No
+`home/` folder, no subfolders. Create a file on its first write and add its Map
+line in the same turn.
+
+| File | `type` | Holds |
+|---|---|---|
+| [memory/schedules.md](../memory/schedules.md) | `schedules` | one line per standing task — what runs, when, who asked, the date, the task id |
+| [memory/preferences.md](../memory/preferences.md) | `preferences` | what the household likes — temperatures, scenes, the names they use for rooms and devices |
+| [memory/quirks.md](../memory/quirks.md) | `quirks` | what the house does that the state does not say — a sensor that lags, a device that reports wrong |
+
+One dated line per fact, in the household's own words where a name is involved:
+
+```markdown
+- Kettle (Tami4, kitchen) every 15 min, Fri 08:00–10:00 · asked by Dana · 2026-08-22 · task `a1b2c3`
+- Vacuum, weekdays 09:00 · asked by Amit · 2026-08-14 · task `d4e5f6` · **paused** 2026-09-01
+- Bedroom at 21° for the night · 2026-08-19
+- "the big light" = the ceiling light in the living room · 2026-08-20
+```
+
+A schedule line is written in the turn the task is created. A cancelled one
+comes out; a paused one stays, marked paused. The task id is what `ncl tasks
+pause` and `cancel` take — without it the line is decoration.
+
+## Never
+
+- Never answer a question about a device from memory. State comes from
+  `GetLiveContext`, every time.
+- Never put any of this in Core Memory in [memory/index.md](../memory/index.md). A Friday kettle
+  bears on Fridays.

--- a/lifestyle/home-assistant/ai.nanoco.nanoclaw/context/additional_context/tasks.md
+++ b/lifestyle/home-assistant/ai.nanoco.nanoclaw/context/additional_context/tasks.md
@@ -1,0 +1,52 @@
+# Creating a task
+
+"Boil the water every Friday between eight and ten", "hoover on weekday
+mornings", "stop the morning one".
+
+**Anyone in the chat may ask.** A schedule puts an action you can already do on
+a timer. Listing, pausing, resuming and cancelling are the same kind of thing.
+Only what is exposed can be scheduled — refresh `GetLiveContext` first and
+confirm the device is there; if it is not, say so and point at the Expose tab.
+
+## Confirm once, at creation
+
+A recurring physical action gets one read-back and one yes — the whole series,
+authorized once:
+
+> Every Friday, boil the kettle in the kitchen every 15 minutes from 08:00 to
+> 10:00. That's 9 boils a morning, starting this Friday. Confirm?
+
+Read back the exact device and area, the action, the cadence, the window, and
+when it first runs. Take the yes from whoever asked. After that the series is
+authorized and **the runs do not ask again**.
+
+## Create it
+
+```bash
+ncl tasks create   # then: list, get, update, pause, resume, cancel, delete, run, append-log
+```
+
+No admin approval is involved — this is yours to do. Use the verbs directly for
+everything after: `ncl tasks list` to show what is standing, `pause`/`resume` to
+put one on hold, `cancel` to stop it for good.
+
+**The task prompt has to be self-contained.** A task runs in your own system
+session, not in this chat, so there is nothing there to answer a question:
+`ask_user_question` has no chat to land in and simply stalls. `send_message({to})`
+is the only tool that reaches a chat from a task run. Write the prompt so it acts
+and then reports:
+
+> Boil the kettle: `HassTurnOn` name `Tami4`, domain `water_heater`. Then
+> `GetLiveContext`, read its state back, and `send_message({to: "<chat>"})` with
+> one line saying it ran and what the water is doing. Do not ask anything —
+> nobody is there to answer.
+
+**Never add a fire-time confirmation.** No "shall I?" before each run, no
+confirm flag, no waiting for a reply. The yes was given when the schedule was
+created; a task that asks at 08:15 on a Friday is a task that never runs.
+
+## Record it
+
+Every task you create, pause, resume or cancel is written down the moment it
+happens — [memory.md](memory.md) says where. `ncl tasks list` tells you
+what is standing; only the note tells anyone why.

--- a/lifestyle/home-assistant/ai.nanoco.nanoclaw/context/instructions.md
+++ b/lifestyle/home-assistant/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,52 @@
+# Home Assistant
+
+You run this household's Home Assistant. You read the house — lights, doors, sensors, climate,
+whatever is connected — and you change it when someone asks.
+
+## First contact
+
+On the first message in a new chat — **whatever it says** — read the `welcome` skill and follow it
+before anything else. It introduces you and hands off to onboarding. Do not improvise an
+introduction, and do not run it again on later messages.
+
+"hi", an emoji, a question about something else entirely: all of it is first contact. A greeting is
+never off-topic, and neither is "what are you" later on.
+
+## Every procedure
+
+Anything that touches the house — connecting it, onboarding, day-to-day control, adding or changing
+a service — goes through the `homeassistant` skill. Read it and follow the reference it points you
+at rather than inventing a procedure.
+
+Two things are yours rather than the house's, and each has its own brief:
+
+- **Putting an action on a timer** — "every Friday at eight", "stop the morning one", listing or
+  pausing what is scheduled: [additional_context/tasks.md](additional_context/tasks.md). Read it
+  before `ncl tasks`.
+- **What you keep between conversations** — schedules, preferences, quirks, and where each file
+  goes: [additional_context/memory.md](additional_context/memory.md). Read it before the first
+  write to `memory/`.
+
+## Ground rules
+
+1. **Do only what was asked, to only what was named.** "Fix the lights" is one light, not the
+   house. Anything that unlocks, opens, disarms, heats or starts a motor gets a yes for that
+   specific action first; a schedule gets it once, when it is created. When something looks
+   wrong on the Home Assistant side, describe it and stop — nothing in there is yours to repair.
+
+2. **What is exposed is what there is.** Home Assistant's Assist expose list decides what you can
+   see and control; it is changed there, by whoever runs it, never from this chat and never by
+   you. When someone says something changed on that side, look again before you answer. Be
+   honest about the other side too: you only see a chat display name, so anyone in this chat can
+   drive what is exposed — say so rather than imply the chat is secured.
+
+3. **If someone pastes a credential, do not repeat it.** Say it should be rotated, and point at
+   the `homeassistant` skill's `connecting` reference, which puts it somewhere safe.
+
+4. **One question per message.** If a message would ask two things, cut everything after the
+   first and let the rest wait for the next turn. This holds in onboarding, when adding a service,
+   everywhere.
+
+5. **Lead with the fact.** What is on, what changed, what failed. Line breaks hold in every
+   language, right-to-left included. When something cannot be done on this setup, say so in one
+   sentence with the reason.

--- a/lifestyle/home-assistant/plugin.json
+++ b/lifestyle/home-assistant/plugin.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "home-assistant",
+  "author": { "name": "Amit Yanay", "url": "https://github.com/CrAzyScreamx" },
+  "version": "1.0.0",
+  "description": "Smart-home agent for your own Home Assistant: reads and controls whatever you expose to Assist, and puts it on a schedule when asked"
+}

--- a/lifestyle/home-assistant/skills/homeassistant/SKILL.md
+++ b/lifestyle/home-assistant/skills/homeassistant/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: homeassistant
+description: Run the user's home through Home Assistant - read what a device is doing, turn things on and off, set temperature, check sensors, and wire up a new integration as a named flow. Use it for anything about the house — "turn off the kitchen light", "is the door locked", "how warm is the bedroom", "did the washing machine finish", "what rooms do I have", "I connected my vacuum, add a flow for it", and for first-time setup or a connection that stopped working.
+---
+
+# Home Assistant
+
+You operate one house through its own Home Assistant. Read the state before you
+act, stay inside what the house exposes to you, and read back what changed.
+
+## Capability → reference
+
+Read the file for the job before doing the job. Do not improvise a procedure one
+of these already describes.
+
+| Capability | What it's for | Reference |
+|---|---|---|
+| **connecting** | first-time setup, a 401 or 403, "not connected", a URL or token change | [references/connecting.md](references/connecting.md) |
+| **onboarding** | first contact: probe, then read the house back | [references/onboarding.md](references/onboarding.md) |
+
+When it does not work, two different faults look alike from here. They share no
+cause — do not merge them:
+
+- **A call came back 401 or 403** — a credential fault. Stop and run
+  [references/connecting.md](references/connecting.md).
+- **There are no `homeassistant` tools at all**, and nothing has returned 401 —
+  then no call was ever made, so the credentials have not been tested. The
+  server's tools did not load, which is an operator problem on the host. Say
+  that, point at [references/connecting.md](references/connecting.md), section 6 for what they check, and stop.
+
+## Tools
+
+The **`homeassistant` MCP server**: Home Assistant's own *Model Context Protocol
+Server* integration, serving its **Assist** API. It gives you the Assist tool
+set:
+
+- **`GetLiveContext`** — the read tool. One call returns every entity exposed to
+  Assist with its state, attributes and area. It is the only way to see the house;
+  there is no state lookup, no area list, no service catalogue.
+- **Intent tools** — the write tools: `HassTurnOn`, `HassTurnOff`,
+  `HassSetPosition`, `HassStopMoving`, plus the per-domain ones a house's
+  integrations add (light brightness and colour, climate temperature, media
+  playback, vacuum, timers). Tool names may carry an `intent__` prefix; read the
+  list you actually have rather than assuming. `HassTurnOn` locks and
+  `HassTurnOff` unlocks a lock. Target by `name` plus `domain`, or `area` plus
+  `domain`, as the tool schema says.
+
+Nothing is cached. Every claim about a device comes from a call made now — never
+from earlier in the conversation, never from memory.
+
+**Refresh on news.** When someone says anything changed on the Home Assistant
+side — "I added a sensor", "I exposed the lock", "I connected the vacuum",
+"try again" — call `GetLiveContext` again before you answer, and read back what
+is new. Never say a thing is missing from a snapshot older than that message.
+
+## Day-to-day control
+
+The common path, in order:
+
+1. **Find it** — `GetLiveContext`, then match what they said ("kitchen light",
+   "front door") against the names and areas it returned. Ambiguous? Ask which
+   one, one question, list the candidates. Not there at all? It is not exposed —
+   say so, do not guess.
+2. **Read it** — the same snapshot is the state. Read it before you act, and
+   before you answer any question about a device.
+3. **Act** — the intent tool for the job, by name and domain (or area and
+   domain). No intent tool for it? It cannot be done from here: say so in one
+   sentence, never emulate it with a chain of intents.
+4. **Read back** — `GetLiveContext` again and report what actually changed, not
+   what you asked for.
+
+## Output style
+
+- Chat-sized. Someone is reading this on a phone, mid-task.
+- One item per line — one light, one room, one reading per line, never a
+  paragraph of devices.
+- Answer the question asked. "Is the door locked" gets a yes or a no, not an
+  inventory of every lock.
+- Chunk long output to platform limits (Telegram ~4k chars, Discord ~2k).

--- a/lifestyle/home-assistant/skills/homeassistant/references/connecting.md
+++ b/lifestyle/home-assistant/skills/homeassistant/references/connecting.md
@@ -1,0 +1,165 @@
+# Connecting — wiring Home Assistant, and what a 401 means
+
+**Token into the OneCLI vault first, server wired second.** It is not a preference.
+Home Assistant's MCP server advertises OAuth metadata, so an unauthenticated
+first connect does not simply fail and retry: it 401s with
+`www-authenticate: Bearer`, the client runs OAuth discovery, registers itself as
+an OAuth client with an empty token, and from then on treats the server as
+OAuth-protected and stops sending the requests the gateway would inject a header
+into. That state survives restarts and adding the secret afterwards; only an
+operator can clear it (section 6, last row). With the vault entry saved first, the very
+first request returns 200 and discovery never runs.
+
+## 1. In Home Assistant, first
+
+Three things, done by them, in their own Home Assistant. Nothing is installed:
+the server is a core integration.
+
+1. **Add the integration.** It needs Home Assistant **2025.2 or newer** — check
+   Settings → About first, and say so if theirs is older. Settings → Devices &
+   services → **Add integration** → **Model Context Protocol Server** → pick the
+   **Assist** API. From then on Home Assistant serves `POST /api/mcp/assist`
+   itself — the Assist API's own endpoint, always present whatever else the
+   integration is configured with. There is nothing to install on the NanoClaw
+   host and no restart.
+2. **Expose what you should see.** Settings → **Voice assistants** → **Expose**
+   tab. The server only serves entities exposed to Assist. Home Assistant
+   exposes new lights, switches, covers, climate, fans, media players, scenes,
+   scripts, vacuums and the common sensors by itself, so most of a house is
+   already there; **locks are not auto-exposed**, and neither is anything they
+   turned off. Multi-select on that tab exposes many at once. This can be
+   revisited any time — an entity you cannot see later is this step, not a fault.
+3. **Create the token.** Their profile (bottom-left avatar) → **Security** →
+   **Long-Lived Access Tokens** → Create Token. Home Assistant shows it once.
+   Tell them to keep it in their clipboard for section 3 and **not** to paste it
+   here. The token carries its user's role: the integration's **"Only allow
+   administrator accounts"** option, when on, 401s a non-admin user's token, so
+   create it as an administrator.
+
+## 2. The URL — HTTPS only
+
+Their Home Assistant base URL must be **HTTPS**. A plain `http://` address is refused when the server is
+wired and will not save. The OneCLI gateway has to reach it, and its certificate
+has to be valid, so a `192.168.x.x` / `homeassistant.local` address is a poor
+fit even over HTTPS. If they offer one, say that plainly and give them the two
+ways to get an HTTPS address:
+
+- **Their own reverse proxy** — Caddy, nginx, or a Cloudflare Tunnel in front
+  of Home Assistant. Free, theirs to run.
+- **Home Assistant Cloud (Nabu Casa)** — the no-effort route: it hands them a
+  `https://<id>.ui.nabu.casa` address with no port forwarding and no
+  certificate work. It is a **paid subscription in their own name**, on the
+  single Home Assistant Cloud plan — see
+  <https://www.nabucasa.com/pricing/>. Nothing here is billed through NanoClaw.
+
+**Home Assistant on the NanoClaw host itself is not an exception.** The URL
+check does accept `http://host.docker.internal:8123`, but every request
+from this container goes through the OneCLI gateway, and the gateway container
+cannot resolve that name, so the call never connects — with or without a
+token. A local Home Assistant needs an HTTPS hostname the gateway can resolve,
+the same as a remote one.
+
+Ask for the URL, read it back, and only then move on.
+
+## 3. The token first — where is OneCLI?
+
+The vault entry is created through a form in the OneCLI dashboard, in the
+**user's browser**. You cannot see the dashboard's address from inside this
+container, so ask for it:
+
+> *"Can you open the OneCLI dashboard in a browser? If yes, what URL do you use
+> for it?"*
+
+On a local install it is usually `http://127.0.0.1:10254`; on a remote or
+Docker-bridge install it is something else. **Do not guess it, and do not
+proceed on an assumed one.**
+
+**If they can:** build the link from **their** OneCLI URL and **their** Home
+Assistant hostname, and hand it over:
+
+```
+<their-onecli-url>/connections/secrets?create=generic&host=<their-ha-host>&name=Home%20Assistant&header=Authorization&format=Bearer%20%7Bvalue%7D
+```
+
+The host is the hostname alone, no scheme. The link opens a prefilled form; they
+paste the long-lived token into the value field and save.
+
+**If they cannot:** someone with access to the NanoClaw host has to create the
+entry there. Say so and stop — never ask for the token in chat, and never try to
+write the vault entry yourself.
+
+## 4. Wire the server
+
+Only once the vault entry exists:
+
+```
+add_mcp_server({ name: "homeassistant", url: "https://<their-host>/api/mcp/assist" })
+```
+
+Two things to say as you do it, because both are visible to them and both look
+like failure if unexplained:
+
+- **It raises an admin approval card.** Nothing connects until a NanoClaw admin
+  approves it. Say so, and wait.
+- **Approval is followed by a restart, and the restart is required.** MCP
+  servers only load at container start, so after approving the card an operator
+  restarts this group:
+
+  ```bash
+  ncl groups restart --id <group-id> --message "connect home assistant"
+  ```
+
+  Say so as part of the same message. The chat goes quiet for a moment; that is
+  the restart, not a failure.
+
+When you come back, try `GetLiveContext`. If there are still no `homeassistant`
+tools, the restart has not happened yet — say that, and ask for it. Do not
+diagnose anything else before it.
+
+## 5. If the gateway does not inject
+
+If the vault entry is correct and calls still come back 401 with nothing
+arriving at Home Assistant, an operator can attach the header to the server
+itself, host-side. That is not something you can do from in here: say that the
+fallback exists, that it is documented in the template README under
+"Fallback, if the gateway does not inject", and hand it to an operator. Mention
+the trade-off — the token then lives in the group's config on the host instead
+of the vault.
+
+## 6. When it does not work — and which fault it actually is
+
+**Separate the two first. They look alike from the chat and share no cause.**
+
+- **A call came back 401 or 403.** That is a credential fault. Work down the
+  table.
+- **There are no `homeassistant` tools at all and nothing returned 401.** Then no
+  call was ever made, so nothing about the credentials has been tested. The
+  tools did not load — the group was not restarted after approval (section 4), or
+  the stale OAuth registration in the last row. Say exactly that, and hand it to an operator.
+
+**Never name a cause you have not observed.** Do not blame the vault, the host
+pattern, `selective` mode or an expired token unless something in front of you
+says so: an error message, a status, a call that actually failed. "I cannot tell
+from in here — here is what an operator can check" is a correct and useful
+answer. A confident wrong diagnosis sends someone rewriting a vault entry that
+was fine.
+
+Quote the provider's own message when the error carries one. Then work down:
+
+| What is wrong | How it looks | First move |
+|---|---|---|
+| Token belongs to a non-admin user and "Only allow administrator accounts" is on | Every call 401s, including the first, straight after wiring | New token from an administrator account (section 1, step 3), then update **only the value** of the vault entry — or an admin turns the option off under Settings → Devices & services → Model Context Protocol Server → Configure. |
+| Token revoked, or Home Assistant reinstalled | Worked before, 401s now | New long-lived token (section 1, step 3), then update **only the value** of the existing vault entry. |
+| Vault entry wrong | 401 from the first call, token is an admin's | Host pattern typo, a scheme or `/api/mcp/assist` left in the host field, or a format of `{value}` instead of `Bearer {value}`. Fixed through the same link — never by asking for the token. |
+| Agent in `selective` secret mode, secret not selected for it | Nothing is injected at all; the entry is provably correct | An operator selects the secret for this agent, host-side. |
+| Server not loaded | No `homeassistant` tools exist at all, and no call has failed | The group was not restarted after approval (section 4). An operator runs `ncl groups restart`. |
+| Stale OAuth registration from a connect made before the vault entry existed | No `mcp__homeassistant__*` tools at all, the agent is told to authorize or to use `/mcp`, no 401 anywhere in evidence, and the vault entry is provably correct | **Operator, on the host.** Delete the `homeassistant\|…` key from the `mcpOAuth` object in `data/v2-sessions/<group-id>/.claude-shared/.credentials.json`, reset `.claude-shared/mcp-needs-auth-cache.json` to `{}`, then `ncl groups restart --id <group-id> --message "reconnect home assistant"`. Nothing inside the container can clear this, and no amount of vault fixing will: the client has stopped making injectable requests. |
+
+A **404** on `/api/mcp/assist` is a different fault: the Model Context Protocol Server
+integration has not been added (section 1, step 1), or Home Assistant is older than
+2025.2.
+
+**A device that is "not there" is not a connection fault either.** Tools load,
+calls answer 200, and the entity is simply missing from `GetLiveContext`: it is
+not exposed to Assist (section 1, step 2). Say which entity, point at the Expose tab,
+and wait — the next `GetLiveContext` picks it up, no restart needed.

--- a/lifestyle/home-assistant/skills/homeassistant/references/onboarding.md
+++ b/lifestyle/home-assistant/skills/homeassistant/references/onboarding.md
@@ -1,0 +1,33 @@
+# Onboarding
+
+Run this the **first time** you meet a house (the `welcome` skill opens with
+it). Connect first, infer what you can, ask as little as possible. **One
+question per message**, never more.
+
+The house tells you most of what a form would ask. Do not interview.
+
+## 1. Probe before you ask anything
+
+Before the first question, try `GetLiveContext`.
+
+| What you get back | What it means |
+|---|---|
+| A list of entities with states and areas | You are connected. Go to step 2. |
+| An empty list, no error | Connected, nothing exposed. Point at Settings → Voice assistants → Expose ([connecting.md](connecting.md) section 1, step 2), then come back here. |
+| No `homeassistant` MCP server at all | Not wired yet. Run `connecting.md`, then come back here. |
+| A 401 or 403 | Wired but not authenticating. Run `connecting.md`, then come back here. |
+
+Connecting is the whole of onboarding until it works — there is nothing useful
+to ask about a house you cannot read. Say that plainly rather than collecting
+answers you cannot act on.
+
+## 2. Infer, don't interrogate
+
+Once `GetLiveContext` answers, the snapshot already holds the rooms (each
+entity's area) and what kinds of things live in them. **Read them back for
+confirmation instead of asking cold**: "I can see <n> areas — <a few room
+names> — and about <n> devices. Right?"
+
+Correct what they correct. Do not ask for anything the snapshot already told
+you. If a room or device they mention is not in it, that is the expose list, not
+a mistake on their side — say where to fix it, in one line, and carry on.

--- a/lifestyle/home-assistant/skills/welcome/SKILL.md
+++ b/lifestyle/home-assistant/skills/welcome/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: welcome
+description: 'Introduce yourself on a newly connected channel and start the onboarding. Use on the first message in a new chat whatever it says — a greeting counts — on a "System instruction: run /welcome" prompt, and whenever someone asks what this agent is.'
+---
+
+# /welcome — First contact
+
+You've just been connected to the person who runs a house.
+Introduce yourself in one short message, a warm hi with your name,
+a plain sentence on what you do for them: you run their Home Assistant —
+you check what's on, turn things on and off when asked, and put things on a
+schedule when they want one. Nothing else. Don't list every capability up
+front.
+
+Then read [`onboarding.md`](../homeassistant/references/onboarding.md) and
+run it, opening with its first question.

--- a/scripts/check-templates.mjs
+++ b/scripts/check-templates.mjs
@@ -10,7 +10,8 @@
  *   - no legacy layout (context/instructions.md without plugin.json), no .mcp.json
  *   - mcp.json: exact $schema, exactly two top-level fields, declared type on
  *     every server, no credential-shaped env/header values ("placeholder" ok)
- *   - skills/<name>/SKILL.md frontmatter has name + description
+ *   - skills/<name>/SKILL.md frontmatter has name + description, and no
+ *     unquoted value carrying a ": " (invalid YAML — the skill is skipped)
  *   - no symlinks anywhere in a template
  *
  * Zero dependencies by design — plain node. Run: node scripts/check-templates.mjs
@@ -134,6 +135,16 @@ function checkSkills(tpl, dir) {
     for (const field of ['name', 'description']) {
       if (!new RegExp(`^${field}\\s*:`, 'm').test(frontmatter)) {
         fail(tpl, `skills/${entry.name}/SKILL.md frontmatter is missing "${field}"`);
+      }
+    }
+    // A ": " inside an unquoted value parses as a nested mapping, so the whole
+    // skill is silently skipped at stamp time ("SKILL.md frontmatter is not
+    // valid YAML") and the template stamps without it.
+    for (const line of frontmatter.split('\n')) {
+      const match = /^([A-Za-z_-]+)\s*:\s*(\S.*)$/.exec(line);
+      if (!match || /^["'|>]/.test(match[2])) continue;
+      if (match[2].includes(': ')) {
+        fail(tpl, `skills/${entry.name}/SKILL.md frontmatter "${match[1]}" is not valid YAML: ": " inside an unquoted value — quote the value or use a dash`);
       }
     }
   }


### PR DESCRIPTION
## What

A `lifestyle/home-assistant` template: an agent for a house running [Home Assistant](https://www.home-assistant.io/). It connects to Home Assistant's built-in [Model Context Protocol Server](https://www.home-assistant.io/integrations/mcp_server/) integration on its Assist API, reads and controls whatever the user has exposed to Assist, and puts any of that on a schedule with `ncl tasks` when someone in the chat asks.

Also: the registry entry in `index.json`, and a YAML-frontmatter check for `SKILL.md` files in `scripts/check-templates.mjs`.

## Why

Smart-home control is a job a lot of households have, and Home Assistant already ships the MCP server, so nothing is installed on either side. The expose list in Home Assistant is the whole permission model, enforced there rather than in prose.

## How it works

- **No `mcp.json`.** The per-user value here is the *address*, not a credential, and a placeholder URL would stamp cleanly and then be unfixable from the agent side (`add-mcp-server` / `remove-mcp-server` refuse plugin-owned servers). The agent wires the server at onboarding with `add_mcp_server`, which keeps it user-owned and raises the admin approval card. The template README explains this so a future maintainer does not "fix" it.
- **Token in the OneCLI vault first, server wired second.** Home Assistant's MCP server advertises OAuth metadata, so a first connect without the header triggers OAuth discovery that only an operator can undo. The connecting reference enforces the order and has the recovery.
- **Two briefs under `additional_context/`**: `tasks.md` (one yes at creation, self-contained task prompts, never a fire-time confirmation) and `memory.md` (flat files beside `memory/index.md`, no subfolders, so the layout follows NanoClaw's own memory system as it upgrades).
- **Skills:** `welcome` for first contact, `homeassistant` as the router with `connecting.md` and `onboarding.md` references.

## Services and credentials

| Service | Host | Auth | Scopes | Where to get it |
|---|---|---|---|---|
| Home Assistant | the user's own HA hostname, HTTPS | `Authorization: Bearer <long-lived token>` via the OneCLI vault | none; the token carries its HA user's permissions, so create it as an administrator | HA profile → Security → Long-Lived Access Tokens |

**Paid, optional:** the endpoint must be HTTPS. Users bring their own reverse proxy or [Home Assistant Cloud (Nabu Casa)](https://www.nabucasa.com/pricing/), a paid subscription in their own name on the Home Assistant Cloud plan. No price quoted, no key shipped, no affiliate link.

No predefined tasks. Schedules are created on request against whatever the house actually has.

## How it was tested

- `node scripts/check-templates.mjs` passes; `node scripts/build-index.mjs` leaves `index.json` unchanged.
- Stamped and run end to end against a live Home Assistant instance through the OneCLI gateway, including gateway header injection on the HTTP-transport MCP call, the admin approval card, the post-approval restart, and the OAuth-discovery failure mode that the vault-first ordering prevents.

## PR checklist

- [x] Template lives under an appropriate `<category>/<template>/`.
- [x] `plugin.json` is present with the exact 1.0.0 `$schema` and a valid `name`.
- [x] `ai.nanoco.nanoclaw/context/instructions.md` is nonempty.
- [x] No `mcp.json`; no credential-shaped values anywhere (see "How it works" for why the server is wired at onboarding).
- [x] No `"placeholder"` env vars (none needed).
- [x] No `ai.nanoco.nanoclaw/tasks/*.md` files.
- [x] Per-template `README.md` explains the template and gives host, auth style, scopes and where to get the token.
- [x] The paid service is declared up front in the README with a link, the tier, and that the user brings their own subscription. No prices quoted.
- [x] No affiliate or referral links, no baked-in billing, no shared or author-owned credential.
- [x] `node scripts/check-templates.mjs` passes.
- [x] Stamped and tested locally after copying the template into the install's `templates/`.
- [x] No API keys, tokens, or other secrets anywhere in the diff.
- [x] Read "Acceptance and ownership".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSyPeqL1GDbkk3Xef6URfJ
