### PR TITLE
Add data/outage-watch: dependency outage sentinel (Tavily track)

### DIFF
--- a/data/outage-watch/README.md
+++ b/data/outage-watch/README.md
@@ -1,0 +1,85 @@
+# Outage Watch Template
+
+A NanoClaw template that watches your cloud/SaaS/data-infra dependencies and tells
+you the moment one is actually having an incident — cross-referencing each
+vendor's own status page against live web signal, since status pages are
+reliably slower than the internet to admit a problem. Confirmed, critical-tier
+incidents can escalate to a real phone call via Dial; everything else stays in
+chat.
+
+## Layout
+
+```
+outage-watch/
+├── plugin.json                              # Agent Plugins manifest
+├── mcp.json                                 # Tavily MCP server: placeholder credential, no secrets
+├── ai.nanoco.nanoclaw/
+│   ├── context/
+│   │   ├── instructions.md                  # the persona — two-signal triage, tiered escalation
+│   │   └── additional_context/
+│   │       ├── services.md                  # EDIT ME: which services you watch, and their tier
+│   │       ├── escalation-policy.md         # the two-signal method, what each tier/state does
+│   │       └── memory-structure.md          # where learned state (open incidents) lives
+│   └── tasks/
+│       └── dependency-check.md              # every 15 minutes — checks every watched service
+├── skills/
+│   └── outage-triage/
+│       └── SKILL.md                         # the check itself: official + unofficial signal, tiering
+└── README.md                                # this file
+```
+
+## Stamp an agent
+
+```bash
+ncl groups create --template data/outage-watch --name "Outage Watch"
+```
+
+Then edit `additional_context/services.md` to match your actual stack, wire the
+agent to a channel (`/manage-channels`), and connect Tavily (below). The
+scheduled check installs paused — activate it once you've configured your
+service list.
+
+## Credentials
+
+| Service | API host | Auth style | Where to get it |
+|---|---|---|---|
+| Tavily | `api.tavily.com` (or `mcp.tavily.com` for the remote MCP) | API key, `Authorization: Bearer` | tavily.com → API Keys |
+
+**Tavily is paid past its free tier.** A free tier exists and is enough to try
+this template; watching many services on a 15-minute cadence will exceed it in
+real use. Check tavily.com/pricing for current plan names — bring your own key,
+this template ships none.
+
+`mcp.json`'s `TAVILY_API_KEY: "placeholder"` is required because the local MCP
+server refuses to boot without the env var present — it is not a real key.
+OneCLI injects the real one at the `api.tavily.com` boundary once you've
+connected Tavily in the vault. Never replace the placeholder yourself.
+
+## Phone escalation via Dial (optional)
+
+Calling/texting on a confirmed critical-tier outage is **not** wired through
+`mcp.json`, unlike Tavily — Dial's own setup skills (`/add-dial-tool`,
+`/add-dial`) install the CLI into the sandbox and pair a real phone number,
+which can't be pre-baked into a template. Run those against the stamped agent
+if you want phone escalation; until you do, the agent degrades to chat-only
+alerts for every tier and says so once.
+
+**Dial is a paid, usage-billed service** — a phone number plus SMS/call usage.
+See Dial's own pricing for current plan names; you connect your own account,
+this template ships no shared line.
+
+## Notes
+
+- **Two-signal detection is the whole point.** An official-status-only checker
+  is a cron job hitting a JSON endpoint; this template exists because status
+  pages lag the internet, sometimes by 30+ minutes, and unofficial chatter
+  (forums, aggregators, news) usually knows first. See
+  `additional_context/escalation-policy.md`.
+- **"Is it us or them" on demand.** Ask the agent directly whether a specific
+  service is down and it runs the same check immediately, outside the
+  schedule — useful mid-incident, not just as a morning digest.
+- **No repeat pages.** An open incident is tracked in `memory/incidents.md` and
+  only re-alerts on a state change or after an hour of continuous confirmed
+  state — not every 15 minutes.
+- **Scheduled check starts paused**, like every NanoClaw task — nothing pages
+  anyone until you activate it.

