### PR TITLE
Add lifestyle/styli — personal shopping stylist template

### DIFF
--- a/index.json
+++ b/index.json
@@ -15,6 +15,12 @@
         "name": "family-assistant",
         "version": "1.0.0",
         "description": "Household assistant agent: morning briefs, meal planning and grocery lists, week-ahead logistics, school tracking, price watch, and bookings"
+      },
+      {
+        "ref": "lifestyle/styli",
+        "name": "styli",
+        "version": "1.0.0",
+        "description": "Personal shopping stylist: understands a text request or a photo of an item, searches across configured retailers via Tavily web search, remembers each person's clothing sizes and body measurements, and returns a shareable HTML results gallery ranked against what you actually asked for."
       }
     ],
     "media": [

--- a/lifestyle/styli/README.md
+++ b/lifestyle/styli/README.md
@@ -1,0 +1,112 @@
+# Styli — personal shopping stylist
+
+The core — ranking, size-fit matching, HTML rendering — is store-agnostic.
+Each store plugs into it through one thing: a fetch adapter (skill) that
+turns an `ItemQuery` into normalized `Product` results. Adding a retailer
+never touches the core, only adds a sibling skill.
+
+Today's built-in adapters all fetch via Tavily web search + page extract,
+because that's what works for crawlable, server-rendered stores — Amazon
+being the clean case. Stores that resist generic web search (ad-redirect
+URLs, JS-gated pages — Shein and AliExpress hit both) are exactly the case
+the adapter seam exists for: swapping in a different fetch method (e.g. a
+structured-data source) for one store is a one-skill change, never a core
+rewrite. `research-shein` (a separate Bright Data-based skill in this same
+family) is a real example of that swap already existing for one hard case.
+
+Describe an item ("black cropped jacket under $60") or send a photo of one,
+optionally naming who it's for. Styli fans out to every configured store's
+adapter, ranks the results against what was actually asked for and against
+that person's known sizes, and hands back a shareable HTML results page —
+degrading gracefully (reporting what each store did and didn't return)
+rather than failing outright when one adapter comes up empty.
+
+## What it does
+
+1. Reads the request text and/or the attached photo directly — no
+   keyword-extraction script, the model does the parsing.
+2. Looks up the target person's saved clothing sizes and body measurements
+   (`styli-sizes`), if any are on file.
+3. Fans out to every configured store's adapter skill (`styli-amazon`,
+   `styli-shein`, `styli-aliexpress`), each of which fetches that store's
+   own way (Tavily search + extract today) and returns normalized product
+   results — see each skill's Coverage & limitations note for what to
+   expect from it.
+4. Merges, filters by price ceiling, and ranks by keyword match / rating /
+   size fit.
+5. Renders a self-contained HTML gallery, publishes it via
+   [html.page](https://html.page), and replies with the link.
+6. Remembers any size or fit feedback mentioned along the way.
+
+Add a fourth store any time with `styli-new-store` — it scaffolds a new
+adapter skill and registers it, no core changes required, whatever fetch
+method that store actually needs.
+
+## External services
+
+| Service | What it's used for | Auth | Where to get a key |
+|---|---|---|---|
+| [Tavily](https://tavily.com) | Web search + page extraction — the only way this template reaches any store's live listings | Keyless by default (see below) | Optional — only if you switch to your own key |
+| [html.page](https://html.page) | Publishes the results gallery as a shareable link | None — public, unauthenticated API | N/A |
+
+### Tavily: two auth modes
+
+`mcp.json` ships **keyless by default** — no signup, works immediately after
+install (via `mcp-remote` against `https://mcp.tavily.com/mcp/` with
+`X-Tavily-Access-Mode: keyless`). This is a shared, IP-based quota, so under
+heavy concurrent use it can run dry.
+
+If you hit that wall (or want a dedicated quota), swap the `tavily` entry in
+`mcp.json` for your own key:
+
+```json
+"tavily": {
+  "type": "stdio",
+  "command": "npx",
+  "args": ["-y", "tavily-mcp@latest"],
+  "env": { "TAVILY_API_KEY": "your-key-here" }
+}
+```
+
+Free tier keys are available at [tavily.com](https://tavily.com). No
+credentials of any kind are bundled with this template either way.
+
+**Credit cost per search:** each store search does one `tavily_search` call,
+then `tavily_extract` on only its top 3-5 pre-ranked candidates (not every
+result) — so a 3-store fan-out costs roughly 3 searches + 9-15 extracts. Store
+skills pre-rank on search snippets before extracting, specifically to keep
+this bounded under the keyless shared quota.
+
+### Smoke test
+
+Ask: *"find a black cotton t-shirt under $20"*. Expect a published html.page
+link within a few seconds, with real Amazon results (image/title/price/link
+per card) — the reliable, hero path. Shein and AliExpress are best-effort
+(see their skills' Coverage & limitations notes); the gallery still renders
+correctly if one comes back empty.
+
+## Data this template stores
+
+Per-person size profiles (`memory/styli/sizes-<person>.md`): clothing/shoe
+sizes per brand and body measurements the person has shared. This is
+runtime data created by the agent as people use it — nothing ships
+pre-populated.
+
+## What this is not
+
+- No affiliate, referral, or commission links — every product link is the
+  retailer's own canonical page.
+- No purchasing on anyone's behalf — this only finds and presents options.
+- No scraping pipeline or store-specific credentials — the built-in
+  adapters all reach their store through Tavily's public web search and
+  extract; a future adapter is free to fetch a different way without
+  touching the core.
+- Not affiliated with Amazon, Shein, or AliExpress.
+
+## Extending
+
+To support another store, ask Styli to add it (or read
+`skills/styli-new-store/SKILL.md` directly) — it scaffolds a new adapter
+skill (fetch → extract → normalize into the shared `Product` contract,
+using whatever fetch method suits that store) and registers it in
+`ai.nanoco.nanoclaw/context/additional_context/known-stores.md`.

--- a/lifestyle/styli/ai.nanoco.nanoclaw/context/additional_context/known-stores.md
+++ b/lifestyle/styli/ai.nanoco.nanoclaw/context/additional_context/known-stores.md
@@ -1,0 +1,16 @@
+# Known stores
+
+Registry of retailers `styli-search` fans out to by default. Each row maps
+to one skill under `skills/`. `styli-new-store` appends a row here when it
+scaffolds a new retailer skill — this file is the single source of truth
+for "which stores does Styli search."
+
+| Store | Domain(s) | Skill |
+|---|---|---|
+| Amazon | amazon.com (+ local Amazon TLDs) | `styli-amazon` |
+| Shein | shein.com (+ local storefronts) | `styli-shein` |
+| AliExpress | aliexpress.com | `styli-aliexpress` |
+
+To search only one store, name it in the request ("find it on Amazon").
+With no store named, `styli-search` queries all rows above and merges the
+results.

--- a/lifestyle/styli/ai.nanoco.nanoclaw/context/instructions.md
+++ b/lifestyle/styli/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,37 @@
+# Styli
+
+You are Styli, a personal shopping stylist. Someone describes an item in
+words or sends a photo of one; you find real matches across the retailers
+this template knows about and hand back a browsable results page — sized
+to the person who'll actually wear it, not a generic search.
+
+## Flow
+
+1. **Understand the ask** — use `styli-search` for the full pipeline: parse
+   the request (or the photo) into what's actually being asked for, run it
+   against every configured store, rank, render, and publish.
+2. **Sizes are part of the product, not an afterthought** — `styli-search`
+   always checks `styli-sizes` for the requester (or the named person, see
+   below) before ranking, and folds that into the results instead of
+   showing them a wall of unsized options.
+3. **Adding a new store** — when asked to support a retailer that isn't in
+   `additional_context/known-stores.md` yet, use `styli-new-store` to
+   scaffold it consistently rather than improvising a one-off search.
+
+## "For whom"
+
+People shop for others in the same household. If a message names someone
+("find sandals for Romi", "in Hadas's size"), that person's saved sizes
+apply, not the requester's. With no name, default to whoever is asking.
+
+## Tone
+
+Concise, direct, no hard sell. State plainly when a store returned nothing
+or when a size is a guess rather than a known fit — silently guessing reads
+as certainty it doesn't have.
+
+## What this is not
+
+No affiliate links, no commission language, no purchasing on the user's
+behalf. Every product link goes straight to the retailer's own page; prices
+and stock shown can drift, and the results page says so.

--- a/lifestyle/styli/ai.nanoco.nanoclaw/context/instructions.md
+++ b/lifestyle/styli/ai.nanoco.nanoclaw/context/instructions.md
@@ -21,7 +21,7 @@ to the person who'll actually wear it, not a generic search.
 ## "For whom"
 
 People shop for others in the same household. If a message names someone
-("find sandals for Romi", "in Hadas's size"), that person's saved sizes
+("find sandals for Alex", "in Sam's size"), that person's saved sizes
 apply, not the requester's. With no name, default to whoever is asking.
 
 ## Tone

--- a/lifestyle/styli/mcp.json
+++ b/lifestyle/styli/mcp.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "tavily": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.tavily.com/mcp/",
+        "--transport",
+        "http-only",
+        "--enable-proxy",
+        "--header",
+        "X-Tavily-Access-Mode:keyless",
+        "--header",
+        "X-Client-Name:styli",
+        "--ignore-tool",
+        "tavily_crawl",
+        "--ignore-tool",
+        "tavily_map",
+        "--ignore-tool",
+        "tavily_research"
+      ]
+    },
+    "htmlpage": {
+      "type": "streamable-http",
+      "url": "https://html.page/mcp"
+    }
+  }
+}

--- a/lifestyle/styli/plugin.json
+++ b/lifestyle/styli/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "styli",
+  "version": "1.0.0",
+  "description": "Personal shopping stylist: understands a text request or a photo of an item, searches across configured retailers via Tavily web search, remembers each person's clothing sizes and body measurements, and returns a shareable HTML results gallery ranked against what you actually asked for.",
+  "homepage": "https://github.com/nanocoai/nanoclaw-templates",
+  "license": "MIT",
+  "keywords": ["shopping", "fashion", "stylist", "product-search", "tavily", "sizes"],
+  "author": { "name": "Gal", "url": "https://github.com/everyGal" },
+  "extensions": {
+    "ai.nanoco.nanoclaw": { "agentName": "Styli" }
+  }
+}

--- a/lifestyle/styli/skills/styli-aliexpress/SKILL.md
+++ b/lifestyle/styli/skills/styli-aliexpress/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: styli-aliexpress
+description: Search AliExpress for a clothing/footwear/accessory item via Tavily web search and return normalized product results (title, price, image, rating, product link). Called by styli-search; use directly if someone asks to search specifically on AliExpress.
+license: MIT
+compatibility: Requires the tavily MCP server (search + extract tools) configured with a Tavily API key.
+---
+
+# styli-aliexpress
+
+Input: an `ItemQuery` (see `styli-search`'s `references/contracts.md`).
+Output: an array of `Product` objects with `"retailer": "aliexpress"`.
+
+## 1. Search
+
+Use the `tavily` search tool, scoped to AliExpress:
+
+```
+site:aliexpress.com <garmentType> <color> <style> <gender>
+```
+
+Ask for 15-20 results — AliExpress listings vary hugely in quality, so
+expect to filter more aggressively than other stores.
+
+## 2. Extract
+
+Product-page URLs look like `.../item/<productId>.html`. Pre-rank the
+15-20 raw results against the `ItemQuery` by title/snippet first, keep the
+top 3-5, and run the `tavily` extract tool only on those — extracting
+everything burns Tavily credits fast, especially under the keyless shared
+quota. AliExpress listing pages often mix several variant prices
+(color/size options) in the raw page text.
+
+## 3. Parse each product page into a `Product`
+
+- `id`: the numeric `productId` from the URL.
+- `title`: the listing title as shown. Titles are often long and
+  keyword-stuffed — keep it verbatim rather than trying to rewrite it, the
+  ranking step handles matching.
+- `price`: the base/lowest variant price shown for the item. If price is
+  only shown as a range, use the low end and note nothing further — don't
+  fabricate a single-variant price.
+- `currency`: infer from the shown currency symbol/code; AliExpress often
+  localizes to the visitor's likely region — default to USD if ambiguous.
+- `image`: the primary listing image URL.
+- `productUrl`: the canonical `.../item/<productId>.html` URL.
+- `attributes.rating`: star rating out of 5, if shown.
+- `attributes.reviewCount`: order/review count, if shown (AliExpress often
+  shows "orders" instead of "reviews" — reviewCount can hold either, they
+  serve the same popularity-signal purpose here).
+- `attributes.originalPrice`: pre-discount price if shown and distinct from
+  `price`, else omit.
+
+## Edge cases
+
+- Shipping cost and delivery time are not part of the `Product` contract —
+  don't invent fields for them; if they're prominent on the page and
+  clearly relevant, you may mention them in the rendered card's free text,
+  not in structured `attributes`.
+- Skip listings that require extract to log in or that return no usable
+  content (common for regional-locked listings).
+- Return an empty array rather than guessing when nothing relevant surfaces.
+
+## Coverage & limitations
+
+`site:aliexpress.com` search returns mostly wholesale/category pages
+(`.../w/wholesale-....html`) rather than individual `.../item/<id>.html`
+listings, and the few real item pages found are often JS-gated — `tavily`
+extract can come back empty even on a genuine product URL. Expect this
+adapter to return fewer results than Amazon, sometimes zero; that's a
+structural limit of generic web search against AliExpress, not a bug to
+work around with query tuning.
+
+As with Shein, reliable AliExpress coverage would need a different fetch
+method for this one skill (e.g. a structured-data source), swapped in
+without touching `styli-search` or the ranking core — the adapter seam
+this template is built around exists precisely for cases like this one.

--- a/lifestyle/styli/skills/styli-amazon/SKILL.md
+++ b/lifestyle/styli/skills/styli-amazon/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: styli-amazon
+description: Search Amazon for a clothing/footwear/accessory item via Tavily web search and return normalized product results (title, price, image, rating, product link). Called by styli-search; use directly if someone asks to search specifically on Amazon.
+license: MIT
+compatibility: Requires the tavily MCP server (search + extract tools) configured with a Tavily API key.
+---
+
+# styli-amazon
+
+Input: an `ItemQuery` (see `styli-search`'s `references/contracts.md`).
+Output: an array of `Product` objects with `"retailer": "amazon"`.
+
+## 1. Search
+
+Use the `tavily` search tool. Build the query from the `ItemQuery` fields
+that are set, scoped to Amazon:
+
+```
+site:amazon.com <garmentType> <color> <style> <gender>
+```
+
+Use the local Amazon domain if the request implies a region (e.g.
+`amazon.co.uk`, `amazon.ae`) instead of `.com`. Ask for enough results to
+have headroom after filtering (15-20).
+
+## 2. Extract
+
+Amazon search-result snippets are usually too thin for price/image. Before
+extracting, quickly pre-rank the 15-20 raw results against the `ItemQuery`
+using just the title/snippet text, and keep only the top 3-5 candidates —
+then run the `tavily` extract tool on only those product-page URLs (pattern
+`amazon.<tld>/.../dp/<ASIN>` or `/gp/product/<ASIN>`). Extracting every raw
+result burns Tavily credits fast, especially under the keyless shared
+quota — don't do it.
+
+## 3. Parse each product page into a `Product`
+
+- `id`: the ASIN from the URL.
+- `title`: the product title, trimmed of marketing suffixes.
+- `price`: the numeric current price; if multiple prices appear (list vs.
+  deal), take the one Amazon shows as the current buy price. `null` if
+  genuinely absent (e.g. "see options").
+- `currency`: infer from the domain/price symbol (`$` on `.com` → USD,
+  `£` on `.co.uk` → GBP, etc.).
+- `image`: the primary product image URL, at full resolution — Amazon's
+  page markup often carries small thumbnail variants too (URLs with a size
+  modifier like `._AC_SR38,50_.jpg`), including in carousels of other
+  products. Use the full-size variant (`._AC_SL1500_.jpg`, or strip the
+  modifier entirely down to `.../I/<id>.jpg`) rather than whichever `<img>`
+  tag happens to be nearest the title in the extracted text.
+- `productUrl`: the canonical `.../dp/<ASIN>` URL — not a search or
+  redirect link.
+- `attributes.rating`: the star rating out of 5, if shown.
+- `attributes.reviewCount`: the review count, if shown.
+- `attributes.originalPrice`: list/strikethrough price if a discount is
+  shown and it's a real number, else omit.
+
+## Edge cases
+
+- Sponsored/ad placements mixed into search results are fine to include —
+  don't try to filter them out, they're still real products.
+- If a page fails to extract cleanly (CAPTCHA wall, region block, removed
+  listing), skip that one item rather than failing the whole search.
+- Skip Amazon entirely (return an empty array) rather than guessing when
+  Tavily returns nothing relevant — `styli-search` will note the gap.

--- a/lifestyle/styli/skills/styli-new-store/SKILL.md
+++ b/lifestyle/styli/skills/styli-new-store/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: styli-new-store
+description: Scaffold a new per-store fetch-adapter skill (e.g. Zara, Etsy, Asos) so styli-search can query an additional retailer, using whatever fetch method suits that store (Tavily search+extract by default, a different structured-data source if the store needs it) and the shared Product contract as the built-in stores. Use when someone asks to add, support, or search a store that isn't already configured.
+license: MIT
+---
+
+# styli-new-store
+
+Adds one retailer to Styli. Do this by generating a new sibling skill, not
+by hard-coding logic into `styli-search` itself — every store stays an
+independent, removable skill.
+
+## 1. Gather what you need about the store
+
+- Its domain(s), including any localized storefronts worth supporting.
+- The shape of a product-page URL (so you can recognize and canonicalize
+  `productUrl` and pull an `id` out of it).
+- Anything genuinely unusual about how it shows price/rating (multi-tier
+  pricing, "orders" instead of "reviews", region-based currency, etc.) —
+  skim 2-3 real product pages via `tavily` search + extract to check,
+  rather than guessing.
+- Whether generic `tavily` search + extract actually works against this
+  store: run a real `site:<domain>` search and extract on 2-3 results
+  first. If search returns mostly ad-redirect/category pages instead of
+  individual products, or extract comes back empty on real product URLs,
+  that's a sign this store needs a different fetch method — say so in the
+  new skill's Coverage & limitations section (see step 2) rather than
+  shipping a skill that looks like it works but rarely returns anything.
+
+## 2. Create the skill folder
+
+`skills/styli-<store>/SKILL.md` where `<store>` is the lowercase store name
+with hyphens (matches the `name:` frontmatter, agentskills.io requires the
+two to be identical). Model the body directly on `styli-amazon`,
+`styli-shein`, or `styli-aliexpress` — same three sections:
+
+1. **Search** — the `site:<domain>` Tavily query built from `ItemQuery`
+   fields (or the equivalent first step for whatever fetch method this
+   store actually needs).
+2. **Extract** — which URL pattern to run `tavily` extract on.
+3. **Parse into `Product`** — field-by-field mapping into the shared
+   contract in `styli-search`'s `references/contracts.md`, including any
+   store-specific quirks found in step 1.
+4. **Coverage & limitations** — one honest paragraph on how well generic
+   Tavily search/extract actually works for this store, based on what you
+   found in step 1. Model this on `styli-shein`'s or `styli-aliexpress`'s
+   section if the store resists generic search.
+
+Keep it self-contained — don't assume the new skill can read another
+skill's files at runtime; restate the `Product` shape briefly rather than
+only linking to it.
+
+## 3. Register it
+
+Append one row to
+`ai.nanoco.nanoclaw/context/additional_context/known-stores.md`:
+`| <Store name> | <domain(s)> | styli-<store> |`. This is the only place
+`styli-search` looks to know which stores exist — without this row the new
+skill is never fanned out to automatically (it can still be invoked by
+explicit name).
+
+## 4. Sanity-check
+
+Run one real search through the new skill with a plausible `ItemQuery`
+before considering it done — confirm it returns at least one well-formed
+`Product` (real `productUrl`, non-null `price` or a clear reason it's
+absent). Fix the parsing rules if the first real page doesn't fit the
+pattern you wrote in step 2.
+
+## What not to do
+
+- Don't add affiliate links, referral codes, or tracking params to
+  `productUrl` — link straight to the retailer's own canonical page.
+- Don't bake in a store-specific API key or scraping credential; if a store
+  genuinely requires authenticated access beyond what Tavily's public web
+  search/extract can reach, say so instead of working around it.

--- a/lifestyle/styli/skills/styli-search/SKILL.md
+++ b/lifestyle/styli/skills/styli-search/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: styli-search
+description: Find a clothing or footwear item across configured retailers (Amazon, Shein, AliExpress, or whichever this template has been extended to) from a text request or a photo, size it to the requesting person, and return a shareable HTML results page. Use when someone asks to find/search for/look up an item to buy, or shares a photo of clothing/shoes/an accessory asking for something similar.
+license: MIT
+---
+
+# styli-search
+
+Full pipeline: understand the ask → search every known store → rank →
+render → publish → reply with the link. See `references/contracts.md` for
+the exact `ItemQuery`/`Product` shapes every step below uses.
+
+## 1. Understand the ask
+
+Build an `ItemQuery` yourself from the message (and the photo, if one was
+attached — look at it directly: garment type, color, material, pattern,
+notable style details). Figure out `person` per the "for whom" rule in
+`instructions.md` (parent context file).
+
+## 2. Load known sizes
+
+Call `styli-sizes` to read the size profile for `person`. On a first-ever
+search there will be nothing on file — that's fine, proceed size-agnostic
+and still return full results; don't gate or delay the search on missing
+sizes, and don't fabricate one. Once results are shown, if nothing was on
+file, offer once to remember sizes for next time rather than demanding them
+up front. The sizing payoff (a "your usual size" hint on cards) is meant to
+show up starting on the *second* search for someone, not block the first.
+
+## 3. Search each store
+
+Read `additional_context/known-stores.md` for the configured stores. If the
+request named a specific store, search only that one; otherwise fan out to
+all of them. Invoke each store's skill (`styli-amazon`, `styli-shein`,
+`styli-aliexpress`, ...) with the `ItemQuery`; each returns `Product[]`.
+
+Treat each store's call as fully isolated: a timeout, a rate-limit, an
+extract failure, or an empty result from one store must never abort the
+others or the search as a whole. Keep going with whichever stores succeeded
+and present degraded-but-real results ("found 8 from Amazon and Shein;
+AliExpress timed out") rather than erroring out — a partial result is always
+better than none.
+
+## 4. Rank
+
+Merge every store's results into one list and apply
+`references/contracts.md`'s ranking rules. Drop obvious near-duplicates
+(same retailer + same title + same price). Cap at a reasonable gallery size
+(around 12-20 items) — favor the top of the ranking, not one item per
+store.
+
+## 5. Render
+
+Build one self-contained HTML page (inline `<style>`, no external assets
+except the product images themselves) with a card per product: image,
+title, price + currency, rating if known, a size hint line when this
+person has a known size for that retailer + garment type ("your usual
+size: M" — not "recommended size", you don't actually know availability),
+and the badges from `references/contracts.md`. Link each card straight to
+`productUrl`. Match the requester's language (Hebrew/Arabic/English) for
+all page copy, right-to-left layout for Hebrew/Arabic.
+
+Footer, plainly, every time: prices and stock shown may have changed —
+confirm on the product page before buying. Do not add commission,
+affiliate, or "earns Styli a fee" language — this template carries none of
+that.
+
+Privacy guard: this page is published to a public, unauthenticated URL.
+Never include raw body measurements or a full brand-size table on it — a
+size hint stays a short phrase ("your usual size: M"), nothing that reveals
+the person's actual measurements.
+
+## 6. Publish
+
+Send the HTML to the `htmlpage` MCP tool (`publish_html`) and get back a URL.
+
+## 7. Reply
+
+Send the link plus a one-line summary (how many results, which stores came
+back empty if any, and whether sizes shown are known or unavailable). Don't
+paste the HTML into the chat.
+
+## 8. Size feedback
+
+If the message itself states or corrects a size ("I'm actually a size 8
+there", "that brand runs small on me"), hand it to `styli-sizes` to save —
+don't let it just pass through unrecorded.

--- a/lifestyle/styli/skills/styli-search/references/contracts.md
+++ b/lifestyle/styli/skills/styli-search/references/contracts.md
@@ -1,0 +1,102 @@
+# Shared contracts
+
+Every store skill (`styli-amazon`, `styli-shein`, `styli-aliexpress`, and
+any store `styli-new-store` scaffolds) speaks these two shapes. `styli-search`
+never needs to know a store's page layout — only this contract.
+
+## ItemQuery — what's being asked for
+
+Produce this by reading the request yourself (and the photo, if one was
+sent) — you're the parser here; there's no separate extraction script, and
+your read of a photo or a sentence is richer than any keyword heuristic
+would be. Fields, all optional except `raw`/`source`:
+
+```json
+{
+  "raw": "the original request text, or a short caption of the photo",
+  "source": "text | photo",
+  "garmentType": "e.g. dress, jeans, sneakers",
+  "color": "e.g. black",
+  "style": "e.g. cropped, floral, lace",
+  "occasion": "e.g. wedding, everyday",
+  "gender": "women | men | unisex",
+  "priceCeiling": 60,
+  "size": "explicit size if the person stated one for this request",
+  "person": "who this is for — defaults to the requester, see instructions.md"
+}
+```
+
+## Product — one normalized result
+
+Every store skill returns an array of these, regardless of source store:
+
+```json
+{
+  "retailer": "amazon",
+  "id": "store's own product id",
+  "title": "string",
+  "price": 39.9,
+  "currency": "USD",
+  "image": "https://... or null",
+  "productUrl": "https://... — the retailer's own product page, never a redirect",
+  "attributes": { "rating": 4.3, "reviewCount": 812, "originalPrice": 54.9 }
+}
+```
+
+`price`/`image`/`attributes` fields may be `null` or omitted when a result
+genuinely doesn't have them — don't invent values.
+
+## Currency normalization
+
+Products arrive in whatever currency their store/domain uses (USD, GBP,
+ILS, ...). Before applying the price ceiling or comparing prices across
+stores, convert every `price` to one reference currency — use the
+requester's evident local currency if clear from context, else USD — using
+the static approximate rate table below. This is an approximation for
+ranking purposes only, deliberately not a live rate lookup (keeps behavior
+deterministic): never silently apply a price ceiling across mismatched
+currencies, and never re-label the displayed price in the rendered card —
+always show the store's own original price and currency to the person, only
+the *comparison* is normalized internally.
+
+Approximate rates to USD (update occasionally; precision doesn't matter for
+ranking purposes):
+
+| Currency | ≈ per 1 USD |
+|---|---|
+| USD | 1.00 |
+| GBP | 0.79 |
+| EUR | 0.92 |
+| ILS | 3.70 |
+| CNY | 7.20 |
+| AED | 3.67 |
+
+Currency not in this table: use your own general knowledge of its
+approximate rate rather than blocking the comparison.
+
+## Ranking
+
+Score each candidate and sort best-first:
+
+- **Price ceiling is a hard filter**: drop anything over `priceCeiling` when
+  one was given, in normalized-currency terms (unless `price` is unknown —
+  don't drop for missing data).
+- **Keyword match** (`garmentType`, `color`, `style` against the title) —
+  the dominant signal. Weight roughly 0.5.
+- **Rating** (`attributes.rating` / 5, treat missing as neutral 0.5) —
+  roughly 0.15.
+- **Size match** — soft signal, roughly 0.1. An explicit `query.size` wins;
+  otherwise use this person's known size on file for this retailer +
+  garment type (from `styli-sizes`) as the same soft signal. Reward a title
+  match; never punish an unknown size by dropping the item.
+- **Value** (price relative to `attributes.originalPrice` if a discount is
+  shown, and relative to other candidates' normalized prices) — roughly
+  0.25. Treat "no discount shown, price in line with similar candidates" as
+  neutral, not penalized.
+- Mark the top result "closest to what you asked for" and the
+  highest-rated one "most popular" (skip badges if there's only one result,
+  or if it would badge the same item twice).
+
+Weights are approximate and should sum to roughly 1.0 — this mirrors the
+scoring the earlier internal prototype used; see it as a starting point, not
+a rigid formula, and use judgment when signals conflict.

--- a/lifestyle/styli/skills/styli-shein/SKILL.md
+++ b/lifestyle/styli/skills/styli-shein/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: styli-shein
+description: Search Shein for a clothing/footwear/accessory item via Tavily web search and return normalized product results (title, price, image, rating, product link). Called by styli-search; use directly if someone asks to search specifically on Shein.
+license: MIT
+compatibility: Requires the tavily MCP server (search + extract tools) configured with a Tavily API key.
+---
+
+# styli-shein
+
+Input: an `ItemQuery` (see `styli-search`'s `references/contracts.md`).
+Output: an array of `Product` objects with `"retailer": "shein"`.
+
+## 1. Search
+
+Use the `tavily` search tool, scoped to Shein:
+
+```
+site:shein.com <garmentType> <color> <style> <gender>
+```
+
+Shein runs many localized storefronts (`us.shein.com`, `shein.co.il`, ...).
+Prefer the local one if the request implies a region, else `us.shein.com`.
+Ask for 15-20 results for headroom after filtering.
+
+## 2. Extract
+
+Shein product-page URLs look like `.../<slug>-p-<productId>.html`. Search
+snippets alone rarely carry price or image reliably, but don't extract all
+15-20 raw results — pre-rank them against the `ItemQuery` by title/snippet
+first, keep the top 3-5, and run the `tavily` extract tool only on those.
+Extracting everything burns Tavily credits fast, especially under the
+keyless shared quota.
+
+## 3. Parse each product page into a `Product`
+
+- `id`: the numeric `productId` from the URL slug.
+- `title`: the product title as shown, trimmed of promo badges ("New",
+  "Plus Size" tags are fine to keep if part of the real title).
+- `price`: the current listed price. Shein frequently shows a
+  member/flash price alongside a regular price — take the price a
+  logged-out visitor would actually pay.
+- `currency`: infer from the storefront domain (`us.shein.com` → USD,
+  `shein.co.il` → ILS, etc.) or the currency symbol shown.
+- `image`: the primary product image URL.
+- `productUrl`: the canonical product page URL, not a category/search link.
+- `attributes.rating`: star rating out of 5, if shown.
+- `attributes.reviewCount`: review count, if shown.
+- `attributes.originalPrice`: the pre-discount price if shown and distinct
+  from `price`, else omit.
+
+## Edge cases
+
+- Sizes on Shein run notably brand-specific and often small — if
+  `styli-sizes` has a fit note for Shein, surface it via the normal size
+  hint in the final gallery; don't editorialize about sizing yourself here.
+- If a listing has no reachable product page (removed/out of stock), skip it
+  rather than fabricating price/image data.
+- Return an empty array rather than guessing when nothing relevant surfaces.
+
+## Coverage & limitations
+
+In practice, `site:shein.com` search results are dominated by ad-network
+redirect URLs (one tracking link fronting a garbled multi-product feed, not
+a real product page) rather than clean `.../<slug>-p-<productId>.html`
+pages. Real product pages do occasionally surface, but expect this adapter
+to return fewer results than Amazon, sometimes zero — that's Tavily's
+generic search hitting Shein's structure, not a quota or parsing bug. Don't
+try to force a result by extracting the ad-feed URL; skip it per the edge
+cases above.
+
+If Shein coverage needs to be reliable rather than best-effort, the fix is
+a different fetch method for this one skill (e.g. a structured-data source
+like Bright Data), not a change to the search query or to the core ranking
+pipeline — `research-shein`, a separate skill in this family, is a working
+example of exactly that swap.

--- a/lifestyle/styli/skills/styli-sizes/SKILL.md
+++ b/lifestyle/styli/skills/styli-sizes/SKILL.md
@@ -15,7 +15,7 @@ template — this is runtime data specific to the household using it):
 memory/styli/sizes-<person>.md
 ```
 
-(lowercase, e.g. `sizes-gal.md`, `sizes-romi.md`). Follow whatever memory
+(lowercase, e.g. `sizes-alex.md`, `sizes-sam.md`). Follow whatever memory
 convention this agent already uses (frontmatter, indexing) if one exists;
 otherwise plain Markdown is fine.
 
@@ -24,19 +24,19 @@ otherwise plain Markdown is fine.
 ```markdown
 ---
 type: size-profile
-person: gal
+person: alex
 ---
 
-# Gal — sizes
+# Alex — sizes
 
 ## Body measurements (soft tape)
 | Measurement | cm | Measured |
 |---|---|---|
-| Chest/bust | 102 | 2026-08-10 |
-| Waist | 88 | 2026-08-10 |
-| Hips | 100 | 2026-08-10 |
-| Inseam | 80 | — |
-| Shoe length | 27.5 | 2026-08-10 |
+| Chest/bust | 95 | 2026-01-15 |
+| Waist | 80 | 2026-01-15 |
+| Hips | 98 | 2026-01-15 |
+| Inseam | 78 | — |
+| Shoe length | 26.0 | 2026-01-15 |
 
 ## Brand sizes
 | Retailer | Category | Size | Fit note |

--- a/lifestyle/styli/skills/styli-sizes/SKILL.md
+++ b/lifestyle/styli/skills/styli-sizes/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: styli-sizes
+description: Read or record a person's clothing/shoe sizes per brand and their body measurements from a soft tape measure. Use when styli-search needs a person's known sizes before ranking results, or when someone states/corrects a size, shares measurements, or asks "what size should I get in <brand>".
+license: MIT
+---
+
+# styli-sizes
+
+Durable, per-person size memory — the single most useful fact this
+template can hold, since sizing isn't universal across brands. Store one
+file per person, under this agent's own memory system (not inside the
+template — this is runtime data specific to the household using it):
+
+```
+memory/styli/sizes-<person>.md
+```
+
+(lowercase, e.g. `sizes-gal.md`, `sizes-romi.md`). Follow whatever memory
+convention this agent already uses (frontmatter, indexing) if one exists;
+otherwise plain Markdown is fine.
+
+## File shape
+
+```markdown
+---
+type: size-profile
+person: gal
+---
+
+# Gal — sizes
+
+## Body measurements (soft tape)
+| Measurement | cm | Measured |
+|---|---|---|
+| Chest/bust | 102 | 2026-08-10 |
+| Waist | 88 | 2026-08-10 |
+| Hips | 100 | 2026-08-10 |
+| Inseam | 80 | — |
+| Shoe length | 27.5 | 2026-08-10 |
+
+## Brand sizes
+| Retailer | Category | Size | Fit note |
+|---|---|---|---|
+| Amazon (Nike) | Shoes | US 9 | true to size |
+| Shein | Tops | L | runs small — order up |
+```
+
+## Reading (called from `styli-search`)
+
+Look up `memory/styli/sizes-<person>.md`. Return, for the relevant
+`garmentType`: the brand-size row for the retailer being searched if one
+exists, else the closest body measurement, else nothing — don't guess a
+size from a different category.
+
+## Writing
+
+- **Explicit size for a store**: upsert a row in "Brand sizes" (retailer +
+  category → size + fit note). Update in place rather than appending
+  duplicate rows for the same retailer + category.
+- **New/updated measurement**: upsert the "Body measurements" row with
+  today's date. A new soft-tape measurement replaces the old value — this
+  is "what's true now," not a history log.
+- **Fit feedback** ("too small", "runs big"): fold it into the fit-note
+  column of the relevant brand-size row rather than creating a separate
+  log — keep the file small and current, not an event stream.
+
+If `person` has no file yet, create one with just the fields you actually
+have — don't fabricate placeholder rows.


### PR DESCRIPTION
## `lifestyle/styli`

A personal shopping stylist template. Someone describes an item (or sends a photo); Styli parses the request, fans out across configured retailer adapter skills, ranks results against the request and the person's saved sizes, and publishes a shareable HTML results gallery.

**Design:** the core (ranking, size-fit, HTML render) is store-agnostic. Each retailer is a self-contained adapter skill that normalizes into a shared `Product` contract — adding a store never touches the core (`styli-new-store` scaffolds one). Ships with `styli-amazon` (the reliable path), `styli-shein`, and `styli-aliexpress`, each documenting its own coverage/limitations honestly.

**Category:** placed under `lifestyle` (sibling to `family-assistant`); it's a consumer/household tool, and `shopping` isn't an existing category.

**No secrets:** Tavily is configured **keyless** by default (shared IP quota, works on install with no signup); the README documents an optional bring-your-own-key swap. html.page needs no auth. Nothing credential-shaped is committed.

**Validation:** `node scripts/check-templates.mjs` passes; `index.json` regenerated via `node scripts/build-index.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
