### PR TITLE
docs: name the CI gates and add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!-- Adding a template? Fill this in. Fixing docs or a typo? Delete all of it and
+     just say what you changed. -->
+
+## What this template does
+
+<!-- One paragraph: the job it does, and for whom. -->
+
+## Where it lives
+
+`<category>/<template>/` <!-- for example sales/sdr -->
+
+## Services and credentials
+
+<!-- Link the section of your template README covering services, auth style,
+     scopes, and any paid tier. Do not retype it here. -->
+
+## Before you open this
+
+- [ ] `node scripts/build-index.mjs` run and the regenerated `index.json`
+      committed. **This is the most common red build.**
+- [ ] `node scripts/check-templates.mjs` passes
+- [ ] If you edited a template that already existed, its `plugin.json` `version`
+      is bumped
+- [ ] No secrets anywhere in the diff
+- [ ] Read [Acceptance and ownership](https://github.com/nanocoai/nanoclaw-templates/blob/main/CONTRIBUTING.md#acceptance-and-ownership)
+      and the full [PR checklist](https://github.com/nanocoai/nanoclaw-templates/blob/main/CONTRIBUTING.md#pr-checklist)
+
+---
+
+<!-- HACKATHON BLOCK. Delete this section after 2026-09-10. Owner: @glifocat -->
+
+### Entering the September 2026 hackathon?
+
+**This pull request is not your entry.** A Submission is made through the
+[entry form](https://form.typeform.com/to/uICRt1Oj), which collects your contact
+email, the track you are entering, a link to this pull request, and a short demo
+video of the agent actually running. Read the
+[Official Rules](https://nanoclaw.dev/hackathon/september-2026-rules) for the
+deadline, and for how many templates you may enter.
+
+**Track (as chosen on the form):** <!-- Overall / Tavily / DIAL -->
+
+Track is how you compete. It is not the same as the category folder your
+template lives in. The form is the record: if it is not on the form, it is not
+entered, whatever this pull request says.

--- a/.github/workflows/check-templates.yml
+++ b/.github/workflows/check-templates.yml
@@ -18,7 +18,11 @@ jobs:
       - uses: actions/checkout@v4
       - run: node scripts/build-index.mjs
       - name: index.json is up to date
-        run: git diff --exit-code index.json
+        run: |
+          git diff --exit-code index.json || {
+            echo "::error::index.json is stale. Run 'node scripts/build-index.mjs' and commit the result."
+            exit 1
+          }
 
   version-bump:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/check-templates.yml
+++ b/.github/workflows/check-templates.yml
@@ -19,10 +19,14 @@ jobs:
       - run: node scripts/build-index.mjs
       - name: index.json is up to date
         run: |
-          git diff --exit-code index.json || {
+          status=0
+          git diff --exit-code index.json || status=$?
+          # Only claim staleness on git's "differences found" exit code. Any
+          # other failure is a real git error and keeps its own message.
+          if [ "$status" -eq 1 ]; then
             echo "::error::index.json is stale. Run 'node scripts/build-index.mjs' and commit the result."
-            exit 1
-          }
+          fi
+          exit "$status"
 
   version-bump:
     if: github.event_name == 'pull_request'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,12 @@ main [README](README.md#anatomy-of-a-template) for the full anatomy.
 Group every template under a category folder, so the path is
 `<category>/<template>/`.
 
+The categories in use today are `data`, `lifestyle`, `media`, `product` and
+`sales`, with `engineering` arriving in open pull requests.
+
 Before adding a new category, check whether an existing one fits and reuse it. If
 you genuinely need a new one, keep it a single, lowercase, broadly-recognized
-business function (for example `sales`, `support`, `engineering`, `marketing`,
-`ops`, `finance`), not a niche or product-specific label. The aim is a small,
+business function, not a niche or product-specific label. The aim is a small,
 predictable set of categories a newcomer can guess.
 
 ## No secrets, ever
@@ -144,8 +146,25 @@ for its author.
    `ai.nanoco.nanoclaw/tasks/*.md`, and a per-template `README.md` covering
    what it does and which MCP servers and credentials it expects. The provider
    is not set in the template; it is chosen on the agent later.
-5. Run the registry checks: `node scripts/check-templates.mjs` (the same
-   script CI runs).
+5. Run the registry checks. CI runs three jobs and you can run all of them
+   locally:
+
+   ```bash
+   node scripts/check-templates.mjs          # structure, manifests, no secrets
+   node scripts/build-index.mjs              # regenerates index.json
+   git diff --exit-code index.json           # must be clean after the line above
+   node scripts/check-version-bump.mjs main  # only bites when editing an existing template
+   ```
+
+   **`index.json` is generated, and CI fails if it drifts.** Run
+   `build-index.mjs` and commit the result whenever you add, move, or remove a
+   template. Never hand-edit it. This is the single most common reason an
+   otherwise fine pull request goes red.
+
+   `check-version-bump.mjs` only applies when you change a template that is
+   already in the registry: bump `version` in its `plugin.json`. Templates added
+   by your own pull request are exempt, because there is no earlier version to
+   compare against.
 6. Test it end to end. `--template` resolves relative to your NanoClaw install's
    templates directory, not your clone, so copy it across first. `templates/`
    ships with only a README, so create the category directory too:
@@ -192,6 +211,10 @@ for its author.
 - [ ] No affiliate or referral links, no baked-in billing, and no shared or
       author-owned credential anywhere in the template.
 - [ ] `node scripts/check-templates.mjs` passes.
+- [ ] `node scripts/build-index.mjs` has been run and the regenerated
+      `index.json` is committed, so `git diff --exit-code index.json` is clean.
+- [ ] If you edited a template that already existed, its `plugin.json` `version`
+      is bumped.
 - [ ] Stamped and tested locally with a bare ref, after copying the template
       into the install's `templates/`.
 - [ ] No API keys, tokens, or other secrets anywhere in the diff.


### PR DESCRIPTION
## What this does

Three changes, aimed at one problem: contributors cannot see what CI actually requires.

1. **CONTRIBUTING names all three CI jobs.** It previously told contributors to run `check-templates.mjs` and nothing else. It now gives runnable commands for all three, states that `index.json` is generated and must be regenerated with `build-index.mjs`, and explains that `check-version-bump` only applies when editing a template that already exists.
2. **Adds `.github/PULL_REQUEST_TEMPLATE.md`.** The repo had none, so nothing prompted contributors for the template path, the services it needs, or `index.json`.
3. **`index-drift` now prints how to fix itself.**

Also replaces the category examples in CONTRIBUTING with the folders that actually exist. It suggested `support`, `marketing`, `ops` and `finance`; the real ones are `data`, `lifestyle`, `media`, `product`, `sales`.

## Why

`build-index.mjs` is a required CI gate named in no contributor-facing document. Right now `index-drift` is the only failing check on four of the eight open template pull requests, and one of those four edited `index.json` by hand and still drifted. That points at a missing mechanical step rather than a missing rule.

The CI message is the part that matters most. A pull request template only populates the body at creation, so it can never help a pull request that is already open. A one-line error message reaches every one of them the moment this merges.

## How I verified it

Locally, on this branch:

```
node scripts/check-templates.mjs   ->  5 template(s) OK
node scripts/build-index.mjs       ->  5 template(s) in 5 categories
git diff --exit-code index.json    ->  clean, this change introduces no drift
```

The pull request template went through an adversarial review before this was opened. Thirteen findings, all dispositioned; the version here is the rewrite. Changes it forced include: absolute links, because relative links in a pull request body resolve against the pull request URL and 404; describing the hackathon entry form accurately, including the demo video it requires; and removing a sentence that contradicted the contest rules.

## Note for reviewers

The hackathon section of the template carries a dated removal marker and an owner. It should be deleted after 2026-09-10.

---

Assisted by Claude; reviewed and verified by a human before submission.