--- a/data/outage-watch/ai.nanoco.nanoclaw/context/additional_context/escalation-policy.md
+++ b/data/outage-watch/ai.nanoco.nanoclaw/context/additional_context/escalation-policy.md
@@ -1,0 +1,27 @@
+# Escalation policy
+
+## The two-signal method
+
+Every check for a service produces one of three states:
+
+1. **Confirmed** — the service's own status page reports anything other than fully operational. High confidence; act on it.
+2. **Suspected** — no official confirmation yet, but independent, current web signal (recent posts/threads/news mentioning the service being down, from more than one distinct domain) is spiking. Real but unconfirmed — the whole reason this template exists is that official status pages lag live incidents, often by 15-30+ minutes.
+3. **Clear** — neither signal present.
+
+Never report "confirmed" from unofficial signal alone, and never report a tier of certainty higher than the evidence supports — say which state it is, and cite what you found.
+
+## What each state does
+
+| State | critical tier | high tier | normal tier |
+|---|---|---|---|
+| Confirmed | chat alert + phone call/SMS via Dial (if connected) | chat alert | chat alert |
+| Suspected | chat alert, marked unconfirmed, no call | chat alert, marked unconfirmed | log only, no alert |
+| Clear | nothing (or resolve an open incident) | nothing | nothing |
+
+## De-duplication and cooldown
+
+Before alerting, check `memory/incidents.md` for an already-open incident on that service. If one is open and the state hasn't changed, do not alert again — an ongoing incident should not repage every 15 minutes. Re-alert only when the state changes (e.g. suspected → confirmed, or confirmed → clear/resolved), or after 60 minutes of continuous confirmed state, whichever comes first.
+
+## Dial availability
+
+Only place a call or send an SMS if the `dial` CLI is available in this sandbox (check for `DIAL_CLI_PATH` before attempting). If it isn't connected, degrade to chat-only for every tier and say so once, not on every check.

--- a/data/outage-watch/ai.nanoco.nanoclaw/context/additional_context/memory-structure.md
+++ b/data/outage-watch/ai.nanoco.nanoclaw/context/additional_context/memory-structure.md
@@ -1,0 +1,8 @@
+# Memory structure
+
+Learned/dynamic state lives in `memory/`, built as the agent works — nothing here ships pre-populated.
+
+- `memory/incidents.md` — one open-or-resolved record per service per incident: state, evidence, tier, action taken, timestamps. This is what makes de-duplication and cooldown possible.
+- `memory/conventions/vendor-notes.md` — anything vendor-specific worth remembering: a status page that's slow to update, a more-reliable RSS/JSON feed, quirks in how a vendor phrases "degraded."
+
+Static, operator-edited config — the actual list of watched services and how escalation is tiered — lives in `additional_context/services.md` and `additional_context/escalation-policy.md` instead, since those are decisions a human makes, not facts the agent learns.

--- a/data/outage-watch/ai.nanoco.nanoclaw/context/additional_context/services.md
+++ b/data/outage-watch/ai.nanoco.nanoclaw/context/additional_context/services.md
@@ -1,0 +1,16 @@
+# Watched dependencies
+
+One row per service this agent watches. Add or remove rows freely — this is the only file you need to edit to change what's monitored.
+
+| Service | Status page | Tier |
+|---|---|---|
+| AWS (us-east-1) | https://health.aws.amazon.com/health/status | critical |
+| Stripe | https://status.stripe.com | critical |
+| Snowflake | https://status.snowflake.com | critical |
+| GitHub | https://www.githubstatus.com | high |
+| Datadog | https://status.datadoghq.com | high |
+
+**Tier** controls escalation, defined in `additional_context/escalation-policy.md`:
+- `critical` — confirmed outage pages the on-call number (if Dial is connected)
+- `high` — confirmed outage posts to chat only, no call
+- `normal` — unofficial-only signal, or a confirmed outage on a non-critical dependency; logged, chat only, no repeat pings

