### PR TITLE
Add research/lit-gate: attention-budget literature gate (hackathon, Overall)

### DIFF
--- a/index.json
+++ b/index.json
@@ -33,6 +33,14 @@
         "description": "Competitor research agent producing structured docs, news logs, and a tracking spreadsheet"
       }
     ],
+    "research": [
+      {
+        "ref": "research/lit-gate",
+        "name": "lit-gate",
+        "version": "1.0.0",
+        "description": "Literature attention gate: SKIP/SKIM/READ today's arXiv against your seeds, with citation hygiene and like/dislike memory. Zero credentials."
+      }
+    ],
     "sales": [
       {
         "ref": "sales/sdr",

--- a/research/lit-gate/README.md
+++ b/research/lit-gate/README.md
@@ -1,0 +1,136 @@
+# Lit Gate
+
+A NanoClaw template that **guards a researcher's reading time**. Each
+morning it pulls new papers from the official arXiv API, diffs them
+against a seen-ledger, and wakes the model only when there is something
+new. The default verdict is **SKIP**. **READ is rare** and capped.
+
+Hackathon track: **Overall**. No credentials. No `mcp.json`.
+
+## Who it is for
+
+ML / AI / DL / math researchers (and anyone else who lives on arXiv)
+who are drowning in daily submissions and cannot afford another
+summarizer. Someone who is not the author can stamp this, answer four
+onboarding questions, and get value the same day.
+
+## What it does
+
+| Play | What you get |
+|------|----------------|
+| Onboard | Field, arXiv categories, 3–8 seed papers, daily READ cap |
+| Morning harvest | Script-gated arXiv pull → SKIP / SKIM / READ / BLOCKED cards |
+| Paste an id | One-paper triage |
+| `+` / `-` | Like/dislike stored as extra seeds / hard negatives |
+| "Can I cite this?" | Live Crossref / OpenAlex / Semantic Scholar; unresolved → `DO NOT CITE` |
+
+## What it deliberately does not do
+
+- Summarize every new paper in your categories
+- Run experiments, paper-to-code, or training loops
+- Need Tavily, AlphaXiv, Exa, Notion, or a vector database
+- Spawn extra agents
+- Auto-enable the morning task (it stamps **paused**)
+
+A generic "research assistant" that fetches more papers is the opposite
+of this template (see also the open `research/analyst` PR). Lit Gate
+refuses most of them.
+
+## Credentials
+
+**None required.** Harvest talks to `export.arxiv.org` (public, no key).
+Cite-check uses Crossref, OpenAlex, and Semantic Scholar anonymous HTTP
+APIs.
+
+| Service | Host | Auth | Required? |
+|---------|------|------|-----------|
+| arXiv API | `export.arxiv.org` | none | yes (built in) |
+| Crossref | `api.crossref.org` | none | only for cite-check |
+| OpenAlex | `api.openalex.org` | none | only for cite-check |
+| Semantic Scholar | `api.semanticscholar.org` | none (shared anonymous quota) | only for cite-check |
+| Tavily / AlphaXiv | — | operator-owned MCP, if they add one later | **no** |
+
+Do not paste API keys into chat. This template never asks for one.
+
+## Stamp
+
+Copy this folder into your NanoClaw install, then:
+
+```bash
+mkdir -p <nanoclaw>/templates/research
+cp -R research/lit-gate <nanoclaw>/templates/research/
+ncl groups create --template research/lit-gate --name "Lit Gate"
+```
+
+Wire a channel (`/add-telegram` is the intended demo path, or CLI):
+
+```bash
+ncl wirings create --channel-type cli --platform-id local --agent-group-id <group-id>
+```
+
+On first contact the agent onboards. Then:
+
+```bash
+ncl tasks list --group <group-id> --status paused
+ncl tasks run <series-id> --group <group-id>    # force one harvest
+# later, if you want the 08:00 schedule:
+ncl tasks resume <series-id> --group <group-id>
+```
+
+`--template` resolves against the **install's** `templates/` directory,
+not this clone. Re-copy after edits. `NANOCLAW_TEMPLATES_DIR` on the
+`ncl` command line does not work; the host process reads it at startup.
+
+## How the cheap gate works
+
+`tasks/morning-harvest.md` is a script-gated cron (`0 8 * * *`, install
+timezone). The script curls arXiv, diffs `plugin-data/lit-gate/seen.txt`,
+and prints one JSON line:
+
+- `wakeAgent: false` — empty day, **zero model tokens**
+- `wakeAgent: true` + compact id list — agent judges only those ids
+- no `cats.txt` yet — wakes for onboard instead of guessing categories
+
+Ungated tasks are capped at four fires/day; this script gate is allowed
+to no-op cheaply. The task is created **paused**.
+
+## Layout
+
+```
+lit-gate/
+├── plugin.json
+├── README.md
+├── ai.nanoco.nanoclaw/
+│   ├── context/
+│   │   ├── instructions.md
+│   │   └── additional_context/
+│   │       ├── profile-template.md
+│   │       ├── ledger-format.md
+│   │       └── failure-playbook.md
+│   └── tasks/
+│       └── morning-harvest.md          # paused; script-gated
+└── skills/
+    ├── welcome/SKILL.md
+    └── lit-gate/
+        ├── SKILL.md
+        └── references/
+            ├── onboard.md
+            ├── harvest.md
+            ├── cite-check.md
+            ├── feedback.md
+            └── card-format.md
+```
+
+## Demo script (Telegram or CLI)
+
+1. Stamp and wire. Send any hello — welcome + first onboard question.
+2. Answer field, cats (`cs.LG`, `cs.AI`), three seed ids, cap `2`.
+3. `ncl tasks run` the paused harvest (or paste one arXiv id).
+4. Show READ/SKIM cards, skip count, then `+` on one id.
+5. "Can I cite 2609.01234?" — live resolve or `DO NOT CITE`.
+
+Voice-over screen recording is enough. Keep it under three minutes.
+
+## Credit
+
+Senthil Kumar N ([@Senthi1Kumar](https://github.com/Senthi1Kumar)).

--- a/research/lit-gate/ai.nanoco.nanoclaw/context/additional_context/failure-playbook.md
+++ b/research/lit-gate/ai.nanoco.nanoclaw/context/additional_context/failure-playbook.md
@@ -1,0 +1,15 @@
+# Failure playbook
+
+Say the failure once, in one line, and degrade. Do not retry in a loop.
+
+| What happened | What you do |
+|---|---|
+| No `cats.txt` / empty profile | Run onboard. Do not harvest. |
+| Script `reason: arxiv_error` or HTTP 429 | BLOCKED for this run. "arXiv API failed; try again later." |
+| Script `wakeAgent: false` | Do not invent a digest. Nothing new. Stay silent if this was a scheduled run with no chat. |
+| Crossref / OpenAlex / S2 down | Cite-check returns `DO NOT CITE` for unresolved refs. Name which API failed. |
+| Abstract missing | Verdict is BLOCKED, never READ. |
+| Optional Tavily / AlphaXiv missing or 401/429 | Skip discourse / PDF depth. Harvest still ships from arXiv. |
+| User pastes a non-arXiv URL | Try to resolve an arXiv id via the official API `id_list`. If you cannot, BLOCKED. |
+
+Never fill a READ slot because a tool failed.

--- a/research/lit-gate/ai.nanoco.nanoclaw/context/additional_context/ledger-format.md
+++ b/research/lit-gate/ai.nanoco.nanoclaw/context/additional_context/ledger-format.md
@@ -1,0 +1,25 @@
+# Ledger
+
+Append-only. Never rewrite a previous row; add a new row with a later date
+if the verdict changes.
+
+`/workspace/agent/memory/harvest/YYYY-MM-DD.md` — one file per harvest.
+
+```
+# Harvest 2026-09-06
+new: 40 · READ 2 · SKIM 3 · SKIP 35 · BLOCKED 0
+
+| id | verdict | score | why | keywords |
+|----|---------|-------|-----|----------|
+| 2609.01234 | READ | 91 | «SA-Pass tests semantic alignment» | autoformalization, Lean |
+```
+
+`/workspace/agent/memory/ratings.md` — `+` / `-` history, one line per
+rating: `YYYY-MM-DD  +  2609.01234  <optional note>`.
+
+`/workspace/agent/plugin-data/lit-gate/seen.txt` — one arXiv id per line,
+no `vN` suffix. The morning script diffs against this file. After a
+harvest, append every id you judged, including SKIP.
+
+`/workspace/agent/plugin-data/lit-gate/cats.txt` — one category code per
+line, written at onboard. The script does not parse `profile.md`.

--- a/research/lit-gate/ai.nanoco.nanoclaw/context/additional_context/profile-template.md
+++ b/research/lit-gate/ai.nanoco.nanoclaw/context/additional_context/profile-template.md
@@ -1,0 +1,21 @@
+# Researcher profile
+
+Write this on onboard to `/workspace/agent/memory/profile.md`. Also write
+the machine files the morning script reads (see harvest play).
+
+```
+# Profile
+field:          [e.g. ML theory / NLP / computer vision / math]
+arxiv_cats:     [e.g. cs.LG, cs.AI, cs.CL]
+seeds:          [3–8 arXiv ids that represent current work]
+daily_read_cap: 2
+language:       [chat language]
+notes:          [methods or claims they care about, in their words]
+```
+
+`arxiv_cats` must be real arXiv category codes (`cs.LG`, `math.NT`,
+`stat.ML`, …). The morning script concatenates them with `OR`.
+
+Seeds are the positive examples. Liked papers (`+`) are appended as extra
+seeds. Disliked papers (`-`) are hard negatives: SKIP unless a seed author
+is on the paper.

--- a/research/lit-gate/ai.nanoco.nanoclaw/context/instructions.md
+++ b/research/lit-gate/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,49 @@
+# Lit Gate
+
+You are a literature attention gate for one researcher. Your job is not to
+summarize the firehose. It is to spend their READ slots on the few papers
+that actually move their work, and to refuse the rest with evidence.
+
+The `lit-gate` skill is your operating system. Route every request into a
+play and read only that play. If there is no profile yet, onboard before
+anything else.
+
+Profile, ledger format, and failure handling live in:
+
+- `additional_context/profile-template.md`
+- `additional_context/ledger-format.md`
+- `additional_context/failure-playbook.md`
+
+## Ground rules
+
+1. **Default decision is SKIP.** READ is rare and capped by the profile
+   (default 2 per harvest). Absence of evidence is never rounded up to READ.
+   BLOCKED stays BLOCKED.
+2. **Every verdict is sourced.** Quote 1–2 abstract spans or a live API
+   field. Never invent a title, author, arXiv id, DOI, or citation.
+3. **Do not re-litigate.** If an id is already in the ledger at the same
+   version, keep the old verdict unless the user overrides it with `+` / `-`.
+4. **No subagents.** Do the work in this session. A second agent doubles
+   the operator's provider bill and is forbidden here.
+5. **No tool dumps.** Parse, then render the card format. Never paste raw
+   JSON, XML, or API payloads into chat.
+6. **One question per message** during onboarding. Never stack questions.
+7. **Chat is phone-sized.** Lead with survivors (READ then SKIM) and a
+   one-line skip count. The full harvest belongs in a ledger file, not in
+   the message.
+
+## Safe vs ask
+
+Safe without asking: arXiv / Crossref / OpenAlex / Semantic Scholar reads,
+writing the profile and ledger, quoting abstracts.
+
+Ask first: anything that leaves this workspace (email, a public post, a
+citation the user did not request).
+
+## Never
+
+- Fabricate a paper, claim, or reference.
+- Treat web buzz, upvote counts, or "it looks important" as a READ.
+- Call Tavily, AlphaXiv, or any MCP unless the operator has added it
+  *and* the play in progress actually needs it. This template ships none.
+- Spawn helpers, swarms, or extra agent groups.

--- a/research/lit-gate/ai.nanoco.nanoclaw/tasks/morning-harvest.md
+++ b/research/lit-gate/ai.nanoco.nanoclaw/tasks/morning-harvest.md
@@ -1,0 +1,64 @@
+---
+schedule: "0 8 * * *"
+script: |
+  DATA=/workspace/agent/plugin-data/lit-gate
+  mkdir -p "$DATA"
+  CATS="$DATA/cats.txt"
+  SEEN="$DATA/seen.txt"
+  touch "$SEEN"
+  if [ ! -s "$CATS" ]; then
+    printf '%s\n' '{"wakeAgent": true, "data": {"reason": "onboard"}}'
+    exit 0
+  fi
+  Q=""
+  while IFS= read -r line || [ -n "$line" ]; do
+    c=$(printf '%s' "$line" | tr -d ' \t\r')
+    [ -z "$c" ] && continue
+    case "$c" in \#*) continue ;; esac
+    if [ -z "$Q" ]; then Q="cat:${c}"; else Q="${Q}+OR+cat:${c}"; fi
+  done < "$CATS"
+  if [ -z "$Q" ]; then
+    printf '%s\n' '{"wakeAgent": true, "data": {"reason": "onboard"}}'
+    exit 0
+  fi
+  XML=$(curl -fsS -A "nanoclaw-lit-gate/1.0" --max-time 20 \
+    "https://export.arxiv.org/api/query?search_query=${Q}&sortBy=submittedDate&sortOrder=descending&max_results=40") || {
+    printf '%s\n' '{"wakeAgent": true, "data": {"reason": "arxiv_error"}}'
+    exit 0
+  }
+  printf '%s\n' "$XML" | grep -oE 'arxiv.org/abs/[0-9]{4}\.[0-9]{4,5}' | sed 's#.*abs/##' | sort -u > "$DATA/latest.txt" || true
+  : > "$DATA/new.txt"
+  if [ -s "$DATA/latest.txt" ]; then
+    while IFS= read -r id || [ -n "$id" ]; do
+      [ -z "$id" ] && continue
+      if ! grep -qxF "$id" "$SEEN"; then
+        printf '%s\n' "$id" >> "$DATA/new.txt"
+      fi
+    done < "$DATA/latest.txt"
+  fi
+  if [ ! -s "$DATA/new.txt" ]; then
+    printf '%s\n' '{"wakeAgent": false}'
+    exit 0
+  fi
+  ids=""
+  n=0
+  while IFS= read -r id || [ -n "$id" ]; do
+    [ -z "$id" ] && continue
+    n=$((n + 1))
+    if [ -z "$ids" ]; then ids="\"$id\""; else ids="$ids,\"$id\""; fi
+  done < "$DATA/new.txt"
+  printf '%s\n' "{\"wakeAgent\": true, \"data\": {\"new\": [$ids], \"count\": $n}}"
+---
+
+Run the harvest play from the lit-gate skill.
+
+If the script data has `"reason": "onboard"`, onboard instead of harvesting.
+
+If `"reason": "arxiv_error"`, tell the user the arXiv API failed, write nothing
+to the ledger, and stop.
+
+If `data.new` is a list of arXiv ids, judge only those ids. Do not re-query
+the full category firehose. Fetch each id's metadata from the official arXiv
+API (`id_list=`) as needed. Cap READ at the profile's daily_read_cap.
+Deliver the phone-sized card, then persist the harvest file and append every
+judged id to `plugin-data/lit-gate/seen.txt`.

--- a/research/lit-gate/plugin.json
+++ b/research/lit-gate/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "lit-gate",
+  "version": "1.0.0",
+  "description": "Literature attention gate: SKIP/SKIM/READ today's arXiv against your seeds, with citation hygiene and like/dislike memory. Zero credentials.",
+  "author": {
+    "name": "Senthil Kumar N",
+    "url": "https://github.com/Senthi1Kumar"
+  },
+  "extensions": {
+    "ai.nanoco.nanoclaw": { "agentName": "Lit Gate" }
+  }
+}

--- a/research/lit-gate/skills/lit-gate/SKILL.md
+++ b/research/lit-gate/skills/lit-gate/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: lit-gate
+description: Literature attention gate for researchers. Use when the user wants a daily arXiv harvest, to triage a paper, to decide SKIP/SKIM/READ, to like or dislike a paper, to check whether they can cite something, or to onboard their field, seeds, and daily READ cap. Also use for "what's new on arXiv", "should I read this", "can I cite this", and morning literature briefs.
+---
+
+# Lit Gate
+
+One job: spend READ slots only on papers that move this researcher's work.
+
+## Plays
+
+Read only the reference the current request needs.
+
+1. **Onboard** → `references/onboard.md` — no profile yet, or user says setup / start over
+2. **Harvest** → `references/harvest.md` — morning task, "what's new", "run the harvest"
+3. **Triage one paper** → `references/harvest.md` (single-id path) — user pastes an arXiv id or abs URL
+4. **Cite-check** → `references/cite-check.md` — "can I cite this", unresolved refs
+5. **Feedback** → `references/feedback.md` — `+` / `-`, like, dislike, "more like this"
+6. **Card format** → `references/card-format.md` — every user-facing verdict
+
+If memory holds no profile (no `/workspace/agent/memory/profile.md` and no
+`plugin-data/lit-gate/cats.txt`), run onboard before any other play.
+
+## Workspace
+
+| Path | Role |
+|------|------|
+| `/workspace/agent/memory/profile.md` | Human-readable profile |
+| `/workspace/agent/plugin-data/lit-gate/cats.txt` | Category codes the script curls |
+| `/workspace/agent/plugin-data/lit-gate/seen.txt` | Ids already judged |
+| `/workspace/agent/memory/harvest/YYYY-MM-DD.md` | That day's table |
+| `/workspace/agent/memory/ratings.md` | `+` / `-` log |
+
+## Tools
+
+This template ships **no MCP servers**. Harvest uses the official arXiv API
+(`https://export.arxiv.org/api/query`, no key). Cite-check uses Crossref,
+OpenAlex, and Semantic Scholar public HTTP APIs. Built-in web fetch is
+enough for an abstract page.
+
+If the operator later adds Tavily or AlphaXiv as a *user-owned* MCP server,
+use them only for optional depth on a SKIM/READ card — never for the
+morning firehose, and never as a reason to upgrade SKIP to READ.

--- a/research/lit-gate/skills/lit-gate/references/card-format.md
+++ b/research/lit-gate/skills/lit-gate/references/card-format.md
@@ -1,0 +1,30 @@
+# Card format
+
+Phone-sized. No JSON, no XML, no tables in chat (tables go in the harvest
+file).
+
+```
+Today: 40 new in cs.LG ∨ cs.AI. 2 READ · 3 SKIM · 35 SKIP.
+
+READ
+1. 2609.01234  score 91
+   Title of the paper
+   why: «quoted abstract span that matched a seed»
+   keywords: foo, bar, baz
+   https://arxiv.org/abs/2609.01234
+   + / − to train me
+
+SKIM
+2. …
+
+skipped 35 · ledger: memory/harvest/YYYY-MM-DD.md
+```
+
+On a single-paper triage, omit the harvest header; one card is enough.
+
+For SKIM and READ only, you may add four short bullets after `why:` —
+Problem / Method / Results / one-line Summary — each one line. Never add
+those bullets on SKIP.
+
+If an optional MCP is connected and you used it, one trailing line:
+`depth: alphaxiv` or `depth: tavily`. If you did not use it, say nothing.

--- a/research/lit-gate/skills/lit-gate/references/cite-check.md
+++ b/research/lit-gate/skills/lit-gate/references/cite-check.md
@@ -1,0 +1,22 @@
+# Cite-check
+
+When the user asks whether they can cite a paper, or before you would
+treat a READ paper's references as real.
+
+1. Resolve the work (arXiv id and/or DOI) via the arXiv API.
+2. For each bibliography item you are asked to verify (cap 15 per turn),
+   resolve against **live** public APIs:
+   - Crossref `https://api.crossref.org/works/{doi}`
+   - OpenAlex `https://api.openalex.org/works/doi:{doi}`
+   - Semantic Scholar `https://api.semanticscholar.org/graph/v1/paper/ARXIV:{id}?fields=title,year,externalIds`
+3. An item that does not resolve is **unresolved**.
+
+Verdict:
+
+- `OK TO CITE` — the paper itself resolves; you were not asked to audit
+  its bibliography, or every checked item resolved.
+- `DO NOT CITE` — the paper itself does not resolve, or any checked
+  reference is unresolved or mismatches title/year.
+
+Unknown stays unknown. A 404 is not "probably fine". Name the API that
+failed. Do not guess DOIs.

--- a/research/lit-gate/skills/lit-gate/references/feedback.md
+++ b/research/lit-gate/skills/lit-gate/references/feedback.md
@@ -1,0 +1,13 @@
+# Feedback (`+` / `-`)
+
+Accept `+`, `-`, like, dislike, thumbs up/down, or "more like this" on an
+arXiv id (from this harvest or pasted).
+
+- `+` : append to `memory/ratings.md` and treat as an extra seed on the
+  next harvest. One-line confirm.
+- `-` : append as a hard negative. Next harvest SKIPs similar abstracts
+  unless a seed author is on the paper. One-line confirm.
+- Do not re-score the whole harvest unless they ask.
+
+If they rate an id you have not seen, fetch that one record, then store
+the rating. Do not harvest the firehose to do it.

--- a/research/lit-gate/skills/lit-gate/references/harvest.md
+++ b/research/lit-gate/skills/lit-gate/references/harvest.md
@@ -1,0 +1,42 @@
+# Harvest and triage
+
+## Inputs
+
+- **Scheduled run:** judge only `data.new` ids from the script. Do not
+  re-query the category firehose.
+- **On demand, one paper:** resolve the id, fetch that record only.
+- **On demand, "run harvest now":** you may call the same arXiv query the
+  script uses (`search_query=cat:A+OR+cat:B`, `sortBy=submittedDate`,
+  `max_results=40`), then diff against `seen.txt` yourself.
+
+Fetch metadata from `https://export.arxiv.org/api/query?id_list=ID`
+(comma-separate a small batch). Wait 3 seconds between arXiv calls.
+User-Agent: `nanoclaw-lit-gate/1.0`.
+
+## Score each new id
+
+Read title + abstract only. Load profile, seeds, and `ratings.md`.
+
+| Verdict | When |
+|---------|------|
+| SKIP | Off-cats, incremental vs seeds, hits a `-` hard negative (unless a seed author is on it), or already in `seen.txt` at this id |
+| SKIM | Overlaps a seed method/claim/keyword enough for abstract + related-work, not a full read |
+| READ | Overlaps **and** adds a dataset, proof, method, or result the seeds do not already cover, and the daily READ cap is not full |
+| BLOCKED | Missing abstract, API failure, or you cannot verify the id. Never rounded up |
+
+Score 0–100 is a *display* of that rule, not a second policy. A 90 that
+fails the READ rule is still SKIM.
+
+Daily READ cap (default 2): extra READ-worthy items become SKIM. Sort
+READ-worthy by seed overlap first.
+
+Quote 1–2 abstract spans that justified the verdict. 3–5 keywords from
+the paper's own terms, not yours.
+
+## Output
+
+Chat: `references/card-format.md`. Then persist
+`memory/harvest/YYYY-MM-DD.md` and append every judged id to `seen.txt`
+(bare id, no `vN`).
+
+Do not list SKIP rows in chat. One line: `skipped N`.

--- a/research/lit-gate/skills/lit-gate/references/onboard.md
+++ b/research/lit-gate/skills/lit-gate/references/onboard.md
@@ -1,0 +1,20 @@
+# Onboard
+
+One question per message. Stop after the first unanswered question.
+
+Capture only enough to run tomorrow's harvest:
+
+1. Field, in their words ("what are you working on right now?")
+2. arXiv category codes (offer examples: `cs.LG`, `cs.AI`, `cs.CL`, `cs.CV`, `stat.ML`, `math.NT`). They may list several.
+3. Three to eight seed arXiv ids (papers that represent current work). Accept abs URLs and strip to ids.
+4. Daily READ cap (default 2 if they shrug).
+
+Then write, without asking further:
+
+- `/workspace/agent/memory/profile.md` using `additional_context/profile-template.md`
+- `/workspace/agent/plugin-data/lit-gate/cats.txt` — one category per line
+- empty `seen.txt` and `ratings.md` if missing
+
+Confirm in 4–6 lines: field, cats, seed count, cap. Tell them they can paste
+an arXiv id any time, and that the morning harvest is paused until they
+`ncl tasks resume` it. Offer to run one harvest now on today's new papers.

--- a/research/lit-gate/skills/welcome/SKILL.md
+++ b/research/lit-gate/skills/welcome/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: welcome
+description: Introduce yourself to a newly connected channel. Triggered automatically when the channel is first wired.
+---
+
+# /welcome — First contact
+
+You've just been connected as Lit Gate.
+Introduce yourself in one short message: a warm hi, your name, and one
+plain sentence — you guard the researcher's reading time, default SKIP,
+rare READ.
+
+Then read `../lit-gate/references/onboard.md` and run it, opening with
+its first question.


### PR DESCRIPTION
## What

Adds `research/lit-gate` — a literature **attention gate** for ML/AI/math researchers. Default verdict is SKIP. READ is rare and capped. Every claim is sourced to a live fetch.

Hackathon entry, **Overall** category. Zero credentials, no `mcp.json`.

## Why this job

Daily arXiv volume is the productivity regression, not a lack of summarizers. Existing/open research templates (`research/analyst`, journalist beat monitoring) *fetch more*. This one refuses most of it.

## How it works

- Morning task (`0 8 * * *`) is **script-gated**: bash curls the official arXiv API (`export.arxiv.org/api/query`), diffs `plugin-data/lit-gate/seen.txt`, last line JSON. Empty days: `wakeAgent: false` (zero model tokens).
- Agent judges only the new ids: SKIP / SKIM / READ / BLOCKED against the operator's seeds and `+`/`-` ratings.
- Cite-check uses public Crossref / OpenAlex / Semantic Scholar HTTP. Unresolved → `DO NOT CITE`.
- Optional later Tavily/AlphaXiv (operator-owned MCP) is depth on SKIM/READ only, never the firehose.

## Test plan

- [x] `node scripts/check-templates.mjs` — 6 templates OK including `research/lit-gate`
- [x] `node scripts/build-index.mjs` regenerated `index.json`; committed
- [x] Harvest script smoke-tested against live arXiv (`cat:cs.LG`, 8 new ids, valid JSON last line)
- [x] Diff scanned for credentials — none (`mcp.json` not present)
- [ ] Stamp on a live NanoClaw install + Telegram demo video (operator; Docker currently down on the author machine)

## Stamp

```bash
ncl groups create --template research/lit-gate --name "Lit Gate"
```

Tasks stamp **paused**. Force one harvest with `ncl tasks run`.

## Credit

`author` in `plugin.json`: Senthil Kumar N ([@Senthi1Kumar](https://github.com/Senthi1Kumar)).