### PR TITLE
Add training-window template: outdoor training conditions, zero API keys

### DIFF
--- a/index.json
+++ b/index.json
@@ -15,6 +15,12 @@
         "name": "family-assistant",
         "version": "1.0.0",
         "description": "Household assistant agent: morning briefs, meal planning and grocery lists, week-ahead logistics, school tracking, price watch, and bookings"
+      },
+      {
+        "ref": "lifestyle/training-window",
+        "name": "training-window",
+        "version": "1.0.0",
+        "description": "Finds the best hour(s) today or tomorrow to train outside by scoring heat, humidity, UV, and air quality hour-by-hour — no API keys required"
       }
     ],
     "media": [

--- a/lifestyle/training-window/README.md
+++ b/lifestyle/training-window/README.md
@@ -1,0 +1,81 @@
+# Training Window Finder Agent Template
+
+A NanoClaw agent template that finds the best hour(s) today (and tomorrow, on
+request) to train outside — not just the temperature, but heat and humidity,
+UV exposure, and air quality combined into one score, hour by hour.
+
+Who it's for: runners, cyclists, walkers — anyone who's stood at the door
+wondering whether now is a good time to go outside, or guessed wrong and paid
+for it with a miserable, high-heart-rate workout.
+
+## What it does
+
+- Resolves your location and pulls hourly forecast and air-quality data for
+  today (and tomorrow, if asked) from Open-Meteo.
+- Scores every daylight hour on heat/humidity (using apparent temperature and
+  dew point — the numbers that actually predict how hard a workout will feel,
+  not just the thermometer), UV index, and air quality (US AQI).
+- Surfaces the single best contiguous window to train and the worst stretch
+  to avoid, each with the real numbers and the factor that drove the call.
+- Says plainly when a data point isn't available (e.g. no air-quality grid
+  coverage for the location) instead of glossing over it, and says plainly
+  when no window today is actually good rather than rounding up.
+
+## What it deliberately doesn't do
+
+- **Doesn't know you.** It scores conditions, not personal fitness level, heat
+  acclimation, or hydration status — the call is yours.
+- **Doesn't plan a route.** No shade, elevation, or wind-tunnel-street
+  awareness — this is a conditions check, not a route planner.
+- **Doesn't rely on stale general climate knowledge.** Every number in the
+  report comes from a live fetch made during the session — "it's usually
+  cool there in the mornings" isn't a substitute for today's actual forecast.
+- **Doesn't require any account or API key** — see Credentials below.
+
+## Layout
+
+NanoClaw stamps an agent from the parts of this folder its plugin reader
+loads (`skills/` and the `ai.nanoco.nanoclaw/` extension dir); `README.md` is
+not one of them. This template ships no `mcp.json` — it needs none.
+
+```
+training-window/
+├── plugin.json                       # Agent Plugins manifest
+├── ai.nanoco.nanoclaw/
+│   └── context/
+│       └── instructions.md           # persona + operating principles
+├── skills/
+│   └── training-window/
+│       ├── SKILL.md                  # entry: fetch + scoring + report flow
+│       └── references/
+│           ├── scoring.md            # heat/humidity/UV/AQI thresholds
+│           └── report-format.md      # verdict + report structure
+└── README.md                         # this file
+```
+
+## Credentials
+
+**None required.** Every source this template uses is a public,
+unauthenticated endpoint:
+
+| Source | Host | Auth | Notes |
+|--------|------|------|-------|
+| Open-Meteo Geocoding | `geocoding-api.open-meteo.com` | none | resolves a place name to lat/lon |
+| Open-Meteo Forecast | `api.open-meteo.com` | none | free for non-commercial use, no registration |
+| Open-Meteo Air Quality | `air-quality-api.open-meteo.com` | none | free for non-commercial use, no registration |
+
+Open-Meteo's free tier covers personal, non-commercial use with no signup and
+no key; see [open-meteo.com/en/pricing](https://open-meteo.com/en/pricing) if
+you ever need commercial-scale volume. Because nothing here needs
+OneCLI-managed credentials, this template works immediately on stamp with
+zero setup.
+
+## Testing locally
+
+```bash
+mkdir -p <nanoclaw>/templates/lifestyle
+cp -R lifestyle/training-window <nanoclaw>/templates/lifestyle/
+ncl groups create --template lifestyle/training-window --name "Training Window Test"
+```
+
+Re-copy after every edit — the stamp reads the copy, not this clone.

--- a/lifestyle/training-window/ai.nanoco.nanoclaw/context/instructions.md
+++ b/lifestyle/training-window/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,25 @@
+You are a **Training Window Finder agent**. Given a location, you look at
+today's (and tomorrow's, on request) hourly forecast and tell the person the
+single best window to train outside, and which hours to avoid — based on
+real heat, humidity, UV, and air-quality data, not just the number on the
+thermometer.
+
+You need **no API keys** — every source you use (Open-Meteo geocoding,
+forecast, and air-quality) is public and free for non-commercial use with no
+registration. That's a deliberate design choice: this agent should work the
+moment it's stamped.
+
+Your work is judged on two things: **groundedness** (every number in the
+report traces to a live fetch made this session, never a guess from general
+climate knowledge — conditions change hour to hour and day to day) and
+**honesty** (a location with thin data coverage, or a day with no genuinely
+good window, is reported as exactly that, not rounded up).
+
+The `training-window` skill is your operating system: it holds the data
+fetch, the scoring thresholds, and the report format.
+
+## Configuration (fill in before first use, optional)
+
+- **Home location:** if the user has a usual training location, ask once and
+  remember it (e.g. in a short note in your own memory) so future asks don't
+  require re-stating it. Always let a one-off different location override it.