--- a/data/outage-watch/ai.nanoco.nanoclaw/context/instructions.md
+++ b/data/outage-watch/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,26 @@
+# Outage Sentinel
+
+You watch the principal's cloud, SaaS, and data-infra dependencies and tell them the moment one is actually in trouble — before the vendor's own status page admits it, and before anyone burns an hour debugging their own code for a problem that isn't theirs.
+
+## How you operate
+
+- Two signals, not one. A vendor's status page is authoritative but slow; the open web (forums, aggregators, news) is fast but noisy. Cross-reference both — see `additional_context/escalation-policy.md` for exactly how. Never call something "down" on unofficial chatter alone; call it "suspected" and say so.
+- Triage on demand, not just on schedule. If the principal asks "is it us or is `<service>` down," run the same check immediately against that one service and answer directly — this is the single most useful thing you do.
+- Don't cry wolf. One alert per state change per service, not one per check. An ongoing incident gets a single open thread, not a ping every 15 minutes — `memory/incidents.md` is how you remember what's already been said.
+- Escalate by tier, not by instinct. Whether an outage rings someone's phone is decided by `additional_context/services.md` (which tier) and `additional_context/escalation-policy.md` (what each tier does), not by how alarming the state looks in the moment.
+- Fact-first. Every claim of "down" carries what you found it from — the status page's own words, or the specific pages/threads behind an unofficial signal — so the principal can check your work in ten seconds.
+
+## Tone
+
+Short, calm, specific. Lead with the verdict (confirmed / suspected / clear), then the evidence, then what's affected. No hedging filler — if you're not sure, say "suspected" and why, not "might possibly potentially."
+
+## Grow your toolkit
+
+You start from `skills/outage-triage/`. If you find yourself building a durable habit around a specific vendor (its status page has a weird format, its API endpoint is more reliable than the page, whatever) — record it as a new entry in `memory/conventions/vendor-notes.md`, not by rewriting the skill.
+
+## Never
+
+- Report "confirmed" from unofficial signal alone.
+- Call or text a phone number for anything below `critical` tier, or for a `suspected`-only state, regardless of how it looks.
+- Re-alert on an unchanged, already-open incident before its cooldown.
+- Fabricate a status, a source, or a quote. If you can't find anything, say so — silence isn't evidence of "clear."

--- a/data/outage-watch/ai.nanoco.nanoclaw/tasks/dependency-check.md
+++ b/data/outage-watch/ai.nanoco.nanoclaw/tasks/dependency-check.md
@@ -1,7 +1,62 @@
 ---
 schedule: "*/15 * * * *"
+script: |
+  # Gate for the 15-min frequency limit: NanoClaw caps ungated tasks at 4
+  # fires/24h, and this task fires 96x/day. This does a cheap, LLM-free
+  # pre-check (curl only) so the agent wakes only when something needs it:
+  #
+  #   - Fast path: any watched service whose status page follows the
+  #     Statuspage.io JSON convention (<page>/api/v2/status.json) reports a
+  #     non-"none" indicator. Covers Snowflake, GitHub, Datadog, and most
+  #     Statuspage.io-hosted vendors out of the box.
+  #   - AWS's Health Dashboard and Stripe's own status page don't expose that
+  #     JSON endpoint, so they don't get the fast path - this is a known gap,
+  #     not silently swallowed. Those (and the unofficial-signal half of the
+  #     check, which needs Tavily) are only covered by the heartbeat below.
+  #   - Heartbeat: if nothing tripped the fast path, wake anyway once an hour
+  #     so the full two-signal check still runs periodically for every
+  #     configured service, keeps memory/incidents.md fresh, and the "is it
+  #     down" on-demand answer never goes stale by more than an hour.
+  #
+  # Edit HEARTBEAT_INTERVAL_SEC to trade cost against staleness tolerance.
+  SERVICES_FILE="/workspace/agent/plugins/outage-watch/ai.nanoco.nanoclaw/context/additional_context/services.md"
+  HEARTBEAT_FILE="/workspace/agent/memory/outage-watch-last-heartbeat"
+  HEARTBEAT_INTERVAL_SEC=3600
+
+  WAKE=false
+
+  if [ -f "$SERVICES_FILE" ]; then
+    URLS=$(grep -oE '\| [^|]+\| https://[^ ]+ \|' "$SERVICES_FILE" | grep -oE 'https://[^ ]+')
+    for url in $URLS; do
+      RESP=$(curl -s -m 5 "${url%/}/api/v2/status.json" 2>/dev/null)
+      INDICATOR=$(echo "$RESP" | grep -oE '"indicator":"[a-z]+"' | head -1 | cut -d'"' -f4)
+      if [ -n "$INDICATOR" ] && [ "$INDICATOR" != "none" ]; then
+        WAKE=true
+      fi
+    done
+  fi
+
+  if [ "$WAKE" != "true" ]; then
+    NOW=$(date +%s)
+    LAST=0
+    [ -f "$HEARTBEAT_FILE" ] && LAST=$(cat "$HEARTBEAT_FILE" 2>/dev/null)
+    [ -z "$LAST" ] && LAST=0
+    if [ $((NOW - LAST)) -ge $HEARTBEAT_INTERVAL_SEC ]; then
+      WAKE=true
+    fi
+  fi
+
+  if [ "$WAKE" = "true" ]; then
+    date +%s > "$HEARTBEAT_FILE" 2>/dev/null
+  fi
+
+  echo "{\"wakeAgent\": $WAKE}"
 ---
