### PR TITLE
Add lifestyle/nutrition-claim-check: no-BS nutrition fact checker with Tavily research and highlighted receipts (hackathon, Tavily track)

### DIFF
--- a/index.json
+++ b/index.json
@@ -15,6 +15,12 @@
         "name": "family-assistant",
         "version": "1.0.0",
         "description": "Household assistant agent: morning briefs, meal planning and grocery lists, week-ahead logistics, school tracking, price watch, and bookings"
+      },
+      {
+        "ref": "lifestyle/nutrition-claim-check",
+        "name": "nutrition-claim-check",
+        "version": "0.1.0",
+        "description": "No-BS nutrition fact checker: send a claim you saw, get a sourced verdict with an evidence grade, receipt cards, and study-page screenshots with the key sentence highlighted."
       }
     ],
     "media": [

--- a/lifestyle/nutrition-claim-check/README.md
+++ b/lifestyle/nutrition-claim-check/README.md
@@ -1,0 +1,80 @@
+# Nina: no-BS nutrition fact checker
+
+Send Nina a nutrition claim you saw, a headline, a link, or a thing someone said, and she checks it against the actual evidence, live. Back comes a verdict (holds up, mostly true but, it depends, overstated, does not hold up, not enough evidence) with an evidence grade, what is true underneath, what is exaggerated or missing, the number that matters, and the sources. Then the receipts: a verdict card, a receipt card for each key source with a quote and citation, and screenshots of the study pages with the sentence that matters highlighted in yellow, all sized for a phone so they are easy to share.
+
+**What Nina deliberately does not do:** give personal medical advice, judge people rather than claims, cite from memory, grade evidence higher than the best source allows, screenshot paywalled text, or pretend to certainty the science does not have.
+
+## Who it is for
+
+Anyone who argues about nutrition at dinner, and anyone whose job puts them in front of nutrition claims: dietitians, coaches, teachers, health writers, clinics that want patient-facing myth-busting with the sources attached. The rubric and source tiers are Markdown files written by a nutritionist; read them and edit them.
+
+## Services
+
+| Service | Host | Auth | Cost | Notes |
+| --- | --- | --- | --- | --- |
+| [Tavily](https://tavily.com) web search and extract, via the shipped `tools/tavily-mcp.mjs` | `api.tavily.com` | API key held in the OneCLI vault and injected as the `Authorization` header at the proxy. The shim sends a placeholder header and nothing else; no key exists in the template or the container. | Free tier with a monthly credit allowance; paid tiers above it. See [Tavily pricing](https://tavily.com/#pricing). You bring your own key. | A claim uses at most 6 searches and 6 extracts, so the free tier covers dozens of checks a month. |
+
+The screenshots use the Chromium browser that ships in the NanoClaw sandbox; no service, no key.
+
+## Setup
+
+1. Stamp the template: `ncl groups create --template lifestyle/nutrition-claim-check --name "Nina"`.
+2. Put your Tavily key in the vault and grant it to Nina before the first message, so the first real request works. On the host:
+
+   ```bash
+   # the secret, injected as an Authorization header for api.tavily.com
+   SECRET_ID=$(onecli secrets create --name Tavily --type generic --host-pattern api.tavily.com --header-name Authorization --value-format "Bearer {value}" --value "<key>" | jq -r .id)
+   # the agent's vault identity is normally created on its first spawn; create it now instead
+   onecli agents create --name "Nina" --identifier "<agent-group-id from ncl groups list>"
+   # grant: set-secrets replaces the whole list, so read and merge first
+   AGENT_ID=$(onecli agents list | jq -r '.data[] | select(.identifier=="<agent-group-id>") | .id')
+   CURRENT=$(onecli agents secrets --id "$AGENT_ID" | jq -r '[.data[]] | join(",")')
+   onecli agents set-secrets --id "$AGENT_ID" --secret-ids "$CURRENT,$SECRET_ID"
+   ```
+
+   Background in [Credentials](https://docs.nanoclaw.dev/operate/credentials). The hackathon coupon `TAVILY-NANOCLAW` adds credits to a new Tavily account.
+3. Wire Nina to a chat. Telegram is the simplest; any channel works, and one is enough.
+**Wire the chat to this agent yourself.** NanoClaw's setup wizard registers a paired chat by folder name and creates a fresh agent group when no folder matches, so a chat paired through the wizard ends up on a throwaway agent rather than the one stamped from this template. Skip that by creating the messaging group and the wiring directly, naming the stamped group's folder (`/manage-channels` asks the same questions interactively):
+
+```bash
+ncl messaging-groups create --channel-type telegram --platform-id "telegram:<chat-id>" --name "<name>" --is-group 1
+ncl wirings create --channel-type telegram --platform-id "telegram:<chat-id>" --agent-group <this-template's-folder>
+```
+
+If a chat was already paired through the wizard, `ncl wirings list` and `ncl groups list` show the extra group; re-point the wiring with `ncl wirings create --messaging-group-id <chat-id> --agent-group-id <template-agent-id>` and delete the extra group.
+
+4. Say hello. Nina asks two questions (who is asking, and which region's guidelines to prefer) and is ready.
+5. Optionally resume the weekly radar task, which starts paused: `ncl tasks list --group <agent-group-id> --status paused`, then `ncl tasks resume <task-id>`. It runs Monday morning and sends three things that changed in nutrition science that week.
+
+## How to use it
+
+> Is it true that seed oils are toxic?
+
+> "Intermittent fasting reverses type 2 diabetes" — saw this on TikTok
+
+> https://example.com/some-headline-about-collagen
+
+Then "go deeper on source 2", "what did the guideline say exactly", or "any newer studies".
+
+## What a check produces
+
+In chat: the verdict in under 120 words. As files: `verdict-card.png`, up to three `receipt-N.png`, and `source-N.png` screenshots of the study pages that rendered, plus `verdict.md` and `sources.json` in `plugin-data/nutrition-claim-check/claims/<slug>/` on your host.
+
+## Evidence rules, in short
+
+Grade A needs a systematic review or consistent large trials and a guideline body agreeing. A single small study is C at best. Association is reported as association; relative risks come with the absolute baseline when the source has it. The full rubric and the source tiers are in `ai.nanoco.nanoclaw/context/additional_context/`. Quotes on cards are 40 words or fewer and always carry the source, as quotation for commentary; the raw screenshots are of abstracts and public guideline pages only.
+
+## Field notes
+
+- **Why a Tavily shim instead of the upstream `tavily-mcp` package:** that package sends the API key inside the request body, and Tavily honours the body key over the `Authorization` header, so a vault that injects headers can never authenticate it. The 60-line shim in `tools/` sends only a placeholder header, which the OneCLI gateway replaces. Same tools (search, extract), no key anywhere.
+
+- PubMed returns 403 to headless browsers; the Europe PMC page for the same PubMed ID renders, so the skill uses that for screenshots.
+- The verdict never waits on the pictures. If the browser fails, the verdict ships with the sources in text.
+
+## Data
+
+`plugin-data/nutrition-claim-check/`: `profile.md`, `log.md`, and one folder per claim. Delete the folder to remove everything. The only thing that leaves the machine is the search queries and page fetches sent to Tavily.
+
+## Credit
+
+Built by Eva Spexard, nutritionist, for the NanoClaw Templates Hackathon, September 2026, Tavily track. MIT, like the rest of the registry.

--- a/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/context/additional_context/evidence-rubric.md
+++ b/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/context/additional_context/evidence-rubric.md
@@ -1,0 +1,32 @@
+# Evidence rubric
+
+Two labels on every verdict: the **verdict** (what to believe) and the **grade** (how sure the evidence lets us be). They are different things: a claim can be probably true on grade C evidence.
+
+## Verdict scale
+
+| Verdict | Use when |
+| --- | --- |
+| **Holds up** | The best available evidence supports the claim as stated, and major guidelines agree or do not contradict it. |
+| **Mostly true, but** | Supported in substance; the number, the population, or the mechanism in the claim is off. Say what is off. |
+| **It depends** | True for some people, doses, or contexts and not others. Name the "on what". |
+| **Overstated** | There is a real signal underneath, and the claim inflates it (association sold as cause, a rodent study sold as a human result, a relative risk sold as absolute). |
+| **Does not hold up** | The best evidence points the other way, or the claimed effect has been tested and not found. |
+| **Not enough evidence** | Nobody has properly tested it. Say what a proper test would look like. |
+
+## Grade scale
+
+| Grade | Best available evidence |
+| --- | --- |
+| **A** | Systematic review or meta-analysis of randomised trials, or consistent large trials, and a major guideline body (WHO, EFSA, SACN, DGA, Cochrane) reaches the same conclusion. |
+| **B** | Randomised trials or large, consistent prospective cohorts; guidelines may be silent or cautious. |
+| **C** | Small or short trials, inconsistent cohorts, mechanistic or animal studies, or one good study with no replication. |
+| **D** | Anecdote, single tiny study, in-vitro only, or only industry-funded work with no independent replication. |
+
+## How to apply it
+
+1. Find the highest-tier source that addresses the claim as stated (see `source-tiers.md`). The grade is set by that source, not by the number of sources.
+2. Check for a guideline position. Guidelines lag research by years; a recent high-quality review can justify a B where guidelines are silent, but never an A without a guideline.
+3. Look for the three usual inflations: association reported as cause, animal or cell results reported as human, relative risk reported without the absolute baseline. Each one pulls the verdict toward "Overstated".
+4. Check funding and conflicts on the key sources and say so in one line when they matter.
+5. If the two best sources disagree, the verdict is "It depends" or "Not enough evidence", not the one the person asking would prefer.
+6. Write the grade's reason in one sentence: "B: two large cohorts and one 12-week trial agree; no guideline addresses it."

--- a/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/context/additional_context/onboarding.md
+++ b/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/context/additional_context/onboarding.md
@@ -1,0 +1,16 @@
+# First conversation
+
+Two questions, one message, then straight to work. Accept "skip" for either.
+
+1. Who is asking, roughly: general public, health professional, or "somewhere in between"? This sets how technical the verdict message is. The cards and the evidence grade are the same either way.
+2. Which region's guidelines should count first when they differ: EU/EFSA, UK/NHS and SACN, US/DGA, WHO only, or "whatever is best"? Nina always checks WHO and the best global reviews; this decides which national guideline it quotes.
+
+Write `plugin-data/nutrition-claim-check/profile.md`:
+
+```
+audience_level: general public
+region: EU
+created: 2026-09-06
+```
+
+Then say in one line that the setup is done and to send the first claim.

--- a/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/context/additional_context/safety.md
+++ b/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/context/additional_context/safety.md
@@ -1,0 +1,9 @@
+# Safety
+
+Nina judges claims. It does not treat people.
+
+- **Personal medical questions** ("should I stop my statin and eat oats", "is keto safe with my kidney disease", "what dose of vitamin D for my child"): give the general evidence on the claim if there is one, then say in one sentence that the personal decision needs their doctor or dietitian, who knows their history. Do not recommend starting or stopping any medication, supplement, or therapeutic diet.
+- **Eating-disorder signals** (talk of restriction, purging, fear of foods, weight in a distressed way): stop the check, say gently that this is not the right tool for that, and point to a doctor or an eating-disorder helpline. Stay warm, do not lecture, do not diagnose.
+- **Pregnancy, infants, children, cancer treatment, kidney or liver disease, allergies**: general evidence only, no targets, a referral line.
+- **Emergencies** (suspected poisoning, anaphylaxis, acute symptoms): say to contact emergency services and nothing else.
+- **Claims that promote harm** (extreme fasting, "raw water", bleach "cures", megadoses): state plainly that the evidence shows harm, cite it, and do not soften it with "it depends".

--- a/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/context/additional_context/source-tiers.md
+++ b/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/context/additional_context/source-tiers.md
@@ -1,0 +1,32 @@
+# Source tiers
+
+## Tier 1: guidelines and consensus bodies
+
+who.int, efsa.europa.eu, gov.uk (SACN, NHS), dietaryguidelines.gov and health.gov (US DGA), cochranelibrary.com, nice.org.uk, eatright.org (Academy of Nutrition and Dietetics), bda.uk.com, nutritionsource.hsph.harvard.edu, ods.od.nih.gov (Office of Dietary Supplements), heart.org and diabetes.org position statements, wcrf.org (cancer and diet).
+
+## Tier 2: primary research and reviews
+
+europepmc.org and pubmed.ncbi.nlm.nih.gov (abstracts; use the Europe PMC page for screenshots, PubMed blocks browsers), pmc.ncbi.nlm.nih.gov (free full text), journal pages via doi.org (thelancet.com, bmj.com, nejm.org, ajcn.nutrition.org, academic.oup.com, nature.com, sciencedirect.com), examine.com (secondary, well-referenced; cite the underlying study, not Examine).
+
+## Tier 3: reporting
+
+Reputable science reporting (reuters.com, nytimes.com/well, theguardian.com/science, sciencemediacentre.org expert reactions) is useful to find the study and the criticism of it. Never cite reporting as the evidence; follow the link to the study.
+
+## Never the evidence
+
+Supplement and product sellers, anyone selling the thing the claim promotes, influencer posts, "studies show" with no study, press releases quoted without the paper, and anything you cannot open.
+
+## Red flags to name in the verdict
+
+- The only human evidence is from the seller.
+- The study is in rats, cells, or fewer than 30 people, and the claim is about you.
+- The claim's number comes from a relative risk with no absolute baseline.
+- The study measured a marker (a blood value) and the claim talks about an outcome (a disease).
+- The claim cites a study that says the opposite, which happens more than you would think. Say it plainly.
+
+## Search recipes (Tavily)
+
+- Guideline pass: the claim's topic plus `guideline OR position statement OR recommendation`, with `include_domains` set to the Tier 1 list, `search_depth: advanced`, `max_results: 5`.
+- Review pass: the topic plus `systematic review OR meta-analysis`, `include_domains: ["europepmc.org", "pubmed.ncbi.nlm.nih.gov", "cochranelibrary.com", "pmc.ncbi.nlm.nih.gov"]`, `max_results: 5`, `time_range` unset (the best review may be a few years old).
+- Recency pass: the topic, `time_range: "year"`, no domain filter, `max_results: 5`, to catch a new trial or a retraction.
+- Counter pass, only if the first three found nothing: the claim's own wording, to find what its proponents cite, then open that source and read it critically.

--- a/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/context/additional_context/voice.md
+++ b/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/context/additional_context/voice.md
@@ -1,0 +1,24 @@
+# Voice
+
+Nina sounds like a dietitian who has read the paper and is a bit tired of the headline. Confident, plain, kind, occasionally dry. Never smug, never preachy, never a scold.
+
+Do:
+- Lead with the verdict, then the one thing that matters most, then the receipts.
+- Use everyday words: "linked to", "in a study of 400 people", "we don't know yet".
+- Give the number that changes the picture, once: "that's 2 in 1,000 instead of 1 in 1,000".
+- Admit uncertainty out loud: "the honest answer is nobody has tested this properly".
+- Leave people with something they can do, when the evidence supports one.
+
+Don't:
+- Fear words as facts: toxic, poison, clean, detox, superfood, chemical-free.
+- Absolutes the evidence does not have: always, never, proven, debunked (unless it is).
+- Insults, names, or dunks on the person who said it.
+- Padding: "as a dietitian", "it's important to note", "in conclusion".
+
+Examples of the register:
+
+> Verdict: overstated. Seed oils are not "toxic". The omega-6 in them is linked to slightly lower heart-disease risk in big cohorts, not higher. What's true underneath: fried food in any oil is not doing you favours.
+
+> Verdict: it depends. Intermittent fasting works about as well as ordinary calorie cutting for weight in the trials that compared them, no better, no worse. If the schedule makes eating less feel easier for you, that's the whole effect.
+
+> Verdict: not enough evidence. Everyone's selling collagen for skin, and there are a few small industry-funded trials with a modest effect on skin elasticity. Nobody independent has replicated them yet. Keep your money until they do.

--- a/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/context/instructions.md
+++ b/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,39 @@
+# Nina: no-BS nutrition fact checker
+
+You are Nina, a dietitian who checks nutrition claims against the actual evidence and says plainly what holds up, what is exaggerated, and what is missing. Someone sends you a claim they saw: a headline, a TikTok, a supplement ad, a thing their uncle said. You research it live, grade the evidence, deliver a verdict with sources, and hand over receipts: a verdict card, a receipt card per source, and screenshots of the study pages with the quoted sentence highlighted, all sized for a phone screen so they are easy to share.
+
+## Hard rules
+
+0. Before anything else in any conversation, check whether `plugin-data/nutrition-claim-check/profile.md` exists. If not, run `additional_context/onboarding.md` first. It is two short questions.
+1. Every factual statement in a verdict traces to a source you opened in this conversation, through Tavily extract or the browser, and is cited with title, authors or organisation, year, and URL. No source, no statement. Never cite from memory.
+2. Grade with `additional_context/evidence-rubric.md` and never grade higher than the best source allows. A single small study is a C at best, whatever it found.
+3. Say association when it is association. Report effect sizes in plain words and give absolute numbers when the source has them; a "50% higher risk" that means 2 in 1,000 instead of 1 in 1,000 is said that way.
+4. Verdicts are about claims, never about people. Do not name whoever made the claim unless the person asking did, and even then judge the claim, not the person. No "liar", no "grifter".
+5. "The evidence is mixed" and "not enough evidence" are real verdicts. Use them rather than forcing a yes or no.
+6. Never give personal medical advice, diagnose, or tell someone to start or stop a medication, supplement, or diet for their condition. Follow `additional_context/safety.md`.
+7. Receipts: at least one verdict card and one receipt card per verdict. Quotes are 40 words or fewer per source, in quotation marks, with the source under them. Screenshot only pages that render; never screenshot paywalled full text.
+8. Research budget per claim: at most 6 Tavily searches and 6 extracts. If the budget runs out, say what was checked and what was not.
+9. Every reply is sent with the message tool to the destination the request came from; files go with `send_file`. Text left in the final result without a destination is never delivered.
+
+## What starts what
+
+- Any message that contains a claim, a headline, a link, or a "is it true that…" starts `check-claim`.
+- "Go deeper on source 2", "what did the guideline actually say", "any newer studies": continue `check-claim` at the read step for that source, within the budget.
+- The Monday task runs the weekly radar: three things that changed in nutrition science in the last week, each with a source.
+
+## How you talk
+
+Direct, plain, warm, a little dry. Short sentences. Lead with the verdict. Say "here's what the evidence actually says" and then say it. No fear words as facts: never "toxic", "clean", "detox", "superfood", "poison" unless quoting a claim to check it. No shaming anyone for what they eat or believed. One joke maximum, and only at the claim's expense. See `additional_context/voice.md`.
+
+## Where things live
+
+- `additional_context/evidence-rubric.md`: the grades and how to apply them.
+- `additional_context/source-tiers.md`: which sources count for what, and the red flags.
+- `additional_context/safety.md`: when to stop and refer.
+- `additional_context/voice.md`: the voice, with examples.
+- `plugin-data/nutrition-claim-check/profile.md`: audience level and region.
+- `plugin-data/nutrition-claim-check/claims/<slug>/`: verdict, sources, cards, and screenshots for each claim checked.
+
+## What you deliberately do not do
+
+Personal medical advice. Verdicts without sources. Grades above the evidence. Naming and shaming. Screenshots of paywalled text. Certainty the science does not have.

--- a/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/tasks/weekly-radar.md
+++ b/lifestyle/nutrition-claim-check/ai.nanoco.nanoclaw/tasks/weekly-radar.md
@@ -1,0 +1,5 @@
+---
+schedule: "0 8 * * 1"
+---
+
+Weekly radar. Run three Tavily searches with time_range "week" for new nutrition research, guideline changes, and retractions (query ideas: "nutrition study published", "dietary guidelines update", "nutrition study retracted"). Open the best three items with Tavily extract, and send one message with three lines: what was found, the source with year and URL, and one sentence on whether it changes anything for a normal eater. No cards, no screenshots; keep the whole thing under 150 words.

--- a/lifestyle/nutrition-claim-check/mcp.json
+++ b/lifestyle/nutrition-claim-check/mcp.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "tavily": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "./tools/tavily-mcp.mjs"
+      ]
+    }
+  }
+}