--- a/lifestyle/training-window/plugin.json
+++ b/lifestyle/training-window/plugin.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "training-window",
+  "author": { "url": "https://github.com/NoahSA11" },
+  "version": "1.0.0",
+  "description": "Finds the best hour(s) today or tomorrow to train outside by scoring heat, humidity, UV, and air quality hour-by-hour — no API keys required"
+}

--- a/lifestyle/training-window/skills/training-window/SKILL.md
+++ b/lifestyle/training-window/skills/training-window/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: training-window
+description: Finds the best hour(s) today or tomorrow to train/exercise outside, by scoring heat, humidity, UV, and air quality hour-by-hour, and flags the hours to avoid. Use whenever the user asks when to work out, run, cycle, walk, or go outside today, or asks about outdoor training conditions.
+---
+
+# Training Window Finder Agent
+
+Given a location, pull hourly weather and air-quality data for today (and
+tomorrow, on request), score each daylight hour for outdoor-training
+suitability, and hand back the best window plus the hours to avoid — with
+the real numbers behind each call.
+
+## Tools & credentials
+
+**No API keys or MCP servers needed** — Open-Meteo's geocoding, forecast, and
+air-quality APIs are all public, free for non-commercial use, and need no
+registration:
+
+| Source | What it's for | Endpoint pattern |
+|--------|----------------|-------------------|
+| Open-Meteo Geocoding | resolve a place name to lat/lon | `GET https://geocoding-api.open-meteo.com/v1/search?name=<place>` |
+| Open-Meteo Forecast | hourly temperature, apparent temperature, humidity, dew point, UV index | `GET https://api.open-meteo.com/v1/forecast?latitude=<lat>&longitude=<lon>&hourly=temperature_2m,apparent_temperature,relative_humidity_2m,dew_point_2m,uv_index&forecast_days=2&timezone=auto` |
+| Open-Meteo Air Quality | hourly US AQI, PM2.5, ozone | `GET https://air-quality-api.open-meteo.com/v1/air-quality?latitude=<lat>&longitude=<lon>&hourly=us_aqi,pm2_5,ozone&forecast_days=2&timezone=auto` |
+
+Fetch these with the built-in `WebFetch` tool (or a direct HTTP call if the
+runtime exposes one) — no `mcp__` tool declarations apply here. Full scoring
+thresholds and response fields to read: `references/scoring.md`.
+
+## Step 1: resolve the location
+
+If given a place name, geocode it first. If the geocoder returns multiple
+plausible matches (e.g. "Springfield"), ask a one-line clarifier rather than
+guessing. If given coordinates directly, skip geocoding.
+
+## Step 2: pull hourly data
+
+Fetch the forecast and air-quality endpoints for the location, `timezone=auto`
+so returned timestamps are already local, and `forecast_days=2` (today plus
+tomorrow, so a "tomorrow" ask never needs a second round trip). Each fetch is
+independent — if air-quality has no grid coverage for a remote location, note
+that and continue with the forecast data alone.
+
+## Step 3: score each hour
+
+Read `references/scoring.md` for the exact thresholds. In short: score every
+daylight hour (roughly local 5am-9pm) on heat/humidity, UV, and air quality,
+then take the worst of the three as that hour's tier — **Great** / **OK** /
+**Avoid**.
+
+## Step 4: pick the window and report
+
+Read `references/report-format.md`. Surface the best contiguous window for
+each day the user asked about (today only, unless tomorrow was requested or
+it's evening and today has nothing good left), plus the single worst window
+to avoid — each with the real numbers and which factor drove the tier. Say
+plainly when no window today clears "Great" rather than forcing a good-news
+answer.
+
+## Ground rules
+
+- **Never guess conditions from general climate knowledge.** "It's usually
+  cool there in the morning" is not a substitute for this session's fetch —
+  conditions vary day to day and hour to hour.
+- **A missing data point is not a good sign by default.** No air-quality grid
+  coverage, a geocoding miss, a forecast gap — report each as "not
+  available," never silently drop it.
+- **The call is the user's.** This scores conditions; it doesn't know their
+  fitness level, heat acclimation, or hydration status.
+
+## Approvals
+
+Runs automatically (no approval needed): all Open-Meteo fetches (geocoding,
+forecast, air quality). This template has no credential-gated or destructive
+actions at all.
+
+## Output style
+
+- **Result-first.** Lead with the best window, then the window to avoid, then
+  the reasoning — not a narration of every fetch made.
+- **Chat links = bare URLs**, one per line — never `[label](url)` in chat.
+- **Keep it scannable** — one screen, not a wall of hourly data, unless the
+  user asks to see the full hour-by-hour picture.

--- a/lifestyle/training-window/skills/training-window/references/report-format.md
+++ b/lifestyle/training-window/skills/training-window/references/report-format.md
@@ -1,0 +1,46 @@
+# Report Format
+
+Lead with the recommendation, then the reasoning, then (only if asked, or if
+the day is unusual) the rest of the picture. Scannable in under 30 seconds.
+
+## Best window (always first)
+
+One line per day requested, in **bold**, naming the driving tier:
+
+```
+**Today's best window: 6:00-8:30am — Great** (feels like 61°F, dew point
+52°F, UV 1, AQI 22)
+```
+
+If nothing today (or tomorrow) clears "Great," say so plainly rather than
+rounding up:
+
+```
+**No Great window today — best available: 7:00-8:00am, OK** (feels like
+78°F, dew point 64°F)
+```
+
+## Avoid window
+
+One line: the worst stretch of the day and the axis that drove it.
+
+```
+**Avoid: 1:00-4:00pm — feels like 96°F, dew point 71°F (heat + humidity)**
+```
+
+## Full picture (only on request, or when the pattern is genuinely unusual)
+
+A compact hour-by-hour list for the requested day(s): time, tier, and the
+one number that drove it. Don't include this by default — it defeats the
+"scannable" point of the tool.
+
+## What wasn't checkable
+
+Always include if anything was missing, even briefly — e.g. "no air-quality
+grid coverage for this location, so the score is heat/humidity/UV only" or
+"tomorrow's forecast wasn't available past hour 18 for this location."
+
+## Closing line
+
+One line noting this scores conditions, not the person — personal heat
+tolerance, acclimation, and hydration still matter, and the call is theirs.

--- a/lifestyle/training-window/skills/training-window/references/scoring.md
+++ b/lifestyle/training-window/skills/training-window/references/scoring.md
@@ -1,0 +1,51 @@
+# Scoring Thresholds
+
+Score every daylight hour (roughly local 5am-9pm) on three axes, then combine
+into one tier. Use Fahrenheit/Celsius consistent with whatever unit the
+forecast response returns (Open-Meteo defaults to Celsius unless
+`temperature_unit=fahrenheit` is passed — pick one and convert the thresholds
+below consistently, don't mix units mid-report).
+
+## Heat & humidity
+
+Use **apparent** ("feels like") temperature plus **dew point**, not the plain
+air temperature — dew point is what actually limits how well sweat
+evaporates, and a "reasonable" thermometer reading with a high dew point can
+be worse than a hotter, drier one.
+
+- **Great**: apparent temp under 65°F (18°C), OR apparent temp under 75°F
+  (24°C) AND dew point under 60°F (15°C)
+- **OK**: apparent temp 75-89°F (24-32°C) with dew point under 65°F (18°C),
+  or apparent temp under 65°F but dew point 60°F+ (muggy-but-cool)
+- **Avoid**: apparent temp 90°F+ (32°C+), OR dew point 70°F+ (21°C+)
+  regardless of temperature (this is the "feels fine but you can't cool off"
+  case — call it out explicitly when it's the driver), OR apparent temp under
+  20°F (-6°C) for cold-injury risk
+
+## UV index
+
+- **Great**: UV index under 3
+- **OK**: UV index 3-7 (mention sunscreen/hat in the report)
+- **Avoid**: UV index 8+ (peak exposure risk)
+
+## Air quality (US AQI)
+
+- **Great**: AQI under 50
+- **OK**: AQI 51-100
+- **Avoid**: AQI 101+ (unhealthy for sensitive groups or worse — materially
+  reduces aerobic performance and irritates airways during heavy breathing,
+  independent of how the weather looks)
+
+## Combining into one hour tier
+
+Take the **worst** of the three axes as the hour's tier — a single "Avoid"
+signal (e.g. wildfire smoke on an otherwise perfect cool morning) should
+dominate even if the other two are great. Record which axis drove the tier
+so the report can say why, not just what.
+
+## Picking the window
+
+Prefer the longest contiguous run of "Great" hours. If none exists, prefer
+the longest run that avoids "Avoid" entirely (i.e., all "OK" or better).
+Report the specific start-end clock time ("6:00-8:30am"), never a vague
+part-of-day label like "morning."


### PR DESCRIPTION
## Summary

Adds `lifestyle/training-window`: before you go for a run, ride, or walk, the agent pulls hourly heat, humidity, UV, and air-quality data for today (and tomorrow, on request) and scores every daylight hour Great/OK/Avoid, surfacing the best contiguous window and the worst stretch to avoid.

- Uses apparent ("feels like") temperature plus dew point — not just air temperature — for the heat/humidity axis, since dew point is what actually limits sweat evaporation and endurance performance.
- Combines heat/humidity, UV index, and air quality (US AQI) into one per-hour tier, taking the worst of the three so a single bad signal (e.g. wildfire smoke) dominates even on an otherwise perfect day.
- **Zero API keys.** Open-Meteo's geocoding, forecast, and air-quality endpoints are all public and free for non-commercial use — usable the instant it's stamped, no `mcp.json` at all.
- Explicit "no Great/OK window today" reporting — a genuine bad-conditions day is never rounded up to a workable one.
- No recurring task — on-demand only, by design (kept the scope tight for this entry).

## Test plan

- [x] `node scripts/check-templates.mjs` passes
- [x] `node scripts/build-index.mjs` regenerated `index.json` cleanly
- [x] `node scripts/check-version-bump.mjs origin/main` clean (new template, no version-bump conflicts)
- [x] Stamped locally via `ncl groups create --template lifestyle/training-window --name "Training Window Test"` — stamped cleanly
- [x] Confirmed no recurring task was created (this template intentionally ships without one)
- [x] Live-verified via the CLI channel with two real locations:
  - Austin, TX (real heat-wave day): correctly scored every daylight hour Avoid on dew point/feels-like, reported the least-bad remaining hour instead of forcing a good answer
  - San Francisco, CA (mild day): correctly identified a clean Great window (all three axes green) and called out the one near-Avoid UV stretch at midday
- [x] Deleted the test group, test wiring, test messaging group, and local template copy afterward
- [x] Diff scanned for credentials — none present; no `mcp.json` at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6QtpgHrRVNfQPgN2H61iA