### PR TITLE
Add checkin-companion template (lifestyle/, Dial track)

### DIFF
--- a/index.json
+++ b/index.json
@@ -11,6 +11,12 @@
     ],
     "lifestyle": [
       {
+        "ref": "lifestyle/checkin-companion",
+        "name": "checkin-companion",
+        "version": "1.0.0",
+        "description": "A best-effort check-in convenience tool: schedules periodic check-ins, calls you if you miss a few, and calls a named emergency contact if you still don't respond. Not a safety-critical system - see README."
+      },
+      {
         "ref": "lifestyle/family-assistant",
         "name": "family-assistant",
         "version": "1.0.0",

--- a/lifestyle/checkin-companion/README.md
+++ b/lifestyle/checkin-companion/README.md
@@ -1,0 +1,105 @@
+# Check-In Companion
+
+A NanoClaw agent template that schedules periodic check-ins, calls you
+if you miss a few, and calls a named emergency contact if you still
+don't respond. Built for the
+[NanoClaw Agent Templates Hackathon](https://nanoclaw.dev/hackathon)
+(Sep 4-6, 2026).
+
+## What this is - and what it is not
+
+**Read this before using it for anything that actually matters.**
+
+This is a best-effort check-in convenience tool. It is **not** a
+safety-critical system, and it should never be relied on as one:
+
+- It runs on your own personal NanoClaw install, on your own computer.
+  If that machine is asleep, offline, or the NanoClaw service has
+  restarted, check-ins **will not fire**. There is no redundancy, no
+  uptime guarantee, no monitoring of the service itself.
+- Task scheduling in NanoClaw has real-world latency - pickup and
+  execution can take anywhere from tens of seconds to several minutes
+  depending on host state. This is not a sub-minute-reliable system.
+- **If you feel unsafe right now, contact emergency services directly**
+  (100/101 in Israel, or your local equivalent). Do not wait for or
+  rely on this bot in that moment.
+
+This template generalizes beyond any single scenario - a date, a solo
+hike, walking home alone, checking on a relative living alone. The
+mechanic is the same regardless of why you started a session.
+
+## What it does
+
+1. **Start a session**: tell it your check-in window, interval, and an
+   emergency contact's name and phone number. It confirms back with
+   the full safety disclaimer above, every time - not just once.
+2. **Check-in loop**: on your interval, it messages "you OK? reply to
+   confirm." Any reply resets the miss count.
+3. **Escalation**: miss a few (default 3) and it places a real phone
+   call to you asking you to confirm. Still nothing after one more
+   interval, and it calls your emergency contact - worded as "hasn't
+   confirmed after multiple attempts, not a confirmed emergency, please
+   try to reach them," never claiming certainty about what's actually
+   happening.
+4. **End any time**: say "I'm home" (or similar) and everything stops
+   immediately, no friction, no confirmation step required.
+
+## Required service and credentials
+
+### Dial (required) - paid service
+
+Both the check-in call and the emergency-contact call go through
+[Dial](https://getdial.ai), which needs a registered, OTP-verified
+phone number **to call from** (`DIAL_FROM_NUMBER`) - Dial's API
+rejects calls with no `fromNumber` set, there is no account-level
+default.
+
+**Paid service - bring your own account:**
+- See [Dial's pricing](https://getdial.ai/pricing) for current plans;
+  this needs at least one phone number on either the flat-rate or
+  metered/pay-as-you-go plan
+- No sandbox/test mode exists - testing this uses your real account
+  balance
+
+`mcp.json`'s `checkin-dial` server is a small custom script
+(`scripts/checkin-call.mjs`), not Dial's own packaged MCP server -
+Dial's own server authenticates from an interactive local session file
+or OAuth, neither of which support NanoClaw's headless,
+env-var-injected credential model. See the comment at the top of that
+file for the full explanation, and `scripts/stdio-mcp.mjs` for why it's
+hand-rolled rather than using `@modelcontextprotocol/sdk` (a stamped
+plugin directory has no `node_modules`).
+
+Unlike a typical template, the call **destination** is not fixed at
+stamp time - who gets called varies per session (your own number for
+the miss-escalation call, your chosen emergency contact for the final
+escalation), so those are captured in chat at session-setup time, not
+baked into `mcp.json`.
+
+## Tuning
+
+Default miss threshold before the first escalation call is 3; default
+check-in interval is 30 minutes if not specified. Both are set per
+session at setup, not as fixed template config - just tell the agent
+different numbers when starting a session.
+
+## Local testing
+
+```bash
+mkdir -p <nanoclaw>/templates/lifestyle
+cp -R . <nanoclaw>/templates/lifestyle/checkin-companion
+ncl groups create --template lifestyle/checkin-companion --name "Test"
+ncl tasks list --status paused
+ncl tasks run <task-id>
+ncl groups delete --id <agent-group-id>
+```
+
+Check the `templateReport` in the creation response for any skipped
+components before relying on a run.
+
+## Scope and safety
+
+Advisory and coordination only. This agent never gives personal safety
+judgment calls - it states facts (confirmed / not confirmed after N
+attempts) and always defers to real emergency services and the
+recipient's own judgment for anything beyond that.

--- a/lifestyle/checkin-companion/ai.nanoco.nanoclaw/context/instructions.md
+++ b/lifestyle/checkin-companion/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,51 @@
+# Check-In Companion
+
+You run scheduled check-ins for one person at a time and escalate
+through phone calls if they miss a few. You generalize beyond any one
+scenario - a date, a solo hike, walking home alone, checking on a
+relative - the mechanic is the same regardless of why someone started
+a session.
+
+## What you are not - read this before doing anything else
+
+You are a best-effort convenience check-in tool, not a safety-critical
+system. You run on someone's personal computer; if it's asleep,
+offline, or the service has restarted, check-ins will not fire. Never
+let a user believe otherwise. Every session-start confirmation
+includes the full disclaimer from `checkin-setup` verbatim - never
+paraphrase it shorter, never drop it because it feels repetitive.
+
+If someone tells you they feel unsafe right now, your answer is always
+the same: tell them to contact emergency services directly (100/101 in
+Israel, or the local equivalent) - never position yourself as an
+alternative to that, even implicitly.
+
+## Escalation discipline
+
+- The emergency-contact call is a real phone ringing for a real person
+  who will worry. Never place it before the full miss sequence in
+  `checkin-cycle` has actually played out - no shortcuts, no "seems
+  urgent so let's skip ahead."
+- Never claim certainty about what's happening to the person you're
+  checking on. "Hasn't confirmed after multiple attempts" is a fact you
+  can state. "Something is wrong" is not - you don't know that, and
+  saying it as if you do could either cause unnecessary panic or, worse,
+  train people to distrust your alerts as overblown.
+- A reply from the user at any point - even mid-escalation - resets
+  everything. Never place a call that a reply already made unnecessary.
+
+## Working with sessions
+
+- One active session at a time. `checkin-setup` handles starting one,
+  `checkin-cycle` handles the recurring loop, `checkin-end` handles
+  stopping - always immediately, no friction, whenever asked.
+- Session state lives in `/workspace/agent/memory/checkin-session.json`.
+  Read it fresh every time - don't assume state from earlier in a
+  conversation still matches what's on disk.
+
+## Tone
+
+Warm but not chatty during setup and confirmations. Terse and factual
+during check-in messages themselves - "Checking in - you OK?" not a
+paragraph. This runs during someone's actual evening; don't make it a
+production.

--- a/lifestyle/checkin-companion/ai.nanoco.nanoclaw/tasks/checkin-poll.md
+++ b/lifestyle/checkin-companion/ai.nanoco.nanoclaw/tasks/checkin-poll.md
@@ -1,0 +1,28 @@
+---
+schedule: "*/10 * * * *"
+script: |
+  node -e '
+  const fs = require("fs");
+  const path = "/workspace/agent/memory/checkin-session.json";
+  function wake(v) { console.log(JSON.stringify({ wakeAgent: v })); }
+  if (!fs.existsSync(path)) { wake(false); process.exit(0); }
+  let s;
+  try { s = JSON.parse(fs.readFileSync(path, "utf8")); }
+  catch { wake(false); process.exit(0); }
+  if (!s.active) { wake(false); process.exit(0); }
+  const now = Date.now();
+  const end = new Date(s.endTime).getTime();
+  if (Number.isNaN(end) || now >= end) { wake(true); process.exit(0); }
+  const last = s.lastCheckinSentAt ? new Date(s.lastCheckinSentAt).getTime() : 0;
+  const intervalMs = (s.intervalMinutes || 30) * 60 * 1000;
+  wake((now - last) >= intervalMs);
+  '
+---
+
+Run the checkin-cycle skill. This task fires every 10 minutes but the
+pre-check script above only wakes you when there is an active session
+AND either the check-in interval has elapsed or the session's end time
+has passed - it reads /workspace/agent/memory/checkin-session.json
+directly and does pure time math, no LLM involvement, so the common
+case (no active session) costs nothing. Follow checkin-cycle's
+escalation discipline exactly - at most one action per wake.

--- a/lifestyle/checkin-companion/mcp.json
+++ b/lifestyle/checkin-companion/mcp.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "checkin-dial": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./scripts/checkin-call.mjs"],
+      "env": {
+        "DIAL_API_KEY": "placeholder",
+        "DIAL_FROM_NUMBER": "placeholder"
+      }
+    }
+  }
+}

--- a/lifestyle/checkin-companion/plugin.json
+++ b/lifestyle/checkin-companion/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "checkin-companion",
+  "version": "1.0.0",
+  "description": "A best-effort check-in convenience tool: schedules periodic check-ins, calls you if you miss a few, and calls a named emergency contact if you still don't respond. Not a safety-critical system - see README.",
+  "homepage": "https://github.com/adamorad/checkin-companion",
+  "repository": "https://github.com/adamorad/checkin-companion",
+  "license": "MIT",
+  "author": {
+    "name": "Adam Morad",
+    "email": "adammor17@gmail.com",
+    "url": "https://github.com/adamorad"
+  },
+  "keywords": ["safety", "checkin", "dial", "lifestyle", "reminders"],
+  "extensions": {
+    "ai.nanoco.nanoclaw": {
+      "agentName": "Check-In Companion"
+    }
+  }
+}

--- a/lifestyle/checkin-companion/scripts/checkin-call.mjs
+++ b/lifestyle/checkin-companion/scripts/checkin-call.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// Minimal stdio MCP server exposing one tool: place_checkin_call.
+//
+// Adapted from finops-cost-sentinel's scripts/dial-call.mjs - same auth
+// model (Bearer token to api.getdial.ai, vault-injected via the
+// "placeholder" convention; see requireEnv below for why "placeholder"
+// is NOT rejected here), same hand-rolled stdio-mcp.mjs helper instead of
+// @modelcontextprotocol/sdk (a stamped plugin directory has no
+// node_modules - see stdio-mcp.mjs's header).
+//
+// Real difference from Cost Sentinel's dial-call.mjs: there the alert
+// destination was fixed at template-stamp time (DIAL_ALERT_PHONE_NUMBER
+// env var). Here, WHO gets called varies per check-in session - a user
+// might set up check-ins for a date one night and a solo hike the next,
+// each with a different emergency contact. So `to` is a call-time tool
+// argument, not a fixed env var. Only DIAL_API_KEY and DIAL_FROM_NUMBER
+// (the account's own caller-ID number) are fixed per deployment.
+//
+// NOTE: written from Dial's published API reference, same as Cost
+// Sentinel's version. Not yet run against a live account - verify before
+// relying on it.
+
+import { runStdioMcpServer } from "./stdio-mcp.mjs";
+
+const DIAL_API_BASE = "https://api.getdial.ai/api/v1";
+const POLL_INTERVAL_MS = 3000;
+const POLL_TIMEOUT_MS = 120_000;
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not set - export a real value for testing.`);
+  }
+  // Deliberately NOT rejecting "placeholder" - the vault rewrites this on
+  // the wire, not before this process reads it. See dial-call.mjs in
+  // finops-cost-sentinel for the full explanation of why.
+  return value;
+}
+
+function isValidE164(value) {
+  return /^\+[1-9]\d{6,14}$/.test(value);
+}
+
+async function placeCheckinCall(to, message) {
+  const apiKey = requireEnv("DIAL_API_KEY");
+  const fromNumber = requireEnv("DIAL_FROM_NUMBER");
+
+  if (!isValidE164(to)) {
+    throw new Error(
+      `"to" must be a phone number in E.164 format (e.g. +14155551234), got: ${to}`,
+    );
+  }
+
+  const createResp = await fetch(`${DIAL_API_BASE}/calls`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      to,
+      fromNumber,
+      outboundInstruction:
+        `Read this message clearly, then stop: "${message}"`,
+      maxCallDurationSeconds: 90,
+    }),
+  });
+
+  if (!createResp.ok) {
+    const body = await createResp.text().catch(() => "");
+    throw new Error(`Dial call creation failed: ${createResp.status} ${body}`);
+  }
+
+  const { call } = await createResp.json();
+  const callId = call.id;
+
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  let lastStatus = call.status;
+  let transcript = call.transcript ?? null;
+
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
+    const pollResp = await fetch(`${DIAL_API_BASE}/calls/${callId}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (!pollResp.ok) continue;
+
+    const polled = await pollResp.json();
+    lastStatus = polled.call?.status ?? lastStatus;
+    transcript = polled.call?.transcript ?? transcript;
+
+    const terminal = ["completed", "failed", "no-answer", "busy"];
+    if (terminal.includes(lastStatus)) break;
+  }
+
+  return {
+    outcome: lastStatus,
+    transcriptSummary: transcript ?? "(no transcript received within timeout)",
+    callId,
+  };
+}
+
+runStdioMcpServer({
+  name: "checkin-dial",
+  version: "1.0.0",
+  tools: [
+    {
+      name: "place_checkin_call",
+      description:
+        "Places a voice call to a given phone number to read out a short " +
+        "message. Used for check-in confirmation calls (call the user) and " +
+        "emergency-contact escalation calls - the destination is always an " +
+        "explicit argument, never assumed.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          to: {
+            type: "string",
+            description: "Destination phone number, E.164 format (e.g. +14155551234).",
+          },
+          message: {
+            type: "string",
+            description: "Short spoken message (2-3 sentences) - will be read aloud verbatim.",
+          },
+        },
+        required: ["to", "message"],
+      },
+    },
+  ],
+  async callTool(name, args) {
+    if (name !== "place_checkin_call") {
+      throw new Error(`Unknown tool: ${name}`);
+    }
+    const { to, message } = args;
+    if (!to || typeof to !== "string") {
+      throw new Error("`to` is required and must be a string.");
+    }
+    if (!message || typeof message !== "string") {
+      throw new Error("`message` is required and must be a string.");
+    }
+    return placeCheckinCall(to, message);
+  },
+});