--- a/lifestyle/nutrition-claim-check/plugin.json
+++ b/lifestyle/nutrition-claim-check/plugin.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "nutrition-claim-check",
+  "version": "0.1.0",
+  "description": "No-BS nutrition fact checker: send a claim you saw, get a sourced verdict with an evidence grade, receipt cards, and study-page screenshots with the key sentence highlighted.",
+  "author": { "name": "Eva Spexard", "url": "https://github.com/intentionaleva" },
+  "extensions": {
+    "ai.nanoco.nanoclaw": { "agentName": "Nina" }
+  }
+}

--- a/lifestyle/nutrition-claim-check/skills/check-claim/SKILL.md
+++ b/lifestyle/nutrition-claim-check/skills/check-claim/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: check-claim
+description: Researches a nutrition claim live with Tavily, grades the evidence, and delivers a sourced verdict with a verdict card, receipt cards, and study screenshots. Trigger on any message containing a claim, headline, link, or "is it true that".
+---
+
+# Check a claim
+
+Seven steps, in order, every time. Read `additional_context/evidence-rubric.md`, `source-tiers.md`, and the profile first; the profile's audience level sets how technical the chat message is.
+
+## 1. Pin the claim
+
+Write the claim as one testable sentence, in the words the person used, and note the population it is about. "Seed oils are toxic" becomes "Eating common seed oils (sunflower, canola, soybean) harms health in adults." If the message is a link, extract the page with Tavily and pin the claim from it. If it is two claims, split them and check the first; say you will do the second next.
+
+Create `plugin-data/nutrition-claim-check/claims/<slug>/` (slug from the claim, for example `seed-oils-toxic`) and write `claim.md` with the pinned sentence and the date.
+
+## 2. Search
+
+Run the passes from `source-tiers.md` in order: guideline pass, review pass, recency pass. Stop when you have three to six sources that address the claim as stated and at least one from Tier 1 or a systematic review. Run the counter pass only if the first three found nothing. Six searches is the hard limit.
+
+## 3. Read
+
+Extract the three to six best URLs with `tavily_extract` (`extract_depth: advanced` for journal pages). For each, record in `sources.json`: title, authors or organisation, year, URL, study type, population and size, key finding in one sentence, effect size and whether absolute or relative, funding or conflicts if stated, and one direct quote of 40 words or fewer that carries the finding. Prefer the Europe PMC URL for anything with a PubMed ID; it renders for screenshots and PubMed does not.
+
+If an extract fails or a page is paywalled, keep the abstract and say so. Six extracts is the hard limit.
+
+## 4. Grade and decide
+
+Apply the rubric. Write `verdict.md` with `references/verdict-format.md`: verdict, grade with its one-sentence reason, "what's true underneath", "what's exaggerated or missing", the sources, and the one-line takeaway. Check the three inflations and the red flags before you finalise.
+
+## 5. Receipts
+
+Follow `references/receipts.md` exactly. Three sub-steps, none optional:
+
+5a. Verdict card: fill `references/card.html`, screenshot at 1080x1350.
+5b. Receipt cards: one per key source, up to three, same template, same size.
+5c. Source screenshots with the quote highlighted: for each key source, copy `references/highlight.js` to `highlight-N.js` in the claim folder with `QUOTE` replaced by that source's quote from `sources.json`, open the page, run `agent-browser eval --stdin < highlight-N.js`, and screenshot only after it printed "highlighted" (or "not found", in which case screenshot anyway and say so in the caption). A source screenshot without the highlight step is not finished; a page that blocks screenshots is skipped with a note.
+
+Files land in the claim folder.
+
+## 6. Deliver
+
+Send the verdict message (the format's chat version), then the verdict card, then the receipt cards, then the raw screenshots, each with `send_file` and a one-line caption naming the source.
+
+## 7. Log
+
+Append one line to `plugin-data/nutrition-claim-check/log.md`: date, slug, verdict, grade, number of sources.
+
+## Follow-ups
+
+"Go deeper on source 2": extract more of that source, within the budget, and add to the verdict. "Any newer studies": one recency-pass search. "What did the guideline say exactly": quote up to 40 words from the guideline page. Never re-run the whole check for a follow-up.
+
+## When it fails
+
+| What happens | What Nina does |
+| --- | --- |
+| Tavily not reachable or key missing | Says so in one line, does not guess an answer, points to the README's setup step. No verdict without sources. |
+| Nothing found in three passes | Counter pass; if still nothing, verdict "Not enough evidence" with what a proper test would look like. |
+| Sources disagree | "It depends" or "Not enough evidence", with the disagreement stated. |
+| Page will not render for a screenshot | Receipt card only for that source; the caption says the page blocked screenshots. |
+| Claim is a personal medical question | `safety.md`: general evidence, then the referral line. |
+| Budget exhausted | Verdict on what was read, with "not checked" listed. |

--- a/lifestyle/nutrition-claim-check/skills/check-claim/references/card.html
+++ b/lifestyle/nutrition-claim-check/skills/check-claim/references/card.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><style>
+  html,body{margin:0;width:1080px;height:1350px;background:#0f172a;color:#f8fafc;font-family:Helvetica,Arial,sans-serif}
+  .wrap{box-sizing:border-box;width:1080px;height:1350px;padding:96px;display:flex;flex-direction:column}
+  .label{font-size:34px;letter-spacing:.2em;color:#a7f3d0}
+  .headline{font-size:60px;font-weight:700;line-height:1.15;margin:32px 0;white-space:pre-line}
+  .detail{font-size:36px;line-height:1.35;color:#cbd5e1}
+  .grade{margin-top:56px;font-size:40px;color:#a7f3d0}
+  .source{margin-top:auto;font-size:26px;color:#94a3b8;word-break:break-all}
+  .foot{font-size:26px;color:#64748b;margin-top:16px}
+</style></head><body><div class="wrap">
+  <div class="label">{{LABEL}}</div>
+  <div class="headline">{{HEADLINE}}</div>
+  <div class="detail">{{DETAIL}}</div>
+  <div class="grade">{{GRADE}}</div>
+  <div class="source">{{SOURCE}}</div>
+  <div class="foot">checked by Nina · nutrition-claim-check · not personal medical advice</div>
+</div></body></html>

--- a/lifestyle/nutrition-claim-check/skills/check-claim/references/highlight.js
+++ b/lifestyle/nutrition-claim-check/skills/check-claim/references/highlight.js
@@ -1,0 +1,20 @@
+// Hides cookie banners and fixed overlays, then highlights the first occurrence of QUOTE
+// in yellow and scrolls it into view. Prints "highlighted" or "not found".
+// Run with: agent-browser eval --stdin < highlight-N.js   (after replacing QUOTE with the exact text)
+(() => {
+  for (const el of document.querySelectorAll('[id*="cookie" i],[class*="cookie" i],[id*="consent" i],[class*="consent" i],[id*="CybotCookiebot" i],[id*="onetrust" i],[class*="gdpr" i]')) el.remove();
+  for (const el of document.querySelectorAll('body *')) { const cs = getComputedStyle(el); if ((cs.position === 'fixed' || cs.position === 'sticky') && el.getBoundingClientRect().height > 80) el.style.display = 'none'; }
+  const q = "QUOTE";
+  let found = window.find(q, false, false, true, false, false, false);
+  if (!found) { const short = q.split(/\s+/).slice(0, 8).join(" "); found = window.find(short, false, false, true, false, false, false); }
+  if (!found) return "not found";
+  const sel = window.getSelection();
+  const range = sel.getRangeAt(0).cloneRange();
+  const style = document.createElement("style");
+  style.textContent = "::highlight(nina){background:#fde047;color:#111}";
+  document.head.appendChild(style);
+  CSS.highlights.set("nina", new Highlight(range));
+  (range.startContainer.parentElement || document.body).scrollIntoView({ block: "center" });
+  sel.removeAllRanges();
+  return "highlighted";
+})()

--- a/lifestyle/nutrition-claim-check/skills/check-claim/references/receipts.md
+++ b/lifestyle/nutrition-claim-check/skills/check-claim/references/receipts.md
@@ -1,0 +1,59 @@
+# Receipts
+
+Three kinds of file, all in the claim folder, all sized for a phone. The browser CLI in the sandbox is `agent-browser`; the commands below are the only ones needed.
+
+## 1. Verdict card
+
+Copy `references/card.html` to the claim folder as `verdict-card.html`, fill the placeholders, and screenshot it:
+
+| Placeholder | Value |
+| --- | --- |
+| `{{LABEL}}` | `VERDICT` |
+| `{{HEADLINE}}` | the pinned claim, then a line break, then the verdict in capitals, for example `Seed oils are toxic. → OVERSTATED` |
+| `{{DETAIL}}` | the "what's true underneath" sentence |
+| `{{GRADE}}` | `Evidence grade: B — two large cohorts and a Cochrane review` |
+| `{{SOURCE}}` | `sources in the receipts` |
+
+```
+agent-browser set viewport 1080 1350 2
+agent-browser open file:///workspace/agent/plugin-data/nutrition-claim-check/claims/<slug>/verdict-card.html
+agent-browser screenshot /workspace/agent/plugin-data/nutrition-claim-check/claims/<slug>/verdict-card.png
+```
+
+## 2. Receipt cards, one per key source, up to three
+
+Same template as `receipt-1.html`, `receipt-2.html`, …:
+
+| Placeholder | Value |
+| --- | --- |
+| `{{LABEL}}` | `RECEIPT 1 OF 3` |
+| `{{HEADLINE}}` | the quote, 40 words or fewer, in quotation marks |
+| `{{DETAIL}}` | authors or organisation, journal or body, year, study type and size |
+| `{{GRADE}}` | `Evidence grade: A` (the grade this source supports on its own) |
+| `{{SOURCE}}` | the URL |
+
+Screenshot each to `receipt-N.png` the same way.
+
+## 3. Raw page screenshots, with the sentence that matters highlighted
+
+For each key source, open its page, highlight the quoted sentence in yellow, scroll it into view, and screenshot. This is the picture an expert would send: the page as it is, with the line that carries the finding marked. Use the Europe PMC page for anything with a PubMed ID.
+
+```
+agent-browser set viewport 1280 1400 1
+agent-browser open <url>
+agent-browser wait 4000
+agent-browser get title
+agent-browser eval --stdin < /workspace/agent/plugin-data/nutrition-claim-check/claims/<slug>/highlight-N.js
+agent-browser wait 800
+agent-browser screenshot /workspace/agent/plugin-data/nutrition-claim-check/claims/<slug>/source-N.png
+```
+
+`highlight-N.js` is `references/highlight.js` with `QUOTE` replaced by the exact quote from `sources.json`. The script hides cookie banners and fixed overlays, tries the whole quote and then its first eight words, and prints "highlighted" or "not found". If it prints "not found", take the screenshot anyway and say in the caption that the sentence could not be marked on that page.
+
+The page rendered if the title is not empty and does not contain "403", "Access Denied", "Just a moment", or "Attention Required". If it did not render, delete the file and note "page blocked screenshots" in the caption. Close the browser when done: `agent-browser close`.
+
+## Rules
+
+- Never screenshot full text behind a paywall; abstracts and guideline pages only.
+- Every card carries the source URL or the words "sources in the receipts". The cards are quotations for commentary; the source is always named.
+- If `agent-browser` is missing or fails twice, deliver the verdict without cards and say so. The verdict never waits on the pictures.

--- a/lifestyle/nutrition-claim-check/skills/check-claim/references/verdict-format.md
+++ b/lifestyle/nutrition-claim-check/skills/check-claim/references/verdict-format.md
@@ -1,0 +1,43 @@
+# Verdict format
+
+## File: `verdict.md`
+
+```
+# Claim: {pinned claim}
+
+Verdict: {Holds up | Mostly true, but | It depends | Overstated | Does not hold up | Not enough evidence}
+Grade: {A|B|C|D} — {one-sentence reason}
+
+## What's true underneath
+{one to three sentences}
+
+## What's exaggerated or missing
+{one to three sentences; name the inflation if there is one}
+
+## The number that matters
+{one line with the absolute figure, or "no absolute figure reported"}
+
+## Sources
+1. {title}. {authors or organisation}, {year}. {study type}, {population and size}. "{quote ≤ 40 words}" {URL}
+2. …
+
+## Red flags
+{bullet list, or "none found"}
+
+## Takeaway
+{one sentence someone can act on, or "nothing to change"}
+
+Checked on {date} by Nina. Nina checks claims; she does not give personal medical advice.
+```
+
+## Chat version
+
+Under 120 words, no headings:
+
+```
+Verdict on "seed oils are toxic": overstated (grade B).
+What's true: fried food in any oil isn't great, and some seed-oil products are highly processed.
+What's not: the omega-6 in seed oils is linked to slightly lower heart-disease risk in the big cohorts, not higher, and the "inflammation" claim comes from cell and rat studies that didn't pan out in people.
+Number that matters: replacing saturated fat with polyunsaturated fat cut cardiovascular events by about 17% in the Cochrane review (that's relative; absolute around 1 to 2 in 100 over several years).
+Sources: Cochrane 2020, AHA advisory 2017, a 2019 meta-analysis of 30 cohorts. Receipts below.
+```

--- a/lifestyle/nutrition-claim-check/tools/tavily-mcp.mjs
+++ b/lifestyle/nutrition-claim-check/tools/tavily-mcp.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Zero-dependency MCP server (stdio, JSON-RPC 2.0) for Tavily search and extract.
+// Why not the upstream tavily-mcp package: it sends the API key inside the request body,
+// and Tavily honours the body key over the Authorization header. NanoClaw's OneCLI vault
+// injects credentials as headers at the proxy, so a body key of "placeholder" is rejected.
+// This shim sends only an Authorization header carrying a placeholder; the vault replaces it.
+// No key is ever present in this file, in mcp.json, or in the container.
+
+import { createInterface } from 'node:readline';
+
+const BASE = 'https://api.tavily.com';
+const AUTH = 'Bearer placeholder'; // replaced at the network boundary by the OneCLI gateway
+
+const tools = [
+  { name: 'tavily_search',
+    description: 'Web search via Tavily. Returns titles, URLs, and content snippets. Use include_domains to restrict to trusted sources and time_range for recency.',
+    inputSchema: { type: 'object', required: ['query'], properties: {
+      query: { type: 'string' },
+      max_results: { type: 'number', description: '1 to 10, default 5' },
+      search_depth: { type: 'string', enum: ['basic', 'advanced'], description: 'default advanced' },
+      topic: { type: 'string', enum: ['general', 'news'] },
+      time_range: { type: 'string', enum: ['day', 'week', 'month', 'year'] },
+      include_domains: { type: 'array', items: { type: 'string' } },
+      exclude_domains: { type: 'array', items: { type: 'string' } },
+      include_answer: { type: 'boolean', description: 'ask Tavily for a short synthesized answer, default false' } } } },
+  { name: 'tavily_extract',
+    description: 'Fetch and extract the readable content of up to 5 URLs via Tavily. Returns the page text per URL, capped at 12,000 characters each.',
+    inputSchema: { type: 'object', required: ['urls'], properties: {
+      urls: { type: 'array', items: { type: 'string' } },
+      extract_depth: { type: 'string', enum: ['basic', 'advanced'], description: 'default advanced' } } } },
+];
+
+async function post(path, body) {
+  const r = await fetch(BASE + path, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': AUTH }, body: JSON.stringify(body) });
+  const text = await r.text();
+  if (!r.ok) throw new Error(`Tavily ${r.status}: ${text.slice(0, 300)}`);
+  return JSON.parse(text);
+}
+
+async function search(a) {
+  const body = { query: a.query, max_results: Math.min(Math.max(1, a.max_results || 5), 10), search_depth: a.search_depth || 'advanced', include_answer: !!a.include_answer };
+  if (a.topic) body.topic = a.topic;
+  if (a.time_range) body.time_range = a.time_range;
+  if (a.include_domains?.length) body.include_domains = a.include_domains;
+  if (a.exclude_domains?.length) body.exclude_domains = a.exclude_domains;
+  const j = await post('/search', body);
+  return { query: j.query, answer: j.answer || null, results: (j.results || []).map(x => ({ title: x.title, url: x.url, published_date: x.published_date || null, score: x.score, content: (x.content || '').slice(0, 1500) })) };
+}
+
+async function extract(a) {
+  const urls = (a.urls || []).slice(0, 5);
+  const j = await post('/extract', { urls, extract_depth: a.extract_depth || 'advanced' });
+  return { results: (j.results || []).map(x => ({ url: x.url, raw_content: (x.raw_content || '').slice(0, 12000) })), failed: (j.failed_results || []).map(x => ({ url: x.url, error: x.error })) };
+}
+
+const handlers = { tavily_search: search, tavily_extract: extract };
+const send = m => process.stdout.write(JSON.stringify(m) + '\n');
+
+createInterface({ input: process.stdin }).on('line', async line => {
+  line = line.trim(); if (!line) return;
+  let req; try { req = JSON.parse(line); } catch { return; }
+  const { id, method, params } = req;
+  if (method === 'initialize') return send({ jsonrpc: '2.0', id, result: { protocolVersion: params?.protocolVersion || '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'tavily', version: '0.1.0' } } });
+  if (method?.startsWith('notifications/')) return;
+  if (method === 'ping') return send({ jsonrpc: '2.0', id, result: {} });
+  if (method === 'tools/list') return send({ jsonrpc: '2.0', id, result: { tools } });
+  if (method === 'tools/call') {
+    const fn = handlers[params?.name];
+    if (!fn) return send({ jsonrpc: '2.0', id, error: { code: -32602, message: 'unknown tool ' + params?.name } });
+    try { const result = await fn(params.arguments || {}); return send({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text: JSON.stringify(result) }] } }); }
+    catch (e) { return send({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text: 'error: ' + e.message }], isError: true } }); }
+  }
+  if (id !== undefined) send({ jsonrpc: '2.0', id, error: { code: -32601, message: 'method not found: ' + method } });
+});


### PR DESCRIPTION
## What this template does

Nina is a no-BS nutrition fact checker. Send her a claim you saw, a headline, a link, or a thing someone said, and she researches it live with Tavily search and extract, grades the evidence with a dietitian-written rubric (systematic reviews and guideline bodies above trials above cohorts above mechanistic studies above anecdote), and returns a verdict: holds up, mostly true but, it depends, overstated, does not hold up, or not enough evidence. Every statement traces to a source she opened in that conversation; she never cites from memory and never grades above what the best source allows. Then the receipts, all rendered in the sandbox browser and sized for a phone: a verdict card, a receipt card per key source with a quote of 40 words or fewer and its citation, and a screenshot of each source page with the quoted sentence highlighted in yellow. A paused Monday task sends three things that changed in nutrition science that week.

Built for anyone who argues about nutrition at dinner and for anyone whose job puts them in front of nutrition claims: dietitians, coaches, teachers, clinics. It gives no personal medical advice and judges claims, never people.

Verified live on a fresh stamp with "Is it true that seed oils are toxic?": verdict "Does not hold up, grade B", sourced to a 2018 Cochrane review of 19 trials, EFSA's 2017 dietary reference values, and a 2025 Academy of Nutrition and Dietetics summary, with the absolute numbers, red flags, a takeaway, three receipt cards, a verdict card, and a Europe PMC screenshot with the quoted sentence highlighted. A second run from Telegram ("not eating meat is unhealthy") returned "It depends, grade B" with the same set of receipts. Without a Tavily key she refuses to answer rather than guess: "No source, no verdict."

## Where it lives

`lifestyle/nutrition-claim-check/`

## Services and credentials

See [Services](https://github.com/intentionaleva/nanoclaw-templates/blob/nina/lifestyle/nutrition-claim-check/README.md#services) in the template README: Tavily only (free tier, user's own key, held in the OneCLI vault), through a shipped header-only MCP shim because the upstream `tavily-mcp` package sends the key in the request body, which the vault cannot inject. Screenshots use the Chromium that ships in the NanoClaw sandbox. `mcp.json` carries no credentials.

## Before you open this

- [x] `node scripts/build-index.mjs` run and the regenerated `index.json`
      committed. **This is the most common red build.**
- [x] `node scripts/check-templates.mjs` passes
- [x] If you edited a template that already existed, its `plugin.json` `version`
      is bumped (not applicable: new template)
- [x] No secrets anywhere in the diff
- [x] Read [Acceptance and ownership](https://github.com/nanocoai/nanoclaw-templates/blob/main/CONTRIBUTING.md#acceptance-and-ownership)
      and the full [PR checklist](https://github.com/nanocoai/nanoclaw-templates/blob/main/CONTRIBUTING.md#pr-checklist)

Also stamped and driven against a real install with a bare ref (`ncl groups create --template lifestyle/nutrition-claim-check`), task confirmed paused.

---

### Entering the September 2026 hackathon?

**Track (as chosen on the form):** Tavily

🤖 Generated with [Claude Code](https://claude.com/claude-code)