-Run outage-triage against every row in `additional_context/services.md`. For each service:
+Run outage-triage against every row in `additional_context/services.md`. This task fires
+every 15 minutes but the pre-check script above only wakes you when a watched service's
+Statuspage.io-style status API reports trouble, or once an hour as a heartbeat sweep that
+also covers AWS and Stripe (whose status pages don't expose that JSON endpoint) and the
+unofficial-signal half of the check. For each service:
 
 1. Check its official status page.
 2. Check for current unofficial signal (recent, independent-domain mentions of it being down).

--- a/data/outage-watch/ai.nanoco.nanoclaw/tasks/dependency-check.md
+++ b/data/outage-watch/ai.nanoco.nanoclaw/tasks/dependency-check.md
@@ -1,0 +1,12 @@
+---
+schedule: "*/15 * * * *"
+---
+Run outage-triage against every row in `additional_context/services.md`. For each service:
+
+1. Check its official status page.
+2. Check for current unofficial signal (recent, independent-domain mentions of it being down).
+3. Compare the resulting state to what's already open in `memory/incidents.md`.
+4. Alert only on a new incident or a state change, per the tiers and cooldown in `additional_context/escalation-policy.md`.
+5. Update `memory/incidents.md` with the current state of every service checked, confirmed or clear.
+
+Never place a call or send an SMS outside what the escalation policy allows for that service's tier. If nothing changed anywhere, say nothing — a silent 15 minutes is a working 15 minutes.

--- a/data/outage-watch/mcp.json
+++ b/data/outage-watch/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "tavily": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "tavily-mcp@0.2.22"],
+      "env": { "TAVILY_API_KEY": "placeholder" }
+    }
+  }
+}

--- a/data/outage-watch/plugin.json
+++ b/data/outage-watch/plugin.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "outage-watch",
+  "version": "1.0.0",
+  "description": "Dependency outage sentinel: cross-references vendor status pages against live web signal to catch cloud/SaaS/data-infra outages early and triage incidents.",
+  "author": { "name": "Adam Morad", "url": "https://github.com/adamorad" }
+}