--- a/lifestyle/checkin-companion/scripts/stdio-mcp.mjs
+++ b/lifestyle/checkin-companion/scripts/stdio-mcp.mjs
@@ -1,0 +1,83 @@
+// Minimal, zero-dependency stdio MCP JSON-RPC server helper.
+//
+// Deliberately not using @modelcontextprotocol/sdk: a stamped template's
+// plugin directory is a plain file copy - no `npm install` (or `pnpm`/`bun`
+// equivalent) ever runs against it, so any script here that imports a
+// non-builtin package fails with ERR_MODULE_NOT_FOUND at spawn time. This
+// mirrors the same choice already made in proxy/src/worker.js, just over
+// stdio instead of HTTP. Node built-ins only.
+//
+// Wire format: one JSON-RPC 2.0 message per line on stdin, one per line on
+// stdout for responses. Notifications (no `id`) get no response.
+
+import { createInterface } from "node:readline";
+
+export function runStdioMcpServer({ name, version, tools, callTool }) {
+  const rl = createInterface({ input: process.stdin, terminal: false });
+
+  function send(obj) {
+    process.stdout.write(`${JSON.stringify(obj)}\n`);
+  }
+
+  rl.on("line", async (rawLine) => {
+    const line = rawLine.trim();
+    if (!line) return;
+
+    let req;
+    try {
+      req = JSON.parse(line);
+    } catch {
+      send({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } });
+      return;
+    }
+
+    const { method, id, params } = req;
+
+    if (method === "initialize") {
+      send({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          protocolVersion: "2025-06-18",
+          capabilities: { tools: {} },
+          serverInfo: { name, version },
+        },
+      });
+      return;
+    }
+
+    if (method === "notifications/initialized") {
+      return;
+    }
+
+    if (method === "tools/list") {
+      send({ jsonrpc: "2.0", id, result: { tools } });
+      return;
+    }
+
+    if (method === "tools/call") {
+      try {
+        const result = await callTool(params?.name, params?.arguments ?? {});
+        send({
+          jsonrpc: "2.0",
+          id,
+          result: { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] },
+        });
+      } catch (err) {
+        send({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            content: [{ type: "text", text: `Error: ${err.message}` }],
+            isError: true,
+          },
+        });
+      }
+      return;
+    }
+
+    if (id !== undefined && id !== null) {
+      send({ jsonrpc: "2.0", id, error: { code: -32601, message: `Method not found: ${method}` } });
+    }
+  });
+}

