### PR TITLE
Add ForkCheck evidence-resolution templateAdd ForkCheck evidence-resolution template

### DIFF
--- a/index.json
+++ b/index.json
@@ -31,6 +31,12 @@
         "name": "competitor-analysis",
         "version": "1.0.0",
         "description": "Competitor research agent producing structured docs, news logs, and a tracking spreadsheet"
+      },
+      {
+        "ref": "product/forkcheck",
+        "name": "forkcheck",
+        "version": "1.0.0",
+        "description": "Evidence-resolution agent that designs decisive tests and keeps volatile verdicts alive"
       }
     ],
     "sales": [

--- a/product/forkcheck/.gitignore
+++ b/product/forkcheck/.gitignore
@@ -1,0 +1,1 @@
+.demo-data/

--- a/product/forkcheck/README.md
+++ b/product/forkcheck/README.md
@@ -1,0 +1,289 @@
+# ForkCheck
+
+**Turn disagreements into tests, not guesses.**
+
+ForkCheck is a NanoClaw agent that converts conflicting claims into competing
+hypotheses, finds the safest observation capable of distinguishing them,
+produces an evidence-backed verdict, and automatically rechecks volatile
+conclusions when reality changes. Every result becomes a versioned evidence
+receipt instead of a disposable answer.
+
+```text
+Conflict
+↓
+Hypotheses
+↓
+Decisive question
+↓
+Safest discriminating test
+↓
+Evidence
+↓
+Verdict
+↓
+Evidence receipt
+↓
+Scheduled recheck
+↓
+Reaffirm / invalidate
+```
+
+Search can locate evidence. Confidence, source counts, and persuasive prose do
+not decide the verdict. The decisive observation does.
+
+## Why this is an Overall entry
+
+ForkCheck targets the hackathon's **Overall** category. `product/forkcheck` is
+the separate registry path: `product` describes where the template belongs in
+the NanoClaw catalog, not the hackathon track.
+
+| Overall criterion | What ForkCheck demonstrates |
+|---|---|
+| Originality | An agent that resolves disagreement by designing a falsifying observation, not summarizing or voting on claims. |
+| Usefulness | Reproducible decisions for software behavior, product claims, operations, research, and any scoped testable dispute. |
+| Broad appeal | The hypothesis → test → receipt loop is domain-neutral and understandable without specialist infrastructure. |
+| Implementation quality | Safe-test gates, explicit evidence mapping, atomic JSON ledger updates, preserved history, deterministic tests, and paused-by-default scheduling. |
+| Documentation | A runnable showcase, exact install and validation commands, service disclosures, limitations, and sample receipt. |
+
+The [Official Rules](https://nanoclaw.dev/hackathon/september-2026-rules)
+require substantive sponsor-product use only for Partner Track entries. An
+integration is not mandatory for Overall. Tavily is included because current web
+discovery is genuinely useful to ForkCheck; it is not being used to imply a
+Tavily Track entry.
+
+## The two-act demo
+
+Run the judge-friendly showcase from the repository root:
+
+```bash
+node product/forkcheck/demos/showcase.mjs
+```
+
+**Demo B is the hero.** Two claims disagree about the exact Node runtime.
+ForkCheck ignores version-general rhetoric and executes one read-only capability
+probe: `typeof Array.prototype.toSorted`. The observed value selects the
+hypothesis and produces a receipt tied to this environment.
+
+**Demo C is the reveal.** A controlled capability record changes from
+`streaming=false` to `streaming=true`. ForkCheck repeats the same decisive test,
+preserves both receipts, appends the transition history, and prints:
+
+```text
+⚠ VERDICT INVALIDATED
+```
+
+The fixture is deliberately labeled and deterministic. It proves the
+invalidation mechanism; it is never presented as an external event that happened
+to change during judging.
+
+Individual machine-readable demos remain available:
+
+```bash
+node product/forkcheck/demos/run-demo.mjs --demo a
+node product/forkcheck/demos/run-demo.mjs --demo b
+node product/forkcheck/demos/run-demo.mjs --demo c
+```
+
+## What ships
+
+- `resolve-disagreement` scopes the conflict and coordinates the full loop.
+- `design-test` predicts observations and ranks safe candidate tests.
+- `evaluate-evidence` maps every evidence item to every hypothesis before
+  issuing a verdict.
+- `recheck-verdict` repeats the stored test and preserves every transition.
+- Tavily Search and Extract provide optional current-evidence discovery.
+- `forkcheck-ledger.mjs` writes dependency-free JSON state and Markdown receipts.
+- `recheck-volatile-verdicts` is a daily, script-gated task that stamps paused.
+- Three deterministic scenarios and Node tests exercise receipts, due checks,
+  and invalidation.
+
+## Architecture and durable state
+
+The stamped plugin is read-only. Runtime state uses NanoClaw's plugin-owned
+writable directory:
+
+```text
+/workspace/agent/plugins/forkcheck/             read-only template
+/workspace/agent/plugin-data/forkcheck/         durable state
+├── ledger.json
+└── receipts/
+    └── FC-0001/
+        ├── 001-created.md
+        ├── 002-verified-again.md
+        └── latest.md
+```
+
+Each record stores the scoped question, hypotheses, predicted observations,
+selected test, evidence classifications, verdict, confidence, limitations,
+volatility, recheck time, and append-only transition history. Old receipts are
+never silently replaced.
+
+## Requirements and service disclosure
+
+- A current NanoClaw v2 checkout with Agent Plugins 1.0.0 template support.
+- Node.js 22+ and a working Linux container runtime supported by NanoClaw.
+- WSL2 when the NanoClaw host is Windows.
+- Network access only when Tavily discovery is used.
+
+No provider, model, credential, API key, or user-specific configuration is
+stored in the template. No paid service is required.
+
+### Tavily Search and Extract
+
+| Requirement | Exact value |
+|---|---|
+| API host | `mcp.tavily.com` |
+| Transport | Remote MCP bridged over stdio by pinned `mcp-remote@0.1.38` |
+| Default auth | Keyless IP-based allowance via `X-Tavily-Access-Mode:keyless` |
+| Exposed access | `tavily_search` and `tavily_extract` only; Crawl, Map, and Research are filtered out |
+| OAuth scopes | Not applicable; the keyless endpoint does not request OAuth scopes |
+| Optional key | Create it at [Tavily](https://app.tavily.com) and store it as an `Authorization: Bearer` credential for `mcp.tavily.com` in NanoClaw's OneCLI vault |
+
+The keyless allowance is shared and can be exhausted. An optional user-supplied
+key can use Tavily's free account allowance; paid Tavily tiers are optional, not
+a template dependency. Never put a key in `mcp.json`, source control, an agent
+prompt, or a receipt.
+
+## Install into NanoClaw
+
+From a current NanoClaw checkout:
+
+```bash
+mkdir -p templates/product
+cp -R /path/to/forkcheck/product/forkcheck templates/product/forkcheck
+ncl groups create --template product/forkcheck --name "ForkCheck"
+```
+
+The bare ref is relative to NanoClaw's local `templates/` directory. It is not a
+Git URL. The command stamps a group but does not wire a messaging channel; use
+NanoClaw's channel-management flow to connect one.
+
+For an existing ForkCheck agent, inspect the restamp plan before applying it:
+
+```bash
+ncl groups create --template product/forkcheck
+ncl groups create --template product/forkcheck --yes --id <group-id>
+ncl groups restart --id <group-id>
+```
+
+Restamping resets plugin-owned surfaces while preserving sessions, memory,
+wiring, task pause/resume state, and `plugin-data/forkcheck`.
+
+## Scheduled living verdicts
+
+Stamping creates `recheck-volatile-verdicts` in a paused state. Inspect it before
+enabling it:
+
+```bash
+ncl tasks list --group <group-id> --status paused
+ncl tasks run <task-id> --group <group-id>
+ncl tasks get <task-id> --group <group-id>
+ncl tasks resume <task-id> --group <group-id>
+```
+
+The gate reads only ledger timestamps. With nothing due it returns
+`wakeAgent: false`, so it consumes no model turn. A due ID is handed to
+`recheck-verdict`. Unchanged checks remain quiet by default; weakened,
+unresolved, or invalidated checks notify the user.
+
+## Verdict contract
+
+ForkCheck labels each item `OBSERVED`, `INFERRED`, `CLAIMED`, or `NOT TESTED`.
+A fresh resolution uses only `SUPPORTED`, `REFUTED`, `MIXED`, or `UNRESOLVED`,
+plus qualitative `LOW`, `MEDIUM`, or `HIGH` confidence.
+
+A receipt looks like this:
+
+```text
+FORKCHECK VERDICT FC-0001
+
+Question: Does this exact runtime provide Array.prototype.toSorted?
+H1: The capability is present.
+H2: The capability is absent.
+Test: Evaluate typeof Array.prototype.toSorted in the current runtime.
+Executed: yes
+Observed: function
+Verdict: SUPPORTED — H1
+Confidence: HIGH
+Volatility: HIGH
+Recheck: 14 days
+Limit: Applies only to the recorded runtime and environment.
+```
+
+## Safety boundaries
+
+A live experiment must be legal, authorized, bounded, read-only or safely
+reversible, free of meaningful financial cost, and unable to harm people,
+systems, data, or third parties. ForkCheck does not bypass controls or request
+secrets in chat.
+
+Destructive writes, production mutations, purchases, load tests, exploit
+attempts, and high-stakes real-world experiments are out of bounds. If no safe
+decisive observation exists, the result is `UNRESOLVED` and the experiment is
+labeled `NOT TESTED`.
+
+## Limitations
+
+- Inaccessible evidence, provider failures, permissions, and rate limits can
+  leave a dispute unresolved.
+- Direct observations can still be mis-scoped by runtime, version, region,
+  feature flag, or authentication state; receipts record those limits.
+- The JSON ledger is designed for one NanoClaw agent group, not concurrent
+  high-throughput writers.
+- Tavily keyless availability is external and not guaranteed.
+- The recurring task remains inactive until an operator resumes it.
+- Demo C uses a controlled fixture and proves mechanics, not a live vendor
+  change.
+
+## Validate before submission
+
+Run ForkCheck's deterministic suite:
+
+```bash
+node --test product/forkcheck/tests/forkcheck.test.mjs
+```
+
+Then copy the template into a fresh checkout of the official registry and run
+the same zero-dependency validator used by CI:
+
+```bash
+git clone https://github.com/nanocoai/nanoclaw-templates.git
+cp -R /path/to/forkcheck/product/forkcheck nanoclaw-templates/product/forkcheck
+cd nanoclaw-templates
+node scripts/check-templates.mjs
+```
+
+Finally, stamp the bare ref into a working NanoClaw install, confirm the task is
+paused, send one real disagreement through the agent, and inspect the generated
+ledger and receipt. The official [template contribution guide](https://github.com/nanocoai/nanoclaw-templates/blob/main/CONTRIBUTING.md)
+is the source of truth for the registry PR.
+
+## Third-party and open-source components
+
+| Component | Use | License / terms |
+|---|---|---|
+| [NanoClaw](https://github.com/nanocoai/nanoclaw) | Host runtime and template extension | MIT |
+| [Agent Plugins 1.0.0](https://agent-plugins.org) | Portable plugin and MCP manifest format | Open standard; no code vendored |
+| [`mcp-remote@0.1.38`](https://github.com/geelen/mcp-remote) | Stdio-to-remote-MCP bridge, installed by `npx` at runtime | MIT |
+| [Tavily Remote MCP](https://docs.tavily.com/documentation/mcp) | Optional Search and Extract service | External service terms apply; no code or credential vendored |
+
+ForkCheck itself is submitted to the MIT-licensed NanoClaw template registry.
+The template contains no copied proprietary data, confidential information, or
+third-party credentials.
+
+## Hackathon submission facts
+
+- Entry category: **Overall**.
+- Registry path: **`product/forkcheck`**.
+- Deadline: **September 6, 2026 at 20:59 UTC**; NanoCo's clock controls.
+- Required path: open a template PR, then provide the requested entry details
+  and a short video showing the agent or workflow running through the official
+  form.
+- The published page and rules do not state a numeric maximum video duration or
+  a required video host. Verify the live form before recording the final cut.
+- Official judging criteria: originality, usefulness, broad appeal,
+  implementation quality, and documentation.
+
+Sources: [hackathon page](https://nanoclaw.dev/hackathon/),
+[Official Rules](https://nanoclaw.dev/hackathon/september-2026-rules), and
+[template submission documentation](https://docs.nanoclaw.dev/templates/submitting).

--- a/product/forkcheck/ai.nanoco.nanoclaw/context/additional_context/evidence-policy.md
+++ b/product/forkcheck/ai.nanoco.nanoclaw/context/additional_context/evidence-policy.md
@@ -1,0 +1,58 @@
+# Evidence policy
+
+## Evidence hierarchy
+
+Use this as a rebuttable ordering, not a mechanical score:
+
+1. Direct reproducible observation
+2. Current authoritative primary source
+3. Current official specification
+4. Maintainer or source-owner statement
+5. High-quality secondary source
+6. Independent reports
+7. Search snippets or tertiary summaries
+8. Unsupported assertion
+
+A current API response can outrank stale documentation. An official source can
+still be old, ambiguous, or about another version. Repeated copies of one claim
+share a dependency and do not count as independent confirmation.
+
+## Evidence record
+
+For every item capture, when available:
+
+- source title and URL or local path;
+- publisher or source owner;
+- published/updated timestamp;
+- retrieval or execution timestamp;
+- version, region, environment, and scope;
+- classification: `OBSERVED`, `INFERRED`, `CLAIMED`, or `NOT TESTED`;
+- what the item predicts under each hypothesis;
+- limitations and source dependencies.
+
+## Verdict semantics
+
+- `SUPPORTED`: the selected claim or identified hypothesis is materially
+  supported by the decisive evidence and alternatives are inconsistent with it.
+- `REFUTED`: the focal claim is materially inconsistent with the decisive
+  evidence.
+- `MIXED`: evidence supports different claims under genuinely different scopes,
+  or no single hypothesis explains all reliable observations.
+- `UNRESOLVED`: no available safe test discriminates, or the evidence remains
+  insufficient or inaccessible.
+
+Confidence is `LOW`, `MEDIUM`, or `HIGH`. Never manufacture numeric precision.
+
+## Freshness and volatility
+
+- `LOW`: stable historical, mathematical, or physical facts. Recheck only on a
+  specific reason or at a long interval.
+- `MEDIUM`: policies, organizational facts, standards, or facts that change
+  occasionally.
+- `HIGH`: APIs, prices, product capabilities, availability, software behavior,
+  live services, and regulations.
+
+Set `nextCheckAt` from the shortest credible expiry among decisive evidence.
+When evidence expires, the verdict is not automatically false, but it is due
+for re-verification.
+

--- a/product/forkcheck/ai.nanoco.nanoclaw/context/additional_context/safety-policy.md
+++ b/product/forkcheck/ai.nanoco.nanoclaw/context/additional_context/safety-policy.md
@@ -1,0 +1,29 @@
+# Verification safety policy
+
+Execute a live test only when every condition below is satisfied:
+
+- legal and within the user's authorization;
+- read-only or safely reversible;
+- no meaningful financial charge;
+- no harm to people, systems, data, or third parties;
+- no security-control bypass, credential abuse, or privilege escalation;
+- bounded in requests, time, and affected resources;
+- supported by the tools actually available;
+- observable enough to record an honest result.
+
+Prefer a dry run, schema inspection, health endpoint, disposable fixture, or
+single minimal request. Stop as soon as decisive evidence is obtained.
+
+Do not run destructive writes, production mutations, financial transactions,
+load tests, vulnerability exploitation, medical experiments, legal tests with
+real-world exposure, or actions requiring someone else's consent. Do not create
+accounts or accept terms solely to settle a disagreement.
+
+For authenticated or privileged evidence, ask the user to provide access
+through the supported credential system. Never request a secret in chat or put
+one in the plugin, ledger, receipt, task, command history, or source control.
+
+If a decisive experiment is unsafe or unavailable, restrict work to passive
+evidence and return `UNRESOLVED` when necessary. Clearly distinguish a proposed
+test from an executed test.
+

--- a/product/forkcheck/ai.nanoco.nanoclaw/context/instructions.md
+++ b/product/forkcheck/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,55 @@
+# ForkCheck
+
+You resolve factual and testable disagreements by finding the observation that
+would make at least one competing answer untenable. Sounding confident is not
+resolution.
+
+When a user presents conflicting claims, use the `resolve-disagreement` skill.
+For test planning, use `design-test`; for evidence-to-hypothesis mapping, use
+`evaluate-evidence`; for stored verdicts or scheduled checks, use
+`recheck-verdict`.
+
+## Standing rules
+
+- Normalize scope, version, region, time, and terminology before declaring a
+  contradiction.
+- State explicit hypotheses and the decisive question.
+- Select the cheapest safe test that can materially discriminate; do not select
+  a weak test merely because it is convenient.
+- Prefer direct reproducible observation and current primary evidence. Treat
+  web search as discovery, never automatically as the decisive test.
+- Label material as `OBSERVED`, `INFERRED`, `CLAIMED`, or `NOT TESTED`.
+- Never majority-vote sources, count duplicated reports as independent, or
+  invent a test result.
+- Return only `SUPPORTED`, `REFUTED`, `MIXED`, or `UNRESOLVED` for a fresh
+  resolution. Add `LOW`, `MEDIUM`, or `HIGH` confidence without fake precision.
+- Persist every completed resolution with the shipped ledger CLI. Preserve
+  history; never silently overwrite evidence.
+- Assign `LOW`, `MEDIUM`, or `HIGH` volatility and a recheck interval.
+- If a recheck overturns the evidence, mark the old verdict `INVALIDATED` and
+  reopen the question.
+- Refuse destructive, privileged, costly, irreversible, illegal, or unsafe
+  experiments. `UNRESOLVED` is a valid result.
+
+## Runtime paths
+
+- Read-only plugin: `/workspace/agent/plugins/forkcheck`
+- Durable state: `/workspace/agent/plugin-data/forkcheck`
+- Ledger CLI: `/workspace/agent/plugins/forkcheck/scripts/forkcheck-ledger.mjs`
+
+Detailed evidence rules are in `additional_context/evidence-policy.md`. Safety
+and experiment boundaries are in `additional_context/safety-policy.md`. Read
+both before executing a live verification.
+
+## Default response shape
+
+Use concise, scannable sections:
+
+`CONFLICT` → `HYPOTHESES` → `DECISIVE QUESTION` → `TEST OPTIONS` →
+`SELECTED TEST` → `OBSERVATION` → `VERDICT` → `EVIDENCE RECEIPT` →
+`RECHECK POLICY`.
+
+If the claims do not genuinely conflict, say `NO MATERIAL CONFLICT` and explain
+the scope difference. If the matter is subjective or untestable, say so rather
+than forcing hypotheses.
+

--- a/product/forkcheck/ai.nanoco.nanoclaw/tasks/recheck-volatile-verdicts.md
+++ b/product/forkcheck/ai.nanoco.nanoclaw/tasks/recheck-volatile-verdicts.md
@@ -1,0 +1,16 @@
+---
+schedule: "0 9 * * *"
+script: |
+  node /workspace/agent/plugins/forkcheck/scripts/due-check.mjs --data-dir /workspace/agent/plugin-data/forkcheck
+---
+
+# Recheck due ForkCheck verdicts
+
+The script gate supplies the IDs of volatile verdicts whose `nextCheckAt` has
+arrived. For each due ID, use the `recheck-verdict` skill.
+
+Reconstruct the original decisive test, verify that it remains safe and valid,
+and repeat it with current evidence. Preserve all prior evidence and history.
+Stay quiet when no verdict is due. Notify the user only if a verdict is
+`WEAKENED`, `UNRESOLVED`, or `INVALIDATED`, or if user action is required.
+

--- a/product/forkcheck/demos/fixtures/demo-a-primary-source.json
+++ b/product/forkcheck/demos/fixtures/demo-a-primary-source.json
@@ -1,0 +1,37 @@
+{
+  "question": "Does a current NanoClaw Agent Template use plugin.json at the template root as its discovery marker?",
+  "hypotheses": {
+    "h1": "Current NanoClaw templates use plugin.json at the template root.",
+    "h2": "Current NanoClaw templates require .codex-plugin/plugin.json instead."
+  },
+  "decisiveTest": {
+    "name": "Inspect the current ForkCheck template root and official NanoClaw template contract",
+    "method": "Read the root manifest and compare its schema/path to the current template parser contract.",
+    "expectedByHypothesis": {
+      "h1": "A root plugin.json is present and accepted as the discovery marker.",
+      "h2": "The root file is absent or rejected in favor of .codex-plugin/plugin.json."
+    },
+    "executed": false,
+    "safety": "read-only"
+  },
+  "evidence": [
+    {
+      "classification": "OBSERVED",
+      "title": "ForkCheck Agent Plugins 1.0.0 manifest",
+      "source": "../../plugin.json",
+      "retrievedAt": "2026-09-01T00:00:00.000Z",
+      "finding": "The conformant manifest is plugin.json at the template root and declares the Agent Plugins 1.0.0 schema.",
+      "supports": ["h1"],
+      "contradicts": ["h2"],
+      "limitations": ["This fixture demonstrates the checked-in current template; registry rules should be rechecked if the standard changes."]
+    }
+  ],
+  "observation": "A root plugin.json exists and is the discovery manifest used by the current template.",
+  "status": "SUPPORTED",
+  "supportedHypotheses": ["h1"],
+  "confidence": "HIGH",
+  "limitations": ["Agent Plugins clients outside NanoClaw may also support product-specific installation layouts."],
+  "volatility": "MEDIUM",
+  "recheckIntervalDays": 30
+}
+

--- a/product/forkcheck/demos/fixtures/demo-c-source-v1.json
+++ b/product/forkcheck/demos/fixtures/demo-c-source-v1.json
@@ -1,0 +1,7 @@
+{
+  "service": "FixtureStream",
+  "version": "1.0.0",
+  "streaming": false,
+  "updatedAt": "2026-09-01T09:00:00.000Z"
+}
+

--- a/product/forkcheck/demos/fixtures/demo-c-source-v2.json
+++ b/product/forkcheck/demos/fixtures/demo-c-source-v2.json
@@ -1,0 +1,7 @@
+{
+  "service": "FixtureStream",
+  "version": "1.1.0",
+  "streaming": true,
+  "updatedAt": "2026-09-08T09:00:00.000Z"
+}
+

--- a/product/forkcheck/demos/run-demo.mjs
+++ b/product/forkcheck/demos/run-demo.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.dirname(here);
+const ledgerCli = path.join(root, 'scripts', 'forkcheck-ledger.mjs');
+
+function option(name, fallback) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 && process.argv[index + 1] ? process.argv[index + 1] : fallback;
+}
+
+const selected = option('--demo', 'all').toLowerCase();
+const dataDir = path.resolve(option('--data-dir', path.join(root, '.demo-data')));
+fs.mkdirSync(dataDir, { recursive: true });
+
+function runLedger(args) {
+  const result = spawnSync(process.execPath, [ledgerCli, ...args, '--data-dir', dataDir], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+  return JSON.parse(result.stdout);
+}
+
+function writePayload(name, payload) {
+  const file = path.join(os.tmpdir(), `forkcheck-${name}-${process.pid}-${Date.now()}.json`);
+  fs.writeFileSync(file, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return file;
+}
+
+function demoA() {
+  const fixture = path.join(here, 'fixtures', 'demo-a-primary-source.json');
+  const result = runLedger(['record', '--input', fixture]);
+  return { demo: 'A', purpose: 'Primary-source resolution', ...result };
+}
+
+function demoB() {
+  const hasToSorted = typeof Array.prototype.toSorted === 'function';
+  const observation = `typeof Array.prototype.toSorted returned ${typeof Array.prototype.toSorted} in ${process.version}.`;
+  const payload = {
+    question: `Does the current runtime (${process.version}) provide Array.prototype.toSorted without a polyfill?`,
+    hypotheses: {
+      h1: 'The current runtime provides Array.prototype.toSorted natively.',
+      h2: 'The current runtime does not provide Array.prototype.toSorted natively.',
+    },
+    decisiveTest: {
+      name: 'Minimal runtime capability probe',
+      method: 'Evaluate typeof Array.prototype.toSorted in a fresh Node process.',
+      expectedByHypothesis: { h1: 'function', h2: 'undefined or another non-function value' },
+      executed: true,
+      safety: 'read-only, local, one expression',
+    },
+    evidence: [
+      {
+        classification: 'OBSERVED',
+        title: 'Current Node runtime capability probe',
+        source: `local:${process.execPath}`,
+        executedAt: new Date().toISOString(),
+        finding: observation,
+        supports: [hasToSorted ? 'h1' : 'h2'],
+        contradicts: [hasToSorted ? 'h2' : 'h1'],
+        limitations: ['The result applies to this exact runtime version and environment.'],
+      },
+    ],
+    observation,
+    status: 'SUPPORTED',
+    supportedHypotheses: [hasToSorted ? 'h1' : 'h2'],
+    confidence: 'HIGH',
+    limitations: ['Other Node versions or runtimes may differ.'],
+    volatility: 'HIGH',
+    recheckIntervalDays: 14,
+  };
+  const file = writePayload('demo-b', payload);
+  try {
+    const result = runLedger(['record', '--input', file]);
+    return { demo: 'B', purpose: 'Documentation is not enough; execute the minimal test', observation, ...result };
+  } finally {
+    fs.unlinkSync(file);
+  }
+}
+
+function demoC() {
+  const v1 = JSON.parse(fs.readFileSync(path.join(here, 'fixtures', 'demo-c-source-v1.json'), 'utf8'));
+  const v2 = JSON.parse(fs.readFileSync(path.join(here, 'fixtures', 'demo-c-source-v2.json'), 'utf8'));
+  const initialPayload = {
+    question: 'Does FixtureStream currently support streaming?',
+    hypotheses: { h1: 'FixtureStream supports streaming.', h2: 'FixtureStream does not support streaming.' },
+    decisiveTest: {
+      name: 'Inspect the controlled machine-readable capability source',
+      method: 'Read the streaming boolean from the versioned demo fixture.',
+      expectedByHypothesis: { h1: 'streaming=true', h2: 'streaming=false' },
+      executed: true,
+      safety: 'read-only deterministic fixture',
+    },
+    evidence: [
+      {
+        classification: 'OBSERVED',
+        title: `FixtureStream capability record ${v1.version}`,
+        source: 'fixtures/demo-c-source-v1.json',
+        retrievedAt: v1.updatedAt,
+        finding: `streaming=${v1.streaming}`,
+        supports: [v1.streaming ? 'h1' : 'h2'],
+        contradicts: [v1.streaming ? 'h2' : 'h1'],
+        limitations: ['Controlled fixture demonstrates mechanics; it is not presented as a live external change.'],
+      },
+    ],
+    observation: `Fixture version ${v1.version} reports streaming=${v1.streaming}.`,
+    status: 'SUPPORTED',
+    supportedHypotheses: [v1.streaming ? 'h1' : 'h2'],
+    confidence: 'HIGH',
+    limitations: ['Controlled deterministic fixture.'],
+    volatility: 'HIGH',
+    recheckIntervalDays: 7,
+  };
+  const initialFile = writePayload('demo-c-initial', initialPayload);
+  let created;
+  try {
+    created = runLedger(['record', '--input', initialFile]);
+  } finally {
+    fs.unlinkSync(initialFile);
+  }
+
+  const recheckPayload = {
+    outcome: 'INVALIDATED',
+    observation: `Fixture version ${v2.version} reports streaming=${v2.streaming}, reversing the decisive field.`,
+    confidence: 'HIGH',
+    limitations: ['Controlled deterministic fixture.'],
+    evidence: [
+      {
+        classification: 'OBSERVED',
+        title: `FixtureStream capability record ${v2.version}`,
+        source: 'fixtures/demo-c-source-v2.json',
+        retrievedAt: v2.updatedAt,
+        finding: `streaming=${v2.streaming}`,
+        supports: [v2.streaming ? 'h1' : 'h2'],
+        contradicts: [v2.streaming ? 'h2' : 'h1'],
+        limitations: ['Controlled fixture demonstrates invalidation deterministically.'],
+      },
+    ],
+  };
+  const recheckFile = writePayload('demo-c-recheck', recheckPayload);
+  try {
+    const rechecked = runLedger(['recheck', '--id', created.id, '--input', recheckFile]);
+    return {
+      demo: 'C',
+      purpose: 'Living verdict invalidation',
+      initial: created,
+      recheck: rechecked,
+      banner: '⚠️ VERDICT INVALIDATED',
+    };
+  } finally {
+    fs.unlinkSync(recheckFile);
+  }
+}
+
+const demos = { a: demoA, b: demoB, c: demoC };
+const names = selected === 'all' ? ['a', 'b', 'c'] : [selected];
+if (names.some((name) => !(name in demos))) {
+  process.stderr.write('Use --demo a, b, c, or all.\n');
+  process.exit(1);
+}
+
+const results = names.map((name) => demos[name]());
+process.stdout.write(`${JSON.stringify({ dataDir, results }, null, 2)}\n`);
+

--- a/product/forkcheck/demos/showcase.mjs
+++ b/product/forkcheck/demos/showcase.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pluginRoot = path.dirname(here);
+const runDemo = path.join(here, 'run-demo.mjs');
+const ledgerCli = path.join(pluginRoot, 'scripts', 'forkcheck-ledger.mjs');
+
+function option(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 && process.argv[index + 1] ? process.argv[index + 1] : undefined;
+}
+
+const requestedDir = option('--data-dir');
+const dataDir = requestedDir
+  ? path.resolve(requestedDir)
+  : fs.mkdtempSync(path.join(os.tmpdir(), 'forkcheck-showcase-'));
+fs.mkdirSync(dataDir, { recursive: true });
+
+function runJson(file, args) {
+  const result = spawnSync(process.execPath, [file, ...args], { encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+  return JSON.parse(result.stdout);
+}
+
+function line(label, value) {
+  process.stdout.write(`${label.padEnd(18)} ${value}\n`);
+}
+
+function rule(title) {
+  process.stdout.write(`\n${'═'.repeat(68)}\n${title}\n${'═'.repeat(68)}\n`);
+}
+
+rule('DEMO B // THE DECISIVE TEST');
+process.stdout.write('Claim A says the exact runtime has Array.prototype.toSorted.\n');
+process.stdout.write('Claim B says it does not. Documentation is not the test.\n\n');
+line('DECISIVE QUESTION', 'What does this runtime expose right now?');
+line('SELECTED TEST', 'typeof Array.prototype.toSorted');
+line('SAFETY', 'read-only · local · one expression');
+
+const demoB = runJson(runDemo, ['--demo', 'b', '--data-dir', dataDir]).results[0];
+const observedType = /returned ([^ ]+)/.exec(demoB.observation)?.[1] ?? 'unknown';
+process.stdout.write('\n');
+line('OBSERVED', `${observedType} on ${process.version}`);
+line('VERDICT', `${observedType === 'function' ? 'H1' : 'H2'} SUPPORTED · HIGH CONFIDENCE`);
+line('RECEIPT', `${demoB.id} · ${demoB.receipt}`);
+
+rule('DEMO C // LIVING VERDICT');
+line('ORIGINAL EVIDENCE', 'FixtureStream 1.0 · streaming=false');
+line('ORIGINAL VERDICT', 'H2 SUPPORTED · HIGH CONFIDENCE');
+process.stdout.write('\nNew evidence arrives. ForkCheck repeats the same decisive field.\n\n');
+line('NEW EVIDENCE', 'FixtureStream 1.1 · streaming=true');
+
+const demoC = runJson(runDemo, ['--demo', 'c', '--data-dir', dataDir]).results[0];
+const record = runJson(ledgerCli, ['show', '--data-dir', dataDir, '--id', demoC.initial.id]);
+process.stdout.write('\n⚠ VERDICT INVALIDATED\n\n');
+line('TRANSITION', `${demoC.recheck.previousStatus} → ${demoC.recheck.status}`);
+line('HISTORY', record.history.map((item) => item.event).join(' → '));
+line('RECEIPTS KEPT', `${record.receipts.length} versioned receipts`);
+line('LATEST RECEIPT', demoC.recheck.receipt);
+
+rule('FORKCHECK // TESTS, NOT GUESSES');
+line('DURABLE LEDGER', path.join(dataDir, 'ledger.json'));
+line('NEXT ACTION', `Reopen decisions that depended on ${demoC.initial.id}.`);

--- a/product/forkcheck/mcp.json
+++ b/product/forkcheck/mcp.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "tavily": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@0.1.38",
+        "https://mcp.tavily.com/mcp/",
+        "--transport",
+        "http-only",
+        "--enable-proxy",
+        "--header",
+        "X-Tavily-Access-Mode:keyless",
+        "--header",
+        "X-Client-Name:nanoclaw",
+        "--ignore-tool",
+        "tavily_crawl",
+        "--ignore-tool",
+        "tavily_map",
+        "--ignore-tool",
+        "tavily_research"
+      ]
+    }
+  }
+}
+

--- a/product/forkcheck/plugin.json
+++ b/product/forkcheck/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "forkcheck",
+  "version": "1.0.0",
+  "author": {
+    "name": "chivest"
+  },
+  "description": "Evidence-resolution agent that designs decisive tests and keeps volatile verdicts alive",
+  "keywords": ["evidence", "verification", "disagreement", "living-verdicts"],
+  "extensions": {
+    "ai.nanoco.nanoclaw": {
+      "agentName": "ForkCheck"
+    }
+  }
+}

--- a/product/forkcheck/scripts/due-check.mjs
+++ b/product/forkcheck/scripts/due-check.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+function parseDataDir(argv) {
+  const index = argv.indexOf('--data-dir');
+  return index >= 0 && argv[index + 1]
+    ? path.resolve(argv[index + 1])
+    : path.resolve(process.env.PLUGIN_DATA || '/workspace/agent/plugin-data/forkcheck');
+}
+
+try {
+  const file = path.join(parseDataDir(process.argv.slice(2)), 'ledger.json');
+  if (!fs.existsSync(file)) {
+    process.stdout.write('{"wakeAgent":false}\n');
+  } else {
+    const ledger = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const now = Date.now();
+    const dueIds = (ledger.records || [])
+      .filter((record) => record.status !== 'INVALIDATED' && record.nextCheckAt)
+      .filter((record) => new Date(record.nextCheckAt).valueOf() <= now)
+      .map((record) => record.id);
+    process.stdout.write(`${JSON.stringify({ wakeAgent: dueIds.length > 0, data: { dueIds } })}\n`);
+  }
+} catch (error) {
+  process.stdout.write(`${JSON.stringify({
+    wakeAgent: true,
+    data: { ledgerError: error instanceof Error ? error.message : String(error) },
+  })}\n`);
+}
+

--- a/product/forkcheck/scripts/forkcheck-ledger.mjs
+++ b/product/forkcheck/scripts/forkcheck-ledger.mjs
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const STATUSES = new Set(['SUPPORTED', 'REFUTED', 'MIXED', 'UNRESOLVED', 'INVALIDATED']);
+const CONFIDENCES = new Set(['LOW', 'MEDIUM', 'HIGH']);
+const VOLATILITIES = new Set(['LOW', 'MEDIUM', 'HIGH']);
+const RECHECK_OUTCOMES = new Set(['UNCHANGED', 'STRENGTHENED', 'WEAKENED', 'INVALIDATED', 'UNRESOLVED']);
+
+function fail(message) {
+  process.stderr.write(`ForkCheck ledger error: ${message}\n`);
+  process.exitCode = 1;
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const options = {};
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (!token.startsWith('--')) throw new Error(`unexpected argument: ${token}`);
+    const key = token.slice(2);
+    const value = rest[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`missing value for --${key}`);
+    options[key] = value;
+    index += 1;
+  }
+  return { command, options };
+}
+
+function resolveDataDir(options) {
+  return path.resolve(
+    options['data-dir'] ||
+      process.env.PLUGIN_DATA ||
+      path.join(process.cwd(), '.forkcheck-data'),
+  );
+}
+
+function emptyLedger() {
+  return {
+    schemaVersion: 1,
+    nextId: 1,
+    records: [],
+  };
+}
+
+function ensureDataDir(dataDir) {
+  fs.mkdirSync(path.join(dataDir, 'receipts'), { recursive: true });
+}
+
+function ledgerPath(dataDir) {
+  return path.join(dataDir, 'ledger.json');
+}
+
+function readLedger(dataDir) {
+  const file = ledgerPath(dataDir);
+  if (!fs.existsSync(file)) return emptyLedger();
+  const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+  if (parsed?.schemaVersion !== 1 || !Number.isInteger(parsed.nextId) || !Array.isArray(parsed.records)) {
+    throw new Error(`unsupported or malformed ledger: ${file}`);
+  }
+  return parsed;
+}
+
+function writeJsonSafely(file, value) {
+  const temporary = `${file}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+  try {
+    fs.renameSync(temporary, file);
+  } catch (error) {
+    if (!['EEXIST', 'EPERM'].includes(error?.code)) throw error;
+    fs.copyFileSync(temporary, file);
+    fs.unlinkSync(temporary);
+  }
+}
+
+function writeLedger(dataDir, ledger) {
+  ensureDataDir(dataDir);
+  writeJsonSafely(ledgerPath(dataDir), ledger);
+}
+
+function readPayload(file) {
+  if (!file) throw new Error('--input is required');
+  return JSON.parse(fs.readFileSync(path.resolve(file), 'utf8'));
+}
+
+function requireText(value, label) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} must be a nonempty string`);
+  return value.trim();
+}
+
+function requireEnum(value, allowed, label) {
+  if (!allowed.has(value)) throw new Error(`${label} must be one of: ${[...allowed].join(', ')}`);
+  return value;
+}
+
+function requireHypotheses(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('hypotheses must be an object');
+  }
+  const entries = Object.entries(value);
+  if (entries.length < 2) throw new Error('at least two hypotheses are required');
+  return Object.fromEntries(entries.map(([key, hypothesis]) => [key, requireText(hypothesis, `hypotheses.${key}`)]));
+}
+
+function requireStringArray(value, label, allowEmpty = true) {
+  if (!Array.isArray(value) || (!allowEmpty && value.length === 0)) {
+    throw new Error(`${label} must be ${allowEmpty ? 'an' : 'a nonempty'} array`);
+  }
+  return value.map((item, index) => requireText(item, `${label}[${index}]`));
+}
+
+function normalizeEvidence(items, recordedAt, metadata = {}) {
+  if (!Array.isArray(items)) throw new Error('evidence must be an array');
+  return items.map((item, index) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      throw new Error(`evidence[${index}] must be an object`);
+    }
+    const classification = requireEnum(
+      item.classification,
+      new Set(['OBSERVED', 'INFERRED', 'CLAIMED', 'NOT TESTED']),
+      `evidence[${index}].classification`,
+    );
+    return {
+      ...item,
+      classification,
+      title: requireText(item.title, `evidence[${index}].title`),
+      finding: requireText(item.finding, `evidence[${index}].finding`),
+      recordedAt,
+      ...metadata,
+    };
+  });
+}
+
+function isoOrNull(value, label) {
+  if (value === null || value === undefined) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) throw new Error(`${label} must be an ISO-8601 date`);
+  return date.toISOString();
+}
+
+function nextCheckFrom(recordedAt, intervalDays) {
+  if (!Number.isFinite(intervalDays) || intervalDays <= 0) {
+    throw new Error('recheckIntervalDays must be a positive number');
+  }
+  return new Date(new Date(recordedAt).valueOf() + intervalDays * 86_400_000).toISOString();
+}
+
+function allocateId(ledger) {
+  const id = `FC-${String(ledger.nextId).padStart(4, '0')}`;
+  ledger.nextId += 1;
+  return id;
+}
+
+function renderEvidence(evidence) {
+  if (!evidence.length) return '- No evidence recorded.';
+  return evidence
+    .map((item) => {
+      const source = item.source ? ` — ${item.source}` : '';
+      const timestamp = item.retrievedAt || item.executedAt || item.recordedAt;
+      return `- [${item.classification}] ${item.title}${source}\n  - Finding: ${item.finding}\n  - Timestamp: ${timestamp}`;
+    })
+    .join('\n');
+}
+
+function renderHypotheses(hypotheses) {
+  return Object.entries(hypotheses)
+    .map(([key, value]) => `${key.toUpperCase()}:\n${value}`)
+    .join('\n\n');
+}
+
+function renderReceipt(record, event) {
+  const latestHistory = record.history.at(-1);
+  const supported = record.supportedHypotheses?.length
+    ? record.supportedHypotheses.map((key) => key.toUpperCase()).join(', ')
+    : 'None assigned';
+  const header = event === 'INVALIDATED' ? '⚠️ VERDICT INVALIDATED' : `FORKCHECK VERDICT ${record.id}`;
+  const invalidation = event === 'INVALIDATED'
+    ? `\nPrevious conclusion:\n${latestHistory.previousStatus} — ${(latestHistory.previousSupportedHypotheses || []).map((key) => key.toUpperCase()).join(', ') || 'no hypothesis recorded'}\n\nRecommended action:\nReopen decisions that depended on ${record.id}.\n`
+    : '';
+
+  return `${header}\n\nForkCheck verdict:\n${record.id}\n\nQuestion:\n${record.question}\n\nHypotheses:\n${renderHypotheses(record.hypotheses)}\n\nTest:\n${record.decisiveTest.name}\n${record.decisiveTest.method || ''}\nExecuted: ${record.decisiveTest.executed === true ? 'yes' : 'no'}\n\nObserved:\n${record.observation}\n\nSupporting evidence:\n${renderEvidence(record.evidence)}\n\nVerdict:\n${record.status}${record.status === 'SUPPORTED' || record.status === 'REFUTED' ? ` — ${supported}` : ''}\n\nConfidence:\n${record.confidence}\n\nVolatility:\n${record.volatility}\n\nRecheck:\n${record.nextCheckAt || 'No automatic recheck scheduled'}\n\nCreated:\n${record.createdAt}\n\nLast checked:\n${record.lastCheckedAt}\n\nLimitations:\n${record.limitations.length ? record.limitations.map((item) => `- ${item}`).join('\n') : '- None recorded.'}\n${invalidation}`;
+}
+
+function writeReceipt(dataDir, record, event) {
+  const directory = path.join(dataDir, 'receipts', record.id);
+  fs.mkdirSync(directory, { recursive: true });
+  const sequence = String(record.receipts.length + 1).padStart(3, '0');
+  const slug = event.toLowerCase().replaceAll('_', '-');
+  const relative = path.join('receipts', record.id, `${sequence}-${slug}.md`);
+  const content = renderReceipt(record, event);
+  fs.writeFileSync(path.join(dataDir, relative), content, 'utf8');
+  fs.writeFileSync(path.join(directory, 'latest.md'), content, 'utf8');
+  record.receipts.push(relative.replaceAll('\\', '/'));
+  return relative.replaceAll('\\', '/');
+}
+
+function validateLedger(ledger) {
+  const ids = new Set();
+  for (const record of ledger.records) {
+    requireText(record.id, 'record.id');
+    if (ids.has(record.id)) throw new Error(`duplicate record id: ${record.id}`);
+    ids.add(record.id);
+    requireText(record.question, `${record.id}.question`);
+    requireHypotheses(record.hypotheses);
+    requireEnum(record.status, STATUSES, `${record.id}.status`);
+    requireEnum(record.confidence, CONFIDENCES, `${record.id}.confidence`);
+    requireEnum(record.volatility, VOLATILITIES, `${record.id}.volatility`);
+    if (!Array.isArray(record.evidence) || !Array.isArray(record.history) || !Array.isArray(record.receipts)) {
+      throw new Error(`${record.id} has malformed evidence, history, or receipts`);
+    }
+  }
+  return { valid: true, records: ledger.records.length, nextId: ledger.nextId };
+}
+
+function recordVerdict(dataDir, ledger, payload) {
+  const now = new Date().toISOString();
+  const status = requireEnum(payload.status, new Set(['SUPPORTED', 'REFUTED', 'MIXED', 'UNRESOLVED']), 'status');
+  const confidence = requireEnum(payload.confidence, CONFIDENCES, 'confidence');
+  const volatility = requireEnum(payload.volatility, VOLATILITIES, 'volatility');
+  const intervalDays = Number(payload.recheckIntervalDays);
+  const hypotheses = requireHypotheses(payload.hypotheses);
+  const supportedHypotheses = requireStringArray(payload.supportedHypotheses || [], 'supportedHypotheses');
+  for (const key of supportedHypotheses) {
+    if (!(key in hypotheses)) throw new Error(`supported hypothesis does not exist: ${key}`);
+  }
+  if (!payload.decisiveTest || typeof payload.decisiveTest !== 'object') {
+    throw new Error('decisiveTest must be an object');
+  }
+
+  const id = allocateId(ledger);
+  const record = {
+    id,
+    question: requireText(payload.question, 'question'),
+    hypotheses,
+    status,
+    supportedHypotheses,
+    confidence,
+    evidence: normalizeEvidence(payload.evidence || [], now),
+    decisiveTest: {
+      ...payload.decisiveTest,
+      name: requireText(payload.decisiveTest.name, 'decisiveTest.name'),
+      executed: payload.decisiveTest.executed === true,
+    },
+    observation: requireText(payload.observation, 'observation'),
+    volatility,
+    recheckIntervalDays: intervalDays,
+    createdAt: now,
+    lastCheckedAt: now,
+    nextCheckAt: payload.nextCheckAt
+      ? isoOrNull(payload.nextCheckAt, 'nextCheckAt')
+      : nextCheckFrom(now, intervalDays),
+    limitations: requireStringArray(payload.limitations || [], 'limitations'),
+    history: [
+      {
+        at: now,
+        event: 'CREATED',
+        status,
+        supportedHypotheses,
+        observation: requireText(payload.observation, 'observation'),
+      },
+    ],
+    receipts: [],
+  };
+  const receipt = writeReceipt(dataDir, record, 'CREATED');
+  ledger.records.push(record);
+  writeLedger(dataDir, ledger);
+  return { id, status, receipt: path.join(dataDir, receipt), nextCheckAt: record.nextCheckAt };
+}
+
+function recheckVerdict(dataDir, ledger, id, payload) {
+  const record = ledger.records.find((item) => item.id === id);
+  if (!record) throw new Error(`verdict not found: ${id}`);
+  const now = new Date().toISOString();
+  const outcome = requireEnum(payload.outcome, RECHECK_OUTCOMES, 'outcome');
+  const previousStatus = record.status;
+  const previousConfidence = record.confidence;
+  const previousSupportedHypotheses = [...record.supportedHypotheses];
+  const previousLastCheckedAt = record.lastCheckedAt;
+  const newEvidence = normalizeEvidence(payload.evidence || [], now, { recheckOutcome: outcome });
+
+  record.evidence.push(...newEvidence);
+  record.observation = requireText(payload.observation, 'observation');
+  record.lastCheckedAt = now;
+  if (payload.confidence !== undefined) {
+    record.confidence = requireEnum(payload.confidence, CONFIDENCES, 'confidence');
+  }
+  if (payload.limitations !== undefined) {
+    record.limitations = requireStringArray(payload.limitations, 'limitations');
+  }
+
+  if (outcome === 'INVALIDATED') {
+    record.status = 'INVALIDATED';
+    record.reopenedAt = now;
+    record.nextCheckAt = null;
+  } else if (outcome === 'UNRESOLVED') {
+    record.status = 'UNRESOLVED';
+    record.nextCheckAt = payload.nextCheckAt
+      ? isoOrNull(payload.nextCheckAt, 'nextCheckAt')
+      : nextCheckFrom(now, record.recheckIntervalDays);
+  } else {
+    record.nextCheckAt = payload.nextCheckAt
+      ? isoOrNull(payload.nextCheckAt, 'nextCheckAt')
+      : nextCheckFrom(now, record.recheckIntervalDays);
+  }
+
+  record.history.push({
+    at: now,
+    event: outcome === 'UNCHANGED' ? 'VERIFIED_AGAIN' : outcome,
+    previousStatus,
+    status: record.status,
+    previousConfidence,
+    confidence: record.confidence,
+    previousSupportedHypotheses,
+    supportedHypotheses: [...record.supportedHypotheses],
+    previousLastCheckedAt,
+    observation: record.observation,
+    evidenceAdded: newEvidence.length,
+  });
+  const receipt = writeReceipt(dataDir, record, outcome);
+  writeLedger(dataDir, ledger);
+  return {
+    id,
+    outcome,
+    status: record.status,
+    receipt: path.join(dataDir, receipt),
+    previousStatus,
+    nextCheckAt: record.nextCheckAt,
+  };
+}
+
+function listDue(ledger, at) {
+  const cutoff = new Date(at || Date.now());
+  if (Number.isNaN(cutoff.valueOf())) throw new Error('--at must be an ISO-8601 date');
+  return ledger.records
+    .filter((record) => record.status !== 'INVALIDATED' && record.nextCheckAt)
+    .filter((record) => new Date(record.nextCheckAt) <= cutoff)
+    .map((record) => ({
+      id: record.id,
+      question: record.question,
+      status: record.status,
+      volatility: record.volatility,
+      nextCheckAt: record.nextCheckAt,
+    }));
+}
+
+function main() {
+  const { command, options } = parseArgs(process.argv.slice(2));
+  const dataDir = resolveDataDir(options);
+  ensureDataDir(dataDir);
+  const ledger = readLedger(dataDir);
+
+  switch (command) {
+    case 'init':
+      if (!fs.existsSync(ledgerPath(dataDir))) writeLedger(dataDir, ledger);
+      return { initialized: true, dataDir, ledger: ledgerPath(dataDir) };
+    case 'record':
+      return recordVerdict(dataDir, ledger, readPayload(options.input));
+    case 'show': {
+      const record = ledger.records.find((item) => item.id === options.id);
+      if (!record) throw new Error(`verdict not found: ${options.id || '(missing --id)'}`);
+      return record;
+    }
+    case 'list':
+      return ledger.records.map(({ id, question, status, confidence, volatility, nextCheckAt }) => ({
+        id,
+        question,
+        status,
+        confidence,
+        volatility,
+        nextCheckAt,
+      }));
+    case 'list-due':
+      return listDue(ledger, options.at);
+    case 'recheck':
+      if (!options.id) throw new Error('--id is required');
+      return recheckVerdict(dataDir, ledger, options.id, readPayload(options.input));
+    case 'validate':
+      return validateLedger(ledger);
+    default:
+      throw new Error('command must be one of: init, record, show, list, list-due, recheck, validate');
+  }
+}
+
+try {
+  const result = main();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}
+

--- a/product/forkcheck/skills/design-test/SKILL.md
+++ b/product/forkcheck/skills/design-test/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: design-test
+description: >
+  Design and rank observations or experiments that distinguish explicit
+  competing hypotheses. Use after a disagreement has been scoped, when deciding
+  what evidence would actually settle a claim, or before executing a live
+  verification.
+---
+
+# Design a discriminating test
+
+## Core question
+
+For each hypothesis ask: “What result would be expected here, and which other
+hypotheses would make that result unlikely or impossible?”
+
+## Candidate generation
+
+Generate the smallest useful set of candidate tests, normally three:
+
+1. current authoritative documentation or specification;
+2. current machine-readable state, schema, repository, or API inspection;
+3. minimal reproducible observation or executable request.
+
+Add other candidates only when they produce a genuinely different observation.
+
+## Candidate card
+
+For each test state:
+
+- predicted result under every hypothesis;
+- evidential strength: `LOW`, `MEDIUM`, `HIGH`, or `VERY HIGH`;
+- cost and time: `VERY LOW`, `LOW`, `MEDIUM`, or `HIGH`;
+- risk: `NONE`, `LOW`, `MEDIUM`, or `HIGH`;
+- reversibility: `READ-ONLY`, `REVERSIBLE`, or `IRREVERSIBLE`;
+- permissions and credentials required;
+- freshness and scope;
+- stopping rule: the exact result that makes further testing unnecessary.
+
+## Selection rule
+
+Discard any candidate that is illegal, unsafe, irreversible, meaningfully
+expensive, outside authorization, or unsupported by available tools.
+
+Among the remaining tests, choose the cheapest test with enough evidential
+strength to materially discriminate. A low-cost test that cannot distinguish
+the hypotheses is not cheaper in the relevant sense; it is wasted work.
+
+Prefer passive primary evidence when conclusive. Prefer a minimal direct
+observation when documents conflict or describe behavior ambiguously. Stop as
+soon as the decisive threshold is met.
+
+## Before execution
+
+Read `additional_context/safety-policy.md`. Confirm:
+
+- target and scope are exact;
+- request count and resource impact are bounded;
+- expected outputs are safe to record;
+- no secret will enter chat, source control, or the ledger;
+- a failure cannot corrupt state or affect third parties;
+- the result can be reproduced or independently inspected.
+
+If any condition fails, return the proposed design as `NOT TESTED` and hand the
+workflow back for passive evidence or `UNRESOLVED`.
+

--- a/product/forkcheck/skills/evaluate-evidence/SKILL.md
+++ b/product/forkcheck/skills/evaluate-evidence/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: evaluate-evidence
+description: >
+  Evaluate gathered evidence against competing hypotheses, account for source
+  quality, freshness, dependencies, and scope, then issue a supported,
+  refuted, mixed, or unresolved verdict with an auditable evidence receipt.
+  Use after evidence collection or a safe verification has produced results.
+---
+
+# Evaluate evidence
+
+## Build the evidence map
+
+Create one row per materially distinct evidence item:
+
+| Evidence | Class | Freshness | H1 | H2 | Dependency | Limits |
+|---|---|---|---|---|---|---|
+
+For H1/H2 use `SUPPORTS`, `CONTRADICTS`, or `NEUTRAL`. Extend the table for a
+hypothesis set. Do not collapse the map into source counts.
+
+Classify every item as:
+
+- `OBSERVED`: directly obtained or executed in this run;
+- `INFERRED`: reasoned from observations;
+- `CLAIMED`: asserted by a source but not independently observed;
+- `NOT TESTED`: proposed or unavailable.
+
+## Quality checks
+
+1. Verify the evidence matches the scoped time, version, region, environment,
+   and terminology.
+2. Prefer current primary evidence, but test whether it is stale or ambiguous.
+3. Identify shared provenance. Mirrors, syndicated articles, and pages quoting
+   the same announcement are one dependency, not independent confirmations.
+4. Compare observed behavior with documentation. A reproducible current
+   observation may override stale docs; document why.
+5. Look for failure explanations that fit multiple hypotheses, such as missing
+   auth, rate limits, feature flags, or wrong versions.
+6. State what evidence would change the verdict.
+
+## Issue the verdict
+
+Use only:
+
+- `SUPPORTED`
+- `REFUTED`
+- `MIXED`
+- `UNRESOLVED`
+
+Name the hypothesis affected, for example `H2 SUPPORTED`. Add qualitative
+confidence `LOW`, `MEDIUM`, or `HIGH`. Do not use percentages unless a real,
+documented statistical model exists.
+
+Choose `MIXED` when reliable observations differ by a legitimate scope. Choose
+`UNRESOLVED` when the discriminating evidence is unavailable, unsafe, or still
+compatible with multiple hypotheses.
+
+## Evidence receipt
+
+The receipt must contain:
+
+- disagreement ID;
+- exact question;
+- all hypotheses;
+- selected decisive test and whether it was executed;
+- evidence with retrieval/execution timestamps;
+- observed result;
+- verdict and supported/refuted hypotheses;
+- confidence;
+- important limitations;
+- volatility and recommended recheck interval;
+- created timestamp.
+
+Persist the structured record with the ledger CLI described in the
+`resolve-disagreement` skill. The generated Markdown receipt is the audit view;
+the JSON ledger is the machine-readable source of truth.
+

--- a/product/forkcheck/skills/recheck-verdict/SKILL.md
+++ b/product/forkcheck/skills/recheck-verdict/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: recheck-verdict
+description: >
+  Re-verify a stored ForkCheck verdict, repeat its decisive test safely, compare
+  old and new evidence, preserve history, and mark changed conclusions as
+  invalidated. Use when a verdict is due, when the scheduled task supplies a
+  disagreement ID, or when a user asks whether an earlier verdict still holds.
+---
+
+# Recheck a living verdict
+
+## Load and reconstruct
+
+Inspect the stored record:
+
+```bash
+node /workspace/agent/plugins/forkcheck/scripts/forkcheck-ledger.mjs show \
+  --data-dir /workspace/agent/plugin-data/forkcheck \
+  --id FC-0001
+```
+
+Confirm the original decisive test still discriminates the hypotheses and is
+still legal, safe, bounded, and supported by available tools. If versions,
+auth, endpoints, or scope changed, redesign the minimal test before proceeding
+and record that limitation.
+
+## Repeat and compare
+
+Gather fresh evidence using the same test where valid. Compare the old and new
+observations and select exactly one transition:
+
+- `UNCHANGED`: same material conclusion; record `VERIFIED_AGAIN`.
+- `STRENGTHENED`: same conclusion with materially better evidence or fewer
+  limitations.
+- `WEAKENED`: same conclusion remains plausible but support degraded.
+- `INVALIDATED`: new evidence materially contradicts the old verdict.
+- `UNRESOLVED`: the current test no longer discriminates or cannot be run.
+
+Write a recheck payload containing `outcome`, `evidence`, `observation`, and
+optional `confidence`, `limitations`, and `nextCheckAt`, then run:
+
+```bash
+node /workspace/agent/plugins/forkcheck/scripts/forkcheck-ledger.mjs recheck \
+  --data-dir /workspace/agent/plugin-data/forkcheck \
+  --id FC-0001 \
+  --input /workspace/agent/plugin-data/forkcheck/pending-recheck.json
+```
+
+The CLI appends history and evidence atomically. It never deletes the old
+receipt or prior evidence.
+
+## User notification
+
+For `UNCHANGED` or `STRENGTHENED`, update the receipt and remain quiet unless the
+user explicitly requested periodic status.
+
+For `WEAKENED` or `UNRESOLVED`, explain what degraded and what would restore a
+decision.
+
+For `INVALIDATED`, lead with:
+
+```text
+⚠️ VERDICT INVALIDATED
+
+ForkCheck verdict: FC-NNNN
+Previous conclusion: ...
+New evidence: ...
+Old verification: ...
+New verification: ...
+Recommended action: Reopen decisions that depended on FC-NNNN.
+```
+
+Do not silently replace the previous conclusion. The record status becomes
+`INVALIDATED`, the disagreement is reopened, and the full old evidence remains
+in history.
+

--- a/product/forkcheck/skills/resolve-disagreement/SKILL.md
+++ b/product/forkcheck/skills/resolve-disagreement/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: resolve-disagreement
+description: >
+  Detect and resolve a factual or testable disagreement by normalizing scope,
+  expressing competing hypotheses, finding a discriminating observation,
+  gathering evidence, issuing a qualitative verdict, and storing an evidence
+  receipt. Use when a user presents conflicting claims, asks which source is
+  correct, or when mutually incompatible evidence is discovered during work.
+---
+
+# Resolve a disagreement
+
+## Goal
+
+Turn disagreement into an observable fork: a result expected under one
+hypothesis and not the alternatives.
+
+## Procedure
+
+1. Quote or faithfully normalize each claim. Identify claimant, time, version,
+   region, environment, and definitions.
+2. Test whether the claims genuinely contradict. Resolve ambiguity and scope
+   first. If both can be true under different scopes, return `NO MATERIAL
+   CONFLICT` or formulate the narrower remaining conflict.
+3. Reject false objectivity. Subjective preferences, values, predictions with no
+   measurable horizon, and unfalsifiable claims are not factual disagreements.
+4. Form hypotheses that are mutually distinguishable and collectively cover the
+   plausible claim set. Use H1/H2 for two claims; use H1..Hn when reality is not
+   binary.
+5. State the decisive question: “What observable result would differ if H1
+   rather than H2 were true?”
+6. Use the `design-test` skill. Do not gather broad research until the desired
+   discriminating evidence is clear.
+7. Gather only evidence relevant to the predictions. Use Tavily Search/Extract
+   to discover current primary sources when available, but do not treat search
+   rank, snippet text, or result count as a verdict.
+8. If documents settle the question conclusively, stop. Otherwise, execute the
+   selected minimal test only when the safety policy permits it.
+9. Use the `evaluate-evidence` skill. Explicitly map each observation to every
+   hypothesis.
+10. Present the result in this order:
+    `CONFLICT`, `HYPOTHESES`, `DECISIVE QUESTION`, `TEST OPTIONS`, `SELECTED
+    TEST`, `OBSERVATION`, `VERDICT`, `EVIDENCE RECEIPT`, `RECHECK POLICY`.
+11. Store the completed record using the ledger CLI. Write the record payload to
+    the durable state directory, then run:
+
+    ```bash
+    node /workspace/agent/plugins/forkcheck/scripts/forkcheck-ledger.mjs record \
+      --data-dir /workspace/agent/plugin-data/forkcheck \
+      --input /workspace/agent/plugin-data/forkcheck/pending-record.json
+    ```
+
+    Report the assigned `FC-NNNN` ID and receipt path. Delete only the temporary
+    payload after the command succeeds; never delete the ledger or receipts.
+
+## Required record fields
+
+The JSON payload must contain:
+
+```json
+{
+  "question": "Exact scoped question",
+  "hypotheses": { "h1": "...", "h2": "..." },
+  "decisiveTest": {
+    "name": "...",
+    "method": "...",
+    "expectedByHypothesis": { "h1": "...", "h2": "..." },
+    "executed": true,
+    "safety": "read-only"
+  },
+  "evidence": [
+    {
+      "classification": "OBSERVED",
+      "title": "...",
+      "source": "https://...",
+      "retrievedAt": "ISO-8601 timestamp",
+      "finding": "...",
+      "supports": ["h1"],
+      "contradicts": ["h2"],
+      "limitations": ["..."]
+    }
+  ],
+  "observation": "What was observed",
+  "status": "SUPPORTED",
+  "supportedHypotheses": ["h1"],
+  "confidence": "HIGH",
+  "limitations": ["..."],
+  "volatility": "HIGH",
+  "recheckIntervalDays": 7
+}
+```
+
+Set `executed` to `false` for a documentary test or proposed experiment. Never
+label an inference as an observation.
+
+## Failure handling
+
+- Inaccessible or authenticated evidence: record what was attempted and return
+  `UNRESOLVED` unless other decisive evidence exists.
+- Unsafe decisive test: show the test as `NOT TESTED`, explain the boundary, and
+  return `UNRESOLVED` if passive evidence is insufficient.
+- More than two claims: retain all viable hypotheses and choose tests that split
+  the set as efficiently as safety permits.
+

--- a/product/forkcheck/tests/forkcheck.test.mjs
+++ b/product/forkcheck/tests/forkcheck.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const pluginRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const ledgerCli = path.join(pluginRoot, 'scripts', 'forkcheck-ledger.mjs');
+const demoCli = path.join(pluginRoot, 'demos', 'run-demo.mjs');
+const showcaseCli = path.join(pluginRoot, 'demos', 'showcase.mjs');
+
+function run(file, args) {
+  const result = spawnSync(process.execPath, [file, ...args], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return JSON.parse(result.stdout);
+}
+
+test('Demo C preserves the old verdict and emits a versioned invalidation receipt', () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forkcheck-demo-c-'));
+  const output = run(demoCli, ['--demo', 'c', '--data-dir', dataDir]);
+  const result = output.results[0];
+  assert.equal(result.banner, '⚠️ VERDICT INVALIDATED');
+  assert.equal(result.recheck.status, 'INVALIDATED');
+
+  const record = run(ledgerCli, ['show', '--data-dir', dataDir, '--id', result.initial.id]);
+  assert.equal(record.history[0].event, 'CREATED');
+  assert.equal(record.history[1].event, 'INVALIDATED');
+  assert.equal(record.evidence.length, 2);
+  assert.equal(record.receipts.length, 2);
+  assert.notEqual(record.receipts[0], record.receipts[1]);
+  assert.match(fs.readFileSync(path.join(dataDir, record.receipts[1]), 'utf8'), /VERDICT INVALIDATED/);
+});
+
+test('due-check remains quiet for a fresh future verdict', () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forkcheck-due-'));
+  run(demoCli, ['--demo', 'a', '--data-dir', dataDir]);
+  const result = run(path.join(pluginRoot, 'scripts', 'due-check.mjs'), ['--data-dir', dataDir]);
+  assert.equal(result.wakeAgent, false);
+  assert.deepEqual(result.data.dueIds, []);
+});
+
+test('due-check wakes only with the exact overdue verdict IDs', () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forkcheck-overdue-'));
+  const demo = run(demoCli, ['--demo', 'a', '--data-dir', dataDir]);
+  const id = demo.results[0].id;
+  const ledgerFile = path.join(dataDir, 'ledger.json');
+  const ledger = JSON.parse(fs.readFileSync(ledgerFile, 'utf8'));
+  ledger.records[0].nextCheckAt = '2000-01-01T00:00:00.000Z';
+  fs.writeFileSync(ledgerFile, `${JSON.stringify(ledger, null, 2)}\n`, 'utf8');
+
+  const result = run(path.join(pluginRoot, 'scripts', 'due-check.mjs'), ['--data-dir', dataDir]);
+  assert.equal(result.wakeAgent, true);
+  assert.deepEqual(result.data.dueIds, [id]);
+});
+
+test('ledger validates after all deterministic demos', () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forkcheck-all-'));
+  run(demoCli, ['--demo', 'all', '--data-dir', dataDir]);
+  const result = run(ledgerCli, ['validate', '--data-dir', dataDir]);
+  assert.deepEqual(result, { valid: true, records: 3, nextId: 4 });
+});
+
+test('showcase leads with the decisive test and makes invalidation visible', () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forkcheck-showcase-test-'));
+  const result = spawnSync(process.execPath, [showcaseCli, '--data-dir', dataDir], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.ok(result.stdout.indexOf('DEMO B // THE DECISIVE TEST') < result.stdout.indexOf('DEMO C // LIVING VERDICT'));
+  assert.match(result.stdout, /OBSERVED\s+\S+ on v\d+/);
+  assert.match(result.stdout, /⚠ VERDICT INVALIDATED/);
+  assert.match(result.stdout, /HISTORY\s+CREATED → INVALIDATED/);
+  assert.match(result.stdout, /RECEIPTS KEPT\s+2 versioned receipts/);
+});


### PR DESCRIPTION
## What

Adds `product/forkcheck`, an evidence-resolution agent template that turns incompatible claims into explicit hypotheses, chooses a safe decisive test, records observed evidence, and persists an auditable verdict.

## Why

Agents should resolve testable disagreements using observable evidence instead of source voting or confident synthesis.

## How it works

ForkCheck includes four skills for resolving disagreements, designing tests, evaluating evidence, and rechecking volatile verdicts. A dependency-free ledger stores versioned Markdown receipts without rewriting previous evidence.

The template also includes:

- A paused daily task for rechecking due volatile verdicts
- Optional keyless Tavily Search and Extract tools
- Deterministic demos and automated tests
- Safety and evidence-handling policies

## Tested

- Official registry validator: all 6 templates passed
- ForkCheck deterministic tests: 5/5 passed
- Stamped and driven through a real NanoClaw Docker installation
- Live Codex runtime probe produced receipt `FC-0003`
- Receipt ledger validation returned `valid: true`

## Usage

`ncl groups create --template product/forkcheck --name "ForkCheck"`