--- a/data/outage-watch/skills/outage-triage/SKILL.md
+++ b/data/outage-watch/skills/outage-triage/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: outage-triage
+description: >
+  Check whether a specific cloud/SaaS/data-infra dependency is actually having an
+  incident, using both its official status page and independent web signal, and
+  decide whether/how to alert. Use on the recurring dependency check, when the
+  principal asks whether a specific service is down, when a suspected incident
+  needs re-checking for an update, or when a new dependency is added to
+  `additional_context/services.md` and needs a first baseline.
+---
+
+# Outage triage
+
+## Goal
+Tell the difference between "actually down," "probably down but not yet confirmed," and "not this service's fault" — fast enough to matter, and precisely enough to trust.
+
+## Procedure
+
+1. **Look up the service's status page and tier** in `additional_context/services.md`. If it isn't listed and the principal asked about it directly, still check it — just note it isn't a tracked dependency yet.
+2. **Check the official signal.** Fetch the status page's current content. Anything other than a clean "operational"/"all systems normal" statement is `confirmed`.
+3. **Check the unofficial signal**, regardless of what step 2 found. Search for recent mentions of the service being down, restricted to the last few hours. Count independent domains, not raw hits — five people quoting the same one post is one signal, not five.
+4. **Weigh them.** Official non-operational → `confirmed`, cite the page's own wording. Official clean but multiple independent-domain unofficial hits in a short window → `suspected`, cite the specific sources. Neither → `clear`.
+5. **Check `memory/incidents.md`** for an already-open incident on this service. If the state matches what's already recorded and it's within cooldown, do not send a new alert — update the record's "last checked" only.
+6. **Decide the action** from the tier (`services.md`) × state (this check) × the table in `additional_context/escalation-policy.md`. A call/SMS only ever happens for `confirmed` + `critical`, and only if the `dial` CLI is available (check before attempting — degrade to chat-only and say so once if it isn't).
+7. **Record the outcome** in `memory/incidents.md`: service, state, evidence sources, tier, action taken, timestamp. Close out incidents that return to `clear`.
+
+## Boundaries
+- Never call a state `confirmed` on unofficial evidence alone.
+- Never escalate by phone below `critical` tier or on a `suspected`-only state.
+- Never re-alert an unchanged, already-open incident before its cooldown elapses.
+- Never attempt a Dial call/SMS without first checking the CLI is actually available in this sandbox.
+- Never fabricate a source. If you found nothing on either signal, that's `clear`, not silence.
+
+## What to record
+Keep `memory/incidents.md` current: every service's last-checked state, the evidence for it, whether it's open or resolved, and what action was taken. Keep `memory/conventions/vendor-notes.md` for anything vendor-specific worth remembering (a status page that lags, an RSS/JSON feed that's more reliable than the HTML page, etc.).

--- a/index.json
+++ b/index.json
@@ -7,6 +7,12 @@
         "name": "analyst",
         "version": "1.0.0",
         "description": "Data analyst agent: pipeline checks, query writing, and recurring report integrity"
+      },
+      {
+        "ref": "data/outage-watch",
+        "name": "outage-watch",
+        "version": "1.0.0",
+        "description": "Dependency outage sentinel: cross-references vendor status pages against live web signal to catch cloud/SaaS/data-infra outages early and triage incidents."
       }
     ],
     "lifestyle": [


### PR DESCRIPTION
# PR title

Add `data/outage-watch`: dependency outage sentinel (Tavily track)

# PR description

## What this template does

`data/outage-watch` watches a configured list of cloud/SaaS/data-infra
dependencies (AWS, Stripe, Snowflake, GitHub, Datadog by default — edit
`additional_context/services.md` to match your own stack) and tells you the
moment one is actually having an incident.

The problem it solves: vendor status pages are authoritative but slow —
they routinely lag a live incident by 15–30+ minutes — while independent web
signal (forums, aggregators, news) usually knows first, but is noisy on its
own. This template cross-references both:

1. **Official signal** — the vendor's own status page, fetched live.
2. **Unofficial signal** — recent, independent-domain mentions of the service
   being down.

Only when the official page itself goes non-operational is a state reported
as `confirmed`; an unofficial-only spike is reported as `suspected` and never
inflated into a confirmed outage. The exact rules are in
`additional_context/escalation-policy.md`.

On top of the scheduled check, the agent answers on-demand "is it us or is
`<service>` down" questions immediately, using the same two-signal check —
this is the fastest way to rule a vendor in or out during an actual incident.

## Tavily usage (this track)

Tavily is the load-bearing piece, not a bolt-on: there is no unified API for
"is any of my vendors down right now," so both the official-status check and
the unofficial-chatter check run through the Tavily MCP server
(`tavily-mcp`, declared in `mcp.json`). Without live search, neither signal
exists — a static per-vendor status-page scraper would break on layout
changes and still miss the unofficial-signal half of the design entirely.

## Optional: Dial escalation

A `confirmed` outage on a `critical`-tier dependency can page on-call via a
real phone call/SMS through Dial. This is **not** wired through `mcp.json`
(Dial's own `/add-dial-tool` + `/add-dial` setup skills install the CLI and
pair a real number post-stamp, which can't be pre-baked into a template) —
until an operator runs those, the agent degrades to chat-only alerts for
every tier and says so once. See the README's "Phone escalation via Dial"
section.

## What it expects

- **MCP servers**: `tavily` (`tavily-mcp`, stdio) — declared in `mcp.json`
  with a `"placeholder"` `TAVILY_API_KEY`; real key supplied via the OneCLI
  vault after stamping. No secrets in this diff.
- **Recurring task**: `ai.nanoco.nanoclaw/tasks/dependency-check.md`, every
  15 minutes (`*/15 * * * *`), installed **paused** per the standard
  template behavior — nothing pages anyone until it's activated. 96
  fires/day exceeds NanoClaw's 4-fires/day ungated cap, so the task
  carries a `--script` pre-gate: a cheap curl-only check against each
  watched service's Statuspage.io-style status API that wakes the full
  agent only when an indicator trips, or once an hour as a heartbeat that
  also covers AWS and Stripe (whose status pages don't expose that JSON
  endpoint) and the unofficial-signal half of the check.
- **Skill**: `skills/outage-triage/` — the two-signal check procedure, tiering,
  de-duplication against `memory/incidents.md`, and cooldown logic.

## Testing

- `node scripts/check-templates.mjs` passes locally (all 6 templates OK,
  including this one).
- [x] Stamped locally with a bare ref and verified the scheduled task installs
      paused and runs cleanly: `ncl groups create --template data/outage-watch
      --name "Outage Watch Test"` stamped successfully, `ncl tasks list
      --status paused` showed `dependency-check` installed paused, and
      `ncl tasks run <task-id>` confirmed the gate script executes against
      the real container paths and correctly wakes the agent on the
      (legitimate) first run. Test group and container torn down after
      verification.

## Credit

`author` set in `plugin.json` to Adam Morad ([@adamorad](https://github.com/adamorad)).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vRbNjWGm7TdsBFRiTwvPK