--- a/lifestyle/checkin-companion/skills/checkin-cycle/SKILL.md
+++ b/lifestyle/checkin-companion/skills/checkin-cycle/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: checkin-cycle
+description: The core check-in loop - decides whether to send a check-in, resend, escalate to calling the user, or escalate to calling the emergency contact, based on session state in memory.
+---
+
+# Check-In Cycle
+
+## Purpose
+
+Runs every time the `checkin-poll` task wakes the agent. Reads session
+state, decides the one right action, updates state, never does more
+than one escalation step per wake.
+
+## Procedure
+
+1. Read `/workspace/agent/memory/checkin-session.json`. If no active
+   session (`active: false` or file missing), do nothing - no message,
+   no call. This is the common case; most wakes should be silent.
+2. If `endTime` has passed, mark the session inactive and send one
+   final "Check-in window ended, hope you had a good time!" message.
+   No further action.
+3. If it's been at least `intervalMinutes` since `lastCheckinSentAt`
+   (or a prior check-in is still unconfirmed), determine the miss
+   count and act on exactly one of:
+   - **First 1-2 misses**: resend "Checking in - you OK? Reply to
+     confirm." Increment `missCount`. Update `lastCheckinSentAt`.
+   - **3rd miss** (configurable, default 3): call `place_checkin_call`
+     with `to` = the stored `userPhoneNumber`. Message: "This is your
+     check-in companion -
+     please reply to confirm you're OK, or I'll contact [contact
+     name]." Record `escalatedToUserCallAt`.
+   - **After the user-call escalation, still no reply within one more
+     interval**: escalate to the emergency contact. Call
+     `place_checkin_call` with the stored `emergencyContactNumber`.
+     Message must match this shape exactly - never claim certainty:
+     "This is an automated check-in alert. [User] set a check-in and
+     hasn't confirmed after multiple attempts as of [time]. This is
+     not a confirmed emergency - please try to reach them and use your
+     own judgment." Record `escalatedToContactAt`, then mark the
+     session inactive - do not keep escalating after the contact call.
+4. Any reply from the user at any point resets `missCount` to 0 and
+   clears the escalation timestamps - a confirmed reply always wins
+   over an in-progress escalation.
+
+## Output
+
+At most one message or one call per wake. Silence is the correct,
+common outcome.

--- a/lifestyle/checkin-companion/skills/checkin-end/SKILL.md
+++ b/lifestyle/checkin-companion/skills/checkin-end/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: checkin-end
+description: Ends an active check-in session immediately on request - a session that can't be cleanly cancelled is worse than useless.
+---
+
+# Check-In End
+
+## Purpose
+
+Let the user stop an active session at any time ("I'm home", "cancel
+the check-in", "I'm fine, stop checking"), with no further messages or
+calls afterward.
+
+## Procedure
+
+1. Read `/workspace/agent/memory/checkin-session.json`.
+2. If no active session, say so plainly - nothing to end.
+3. If active, set `active: false`, clear `missCount` and the
+   escalation timestamps, and confirm: "Check-in ended. Glad you're
+   safe." Do not require any justification or confirmation step first -
+   ending must be immediate and unconditional whenever asked.
+
+## Output
+
+One confirmation message. No further check-in activity for this
+session after this point - `checkin-cycle` reads `active: false` and
+does nothing on future wakes.

--- a/lifestyle/checkin-companion/skills/checkin-setup/SKILL.md
+++ b/lifestyle/checkin-companion/skills/checkin-setup/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: checkin-setup
+description: Starts a new check-in session from a natural-language request - parses the window, interval, and emergency contact, confirms with the required safety disclaimer, and stores session state in memory.
+---
+
+# Check-In Setup
+
+## Purpose
+
+Turn a request like "I'm on a date until 9, check on me every 30 min,
+call Danny at +972... if I don't respond" into a stored, active
+check-in session.
+
+## Procedure
+
+1. Extract from the request: end time (or duration), check-in interval
+   (default 30 minutes if not stated), and the emergency contact's name
+   + phone number in E.164 format. **Also ask for the user's own phone
+   number** (E.164) if this session isn't wired to a channel where the
+   platform identity already is one (WhatsApp's platform ID is a phone
+   number; Telegram's is not) - the miss-escalation call needs a real
+   number to call, and it must never be guessed or left unset. If any
+   phone number isn't in E.164 format, ask for it in that format before
+   proceeding - never guess a country code.
+2. Only one active check-in session at a time. If one is already
+   active, tell the user and ask whether to end it first
+   (`checkin-end`) or that this new request replaces it.
+3. Write session state to `/workspace/agent/memory/checkin-session.json`:
+   ```json
+   {
+     "active": true,
+     "endTime": "<ISO 8601>",
+     "intervalMinutes": 30,
+     "userPhoneNumber": "+972...",
+     "emergencyContactName": "Danny",
+     "emergencyContactNumber": "+972...",
+     "missCount": 0,
+     "lastCheckinSentAt": null,
+     "escalatedToUserCallAt": null,
+     "escalatedToContactAt": null
+   }
+   ```
+   `userPhoneNumber` is required, not optional - `checkin-cycle` cannot
+   place the miss-escalation call without it, so do not write the
+   session file until it's captured.
+4. Confirm back to the user, **including this exact disclaimer** (not
+   paraphrased, not shortened):
+
+   > "Check-in started until [end time], every [interval] minutes.
+   > I'll call you if you miss a few, and call [contact name] if you
+   > still don't respond. This is a best-effort convenience check-in,
+   > not a safety-critical system - if you feel unsafe right now, call
+   > emergency services directly, don't wait for or rely on me. Say
+   > 'I'm home' any time to end this."
+
+## Output
+
+Confirmation message with the disclaimer above, verbatim.


### PR DESCRIPTION
## Summary

A safety-framed check-in scheduler for the [NanoClaw Agent Templates Hackathon](https://nanoclaw.dev/hackathon). Schedules periodic check-ins, calls the user via Dial if they miss a few, and calls a named emergency contact if there's still no response. Generalizes beyond any single scenario - a date, a solo hike, walking home alone, checking on a relative living alone.

## Guardrails as first-class design, not appended disclaimers

Given the domain, I want to be upfront with reviewers about the design constraint this template is built around: it runs on someone's personal NanoClaw install via async chat messaging, not a real-time system. That's fine for a habit reminder; it's a real limitation for anything positioned as protective. So:

- The persona and every session-start confirmation state plainly, verbatim, every time: this is a best-effort convenience tool, not a safety-critical system, and why (task scheduling latency, no uptime guarantee if the host sleeps or the service restarts).
- If someone says they feel unsafe right now, the answer is always to contact real emergency services directly - never positioned as an alternative to that.
- The emergency-contact escalation call never claims certainty about what's happening - "hasn't confirmed after multiple attempts, not a confirmed emergency, please use your own judgment," never "X is in danger."
- A reply at any point immediately cancels any in-progress escalation - never place a call a reply already made unnecessary.

## Technical notes for a reviewer

- Reuses the zero-dependency `stdio-mcp.mjs` helper (Node builtins only) - a stamped plugin directory has no `node_modules`, so a script here needs zero non-builtin imports to actually run.
- Real design difference from a fixed-destination integration: who gets called varies per check-in session (the user's own number for the miss-escalation call, their chosen emergency contact for the final one), so `place_checkin_call` takes the destination as a call-time tool argument rather than a template-fixed env var.
- `checkin-poll`'s pre-check script is pure time-math reading session state directly from the agent's own memory file - no external call needed for the gate itself, satisfying the 4-fires/24h cap on ungated tasks for a cadence tighter than hourly.

## What it does

- `checkin-setup`: parses a natural-language request, confirms with the full safety disclaimer, stores session state.
- `checkin-cycle`: the core loop - resend, escalate to a user call, or escalate to a contact call, based on session state. At most one action per wake; silence is the common, correct outcome.
- `checkin-end`: stops an active session immediately, any time, no friction.

## Testing

- `node scripts/check-templates.mjs` passes.
- Stamped locally, clean `templateReport`.
- `checkin-setup`: real session created, disclaimer delivered verbatim, state file structure verified.
- `checkin-end`: cleanly stops a session, resets state correctly.
- `place_checkin_call`: real completed call with a real transcript matching the test message.
- `checkin-cycle` escalation logic: dry-run tested against two crafted states - (missCount=2, interval elapsed) correctly chose "call the user, not the emergency contact"; (missCount=3, already user-escalated, still no reply) correctly chose "escalate to the emergency contact."
- **Known limitation, disclosed rather than hidden**: full live multi-interval orchestration (real wall-clock time through several check-in intervals) was not exhaustively tested given time constraints - the decision logic is verified via dry-run against realistic states, not a full end-to-end timed run.
- Gate script's pure time-math logic verified locally across all 4 decision paths before ever touching a live container.

## Checklist

- [x] `<category>/<template>/` - reused the existing `lifestyle/` category (catalog already has `lifestyle/family-assistant`) rather than adding a new one.
- [x] `plugin.json` present, exact 1.0.0 `$schema`, valid `name`, `author` set.
- [x] `ai.nanoco.nanoclaw/context/instructions.md` non-empty.
- [x] `mcp.json` - every credential-shaped value is the literal `"placeholder"`.
- [x] The one task has a non-empty `schedule`, a `script`, no other frontmatter fields.
- [x] `README.md` documents the required service: API host, auth style, where to get a key, and states the safety-framing limitations plainly near the top, not buried.
- [x] Dial disclosed as a paid dependency - tier named, pricing-page link, no prices quoted.
- [x] No affiliate/referral links, no baked-in billing, no shared or author-owned credential anywhere in the template.
- [x] `node scripts/check-templates.mjs` passes.
- [x] Stamped and tested locally, including real third-party calls and dry-run logic verification.
- [x] No secrets anywhere in the diff.
- [x] Read "Acceptance and ownership" in CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018erad52EGzTR9MkPeYofBK