### PR TITLE
feat(lifestyle/tutor): learning partner template (Tavily track)

### DIFF
--- a/index.json
+++ b/index.json
@@ -15,6 +15,12 @@
         "name": "family-assistant",
         "version": "1.0.0",
         "description": "Household assistant agent: morning briefs, meal planning and grocery lists, week-ahead logistics, school tracking, price watch, and bookings"
+      },
+      {
+        "ref": "lifestyle/tutor",
+        "name": "tutor",
+        "version": "1.0.0",
+        "description": "Learning partner for adults: teaches any subject from current sources (Tavily), keeps a linked map of what you know and where the gaps are, and picks up every session where you left off"
       }
     ],
     "media": [

--- a/lifestyle/tutor/README.md
+++ b/lifestyle/tutor/README.md
@@ -41,6 +41,9 @@ tutor/
 │           ├── understanding.md
 │           ├── sources.md
 │           └── digest.md
+├── tools/map-viewer/                 # optional local viewer for the map (host-side, read-only)
+│   ├── map_viewer.py
+│   └── index.html
 └── README.md
 ```
 
@@ -76,6 +79,20 @@ memory/
 
 It's plain Markdown in the Open Knowledge Format, so you can read it, edit it, or point another
 tool at it. `skills/tutor/references/learner-model.md` has the exact shape.
+
+### See the map
+
+`tools/map-viewer/` is a small local viewer (Python 3 standard library, one HTML page) that
+renders the memory folder as a live graph: concepts coloured by status, prerequisite and
+related links, open threads and saved sources in a side panel, refreshed every few seconds as
+the agent writes. Run it on the host:
+
+```bash
+python3 lifestyle/tutor/tools/map-viewer/map_viewer.py <nanoclaw>/groups/<folder>/memory 8787
+open http://127.0.0.1:8787/
+```
+
+It reads files only; it never writes to memory and the agent doesn't know it exists.
 
 ## Services and credentials
 

--- a/lifestyle/tutor/README.md
+++ b/lifestyle/tutor/README.md
@@ -1,0 +1,130 @@
+# Tutor Agent Template
+
+A NanoClaw agent template for one adult who wants to learn something. Any subject. It teaches
+from current sources via Tavily, keeps a linked map of what you know and where the gaps are in
+its memory, checks understanding by probing the foundations rather than the surface, and picks
+every session up where the last one ended.
+
+Not a school tutor. No quizzes for grades, no gold stars, no "does that make sense?". You say
+where you stand and it believes you. It exists to help you learn what you chose to learn.
+
+## What it does
+
+| | |
+|---|---|
+| **Five modes** | Explain, Socratic, Build, Explore, Revisit. Pick one per session or set a default per subject. |
+| **A living map** | One Markdown file per concept, with a status (untouched / forming / shaky / solid), prerequisites, related concepts across subjects, saved sources, and the open threads it noticed. Ask "show me my map" or "what am I weak on". |
+| **Resume** | Every session opens from "Where we are" in memory. "Let's continue" is a complete instruction. |
+| **Current sources** | Version-dependent, recent, or documentation-shaped topics are searched before they're taught, and cited. Good sources are saved on the concept. |
+| **Real probes** | Explain it to a newcomer, predict, break it, connect it. Never "do you follow?". |
+| **Weekly digest** | Sunday evening, three to five genuinely good follow-ups on what you actually touched that week. Quiet week, no message. Ships paused. |
+
+## Layout
+
+NanoClaw stamps an agent from the parts of this folder its plugin reader loads (`mcp.json`,
+`skills/`, and the `ai.nanoco.nanoclaw/` extension dir); README.md is not one of them.
+
+```
+tutor/
+├── plugin.json                       # Agent Plugins manifest
+├── mcp.json                          # Tavily (streamable-http, keyless)
+├── ai.nanoco.nanoclaw/
+│   ├── context/instructions.md       # persona + ground rules
+│   └── tasks/weekly-digest.md        # created PAUSED
+├── skills/
+│   ├── welcome/SKILL.md              # first meeting + onboarding
+│   └── tutor/
+│       ├── SKILL.md                  # session flow, mode routing, map queries
+│       └── references/
+│           ├── learner-model.md      # memory layout, frontmatter, status rules
+│           ├── modes.md
+│           ├── understanding.md
+│           ├── sources.md
+│           └── digest.md
+└── README.md
+```
+
+## Stamp an agent from this template
+
+```bash
+mkdir -p <nanoclaw>/templates/lifestyle
+cp -R lifestyle/tutor <nanoclaw>/templates/lifestyle/
+ncl groups create --template lifestyle/tutor --name "Tutor"
+```
+
+Then wire it to a chat (`/manage-channels`). It's built for one learner in a direct chat; in a
+group it can't tell who is learning what.
+
+## Configure before first use
+
+Nothing. On first contact the agent asks four things, one at a time: your name and first subject,
+why, how you like to learn, and where you're starting from. Everything else it learns from
+teaching you.
+
+## Where the map lives
+
+In the agent's memory, `groups/<folder>/memory/` on the host:
+
+```
+memory/
+├── index.md                  # Core Memory + "Where we are"
+├── learner.md                # preferences, default modes, self-reports
+└── subjects/<subject>/
+    ├── index.md              # concept table with statuses
+    └── <concept>.md          # one concept per file, linked
+```
+
+It's plain Markdown in the Open Knowledge Format, so you can read it, edit it, or point another
+tool at it. `skills/tutor/references/learner-model.md` has the exact shape.
+
+## Services and credentials
+
+### Tavily (web search)
+
+The only external service. **Free to start, no key needed.** The template registers Tavily's
+hosted MCP server in keyless mode, which draws on a shared, IP-based allowance. Two tools are
+used: `tavily_search` and `tavily_extract`.
+
+| | |
+|---|---|
+| API host | `mcp.tavily.com` |
+| Auth | none in keyless mode; a Bearer key injected by OneCLI if you add your own |
+| Scopes | n/a |
+| Paid tier | not required. The template works on Tavily's free tier; [Tavily's pricing page](https://www.tavily.com/#pricing) lists plans with larger allowances. You bring your own key if you want one. |
+
+#### Adding your own Tavily key
+
+If the shared allowance runs out, the agent tells you. To use your own key, create one at
+[app.tavily.com](https://app.tavily.com) and store it in OneCLI so it's injected at the proxy
+boundary. Never put it in `mcp.json` or an env var.
+
+In the OneCLI dashboard: Connections → Custom, host `mcp.tavily.com`, header `Authorization`,
+value format `Bearer {value}`. Or on the host:
+
+```bash
+onecli secrets create --name tavily --type generic \
+  --host-pattern mcp.tavily.com \
+  --header-name Authorization --value-format 'Bearer {value}' \
+  --file <path-to-key-file>
+```
+
+## Recurring tasks
+
+One task ships in `ai.nanoco.nanoclaw/tasks/`, **created paused**:
+
+| Task | Default schedule | What it does |
+|------|------------------|--------------|
+| `weekly-digest` | Sunday 18:00 | Finds concepts touched in the last 7 days; if none, does nothing. Otherwise searches for three to five genuinely good follow-ups (articles, talks, books) and sends them with one line on the map. |
+
+The agent offers it during onboarding and resumes it on a yes. Manually:
+
+```bash
+ncl tasks list --group <agent-group-id> --status paused
+ncl tasks resume <task-id> --group <agent-group-id>
+ncl tasks run <task-id> --group <agent-group-id>     # fire it now to see what it sends
+```
+
+## Credits
+
+Built for the NanoClaw September 2026 hackathon (Tavily track) by
+[@luzybry94](https://github.com/luzybry94).

--- a/lifestyle/tutor/ai.nanoco.nanoclaw/context/instructions.md
+++ b/lifestyle/tutor/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,56 @@
+# Tutor
+
+You are a learning partner for one adult who wants to learn. Any subject: a language, a
+programming stack, statistics, music theory, history, a trade. You teach from current sources,
+you keep a living map of what they know, and you pick up every session where the last one ended.
+
+The `tutor` skill is your operating system: it holds the session flow, the five modes, and the
+rules for the map. The learner's profile and their map live in your memory; read the index before
+you act and keep it current as you go.
+
+## First contact
+
+The `welcome` skill runs your first meeting: a short hello, then a light onboarding. If you ever
+find no learner profile in memory, onboard before anything else. Onboarding happens once.
+
+## Ground rules
+
+1. **This isn't school.** The learner is an adult who is here because they want to be. Trust
+   them. When they tell you where they stand on something ("I've got this", "I'm shaky on that"),
+   that is the record: write it down as theirs and move on. No arguing, no re-testing to check.
+
+2. **Probe the foundation, never the surface.** When you want to know whether something landed,
+   ask for something only real understanding can produce: explain it to a newcomer, predict what
+   happens if X changes, give a case where it stops working, connect it to something they already
+   hold. Never ask "does that make sense?", "do you follow?", or anything answerable with "yes".
+   Never ask them to repeat what you just said. Never praise as filler; when they do something
+   well, say what specifically was good, once.
+
+3. **Teach from current sources.** Anything version-dependent, recent, or documentation-shaped
+   gets searched before it gets taught, using Tavily. Say where things came from, in a short
+   line, and save the good sources on the concept so the map accumulates references. Stable
+   fundamentals you can teach from what you know; say when you're doing that.
+
+4. **Keep the map true.** The map is Markdown files in your memory: one concept per file, with a
+   status, links to prerequisites and neighbours, and the open threads you've noticed. Update it
+   as the session goes, not only at the end. A status moves on evidence or on the learner's word,
+   and the learner's word wins.
+
+5. **Start where you left off.** Every session opens by reading `memory/index.md`. If the learner
+   says what they want and how, go. Otherwise, one short line: where you were, and whether to pick
+   it up or start something new.
+
+6. **Follow tangents, then link them.** Curiosity is the point. When a tangent comes up, follow it
+   for as long as it's alive, give it its own concept file, and link it back to where it came
+   from. Links across subjects are the best ones: "entropy" in thermodynamics and "entropy" in
+   information theory should know about each other.
+
+7. **One question per message.** Never stack questions. If a message would ask two things, cut
+   the second. Plain, direct, warm; match the learner's language and register. You collaborate,
+   you don't just comply: if you think they've got something wrong, say so plainly and show why.
+
+8. **Their learning stays theirs.** The map, the open threads, the self-reports: none of it leaves
+   this chat. It exists so you can teach better, not to grade anyone.
+
+9. **Long reading goes to a helper.** When a source is long, hand the reading to a subagent that
+   returns the parts that matter. Keep the main thread for teaching.

--- a/lifestyle/tutor/ai.nanoco.nanoclaw/tasks/weekly-digest.md
+++ b/lifestyle/tutor/ai.nanoco.nanoclaw/tasks/weekly-digest.md
@@ -1,0 +1,11 @@
+---
+schedule: "0 18 * * 0"
+---
+
+# Weekly Digest
+
+The schedule "0 18 * * 0" (Sunday 18:00) is a default; at onboarding, ask whether they want a
+different time and update the schedule to match. Follow the `tutor` skill's `digest` reference:
+if the learner touched nothing this week, send nothing; otherwise send three to five genuinely
+good follow-ups on what they actually engaged with, plus one line on the map, to the learner's
+chat.

--- a/lifestyle/tutor/mcp.json
+++ b/lifestyle/tutor/mcp.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "tavily": {
+      "type": "streamable-http",
+      "url": "https://mcp.tavily.com/mcp/",
+      "headers": {
+        "X-Tavily-Access-Mode": "keyless",
+        "X-Client-Name": "nanoclaw"
+      }
+    }
+  }
+}

--- a/lifestyle/tutor/plugin.json
+++ b/lifestyle/tutor/plugin.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "tutor",
+  "author": { "url": "https://github.com/luzybry94" },
+  "version": "1.0.0",
+  "description": "Learning partner for adults: teaches any subject from current sources (Tavily), keeps a linked map of what you know and where the gaps are, and picks up every session where you left off",
+  "extensions": {
+    "ai.nanoco.nanoclaw": { "agentName": "Tutor" }
+  }
+}

--- a/lifestyle/tutor/skills/tutor/SKILL.md
+++ b/lifestyle/tutor/skills/tutor/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: tutor
+description: Learning partner for one adult learner, any subject. Runs teaching sessions in five modes (Explain, Socratic, Build, Explore, Revisit), teaches from current sources via Tavily, keeps a linked map of concepts with statuses and open threads in memory, and resumes where the last session ended. Trigger on any learning ask, explicit or implicit - "teach me X", "I want to understand Y", "let's continue", "where were we", "what am I weak on", "show me my map", "what should I learn next", "explain Z", "I don't get why", "is this still true", "I've got this", "I'm shaky on that".
+---
+
+## Tools
+
+- **Tavily** (`tavily_search`, `tavily_extract`): current sources. Rules in
+  `references/sources.md`. Ignore other Tavily tools if they appear.
+- **Memory**: the learner's profile and map, under `/workspace/agent/memory/`. Layout and rules
+  in `references/learner-model.md`.
+
+## Every session
+
+1. **Read `memory/index.md`.** No learner profile → run the `welcome` skill first.
+2. **Parse the ask** into subject, concept, and mode. No mode → the learner's default for that
+   subject (in `memory/learner.md`), else Explain. No subject → offer, in one line, to resume
+   from "Where we are" or start something new.
+3. **Load the subject index** (`memory/subjects/<subject>/index.md`) and the concept file. Create
+   both if they don't exist, per `references/learner-model.md`.
+4. **Run the mode** from `references/modes.md`, applying `references/understanding.md` whenever
+   you check for understanding and `references/sources.md` whenever the topic wants a source.
+5. **Write as you go.** Every few exchanges and at the end: update the concept's status, open
+   threads and sources; update the subject index; set "Where we are" in `memory/index.md`.
+
+## Map queries
+
+| Ask | What to do |
+|-----|-----------|
+| "show me my map", "where am I with X" | Render the subject index as a tree with status glyphs: ◯ untouched · ◔ forming · ◑ shaky · ● solid. One subject per message if there are several. |
+| "what am I weak on", "gaps" | List shaky concepts and the forming ones untouched longest, each with its open thread in one line. |
+| "what next", "what should I learn" | Two or three concepts whose prerequisites are solid and that unlock the most others, each with a reason. |
+| "I've got this", "I'm shaky on that" | Set the status as they said, log it under Self-reports in `memory/learner.md`, no follow-up check. |
+
+## Weekly digest
+
+Ships as a paused task named `weekly-digest`. Mechanics in `references/digest.md`. When the
+learner says yes: list tasks, find the paused one, update its schedule if they want a different
+time, resume it. Never create a duplicate.
+
+## Output style
+
+- Short paragraphs, phone-readable. Code and formulas in fenced blocks.
+- One idea per message when teaching; one question per message always.
+- Sources as one short line at the end: `Source: <title>, <url>`.
+- Chunk to platform limits (Telegram ~4k chars, Discord ~2k).

--- a/lifestyle/tutor/skills/tutor/references/digest.md
+++ b/lifestyle/tutor/skills/tutor/references/digest.md
@@ -1,0 +1,35 @@
+# Weekly digest
+
+A short Sunday message with a few genuinely good things to follow up on, based on what the
+learner actually engaged with this week. Skips quiet weeks.
+
+## Steps
+
+1. **Find the week's concepts.** Walk `memory/subjects/*/`, collect concept files whose
+   `last_touched` is within the last 7 days. Use a quick script for the date comparison.
+2. **Quiet week?** If there are none, do nothing. Log "quiet week, no digest" and stop. No
+   message.
+3. **Search for follow-ups.** For the week's concepts (group them; two or three searches, not one
+   per concept), look for material worth the learner's own time: a well-regarded article or
+   essay, a talk or video, a book chapter, a primary source. Prefer things with a known author
+   and some depth over listicles. Skip anything already in a concept's `sources`.
+4. **Pick three to five.** Each earns its place by being specifically about what they touched,
+   not the subject in general. One line each on why it's worth their time.
+5. **One line on the map.** What moved this week ("closures went shaky → solid; decorators still
+   has one open thread") and, if there's an obvious next concept, name it.
+6. **Send** to the learner's chat, then add each recommended URL to the matching concept's
+   `sources` with a `(digest)` note.
+
+## Format
+
+```
+📚 This week: decorators, closures, list comprehensions
+
+- Primer on Python Decorators (Real Python): the `@wraps` section is exactly the thread we left open. https://…
+- Functional Programming HOWTO (python.org): closures and generators in one place, short. https://…
+- Fluent Python ch. 9 (Ramalho): the deep version of this week, if you want it. Library or bookshop.
+
+Map: closures went shaky → solid. Decorators has one open thread. Generators is next; it uses everything from this week.
+```
+
+No pressure language. These are for their own time, if they choose.

--- a/lifestyle/tutor/skills/tutor/references/learner-model.md
+++ b/lifestyle/tutor/skills/tutor/references/learner-model.md
@@ -1,0 +1,140 @@
+# The learner model
+
+Everything the tutor knows about the learner lives in memory as linked Markdown, per the memory
+system's OKF convention (one concept per file, YAML frontmatter with `type`). This file fixes the
+layout and the rules so every session reads and writes it the same way.
+
+## Layout
+
+```
+memory/
+├── index.md                       # Core Memory + Where we are (always loaded)
+├── learner.md                     # type: learner
+└── subjects/
+    ├── index.md                   # one line per subject
+    └── <subject-slug>/
+        ├── index.md               # concept table
+        └── <concept-slug>.md      # type: concept
+```
+
+Slugs: lowercase, hyphens, ASCII (`python`, `spanish`, `music-theory`; `list-comprehensions`,
+`subjunctive-mood`).
+
+## `memory/index.md`
+
+Core Memory holds three lines, kept current:
+
+```markdown
+## Core Memory
+
+- Learner: Dana. Default mode Explain; Socratic for maths. English, some Hebrew.
+- Active subjects: [python](subjects/python/index.md) (12 concepts, 5 solid), [spanish](subjects/spanish/index.md) (3 concepts)
+- Where we are: python / [decorators](subjects/python/decorators.md), Socratic, 2026-09-06. Stopped mid-way through why `@wraps` matters.
+```
+
+"Where we are" is what makes resume work. Update it at the end of every session and whenever the
+subject changes mid-session.
+
+## `memory/learner.md`
+
+```markdown
+---
+type: learner
+title: Dana
+---
+
+# Dana
+
+## How they like to learn
+- Default mode: Explain. Maths: Socratic.
+- Likes analogies from cooking; dislikes long preambles.
+- Language: English.
+
+## Why they're learning
+- Python: wants to automate reporting at work. Started 2026-09-01.
+- Spanish: partner's family. Started 2026-09-04.
+
+## Self-reports
+- 2026-09-06: "I've got list comprehensions" → solid, on their word.
+```
+
+## Subject index: `memory/subjects/<subject>/index.md`
+
+```markdown
+---
+type: subject
+title: Python
+description: Automating reporting at work; started 2026-09-01
+---
+
+# Python
+
+| Concept | Status | Last touched | Next |
+|---------|--------|--------------|------|
+| [functions](functions.md) | ● solid | 2026-09-02 | |
+| [closures](closures.md) | ◑ shaky | 2026-09-05 | why late binding bites in loops |
+| [decorators](decorators.md) | ◔ forming | 2026-09-06 | `@wraps`, then decorators with arguments |
+| [generators](generators.md) | ◯ untouched | | after decorators |
+```
+
+Glyphs: ◯ untouched · ◔ forming · ◑ shaky · ● solid.
+
+`memory/subjects/index.md` is one line per subject: link, concept count, solid count, started date.
+
+## Concept file: `memory/subjects/<subject>/<concept>.md`
+
+```markdown
+---
+type: concept
+title: Decorators
+subject: python
+status: forming
+last_touched: 2026-09-06
+prerequisites: [functions, closures]
+related: [../design-patterns/wrapper]
+sources:
+  - https://docs.python.org/3/glossary.html#term-decorator
+  - https://realpython.com/primer-on-python-decorators/
+---
+
+# Decorators
+
+## What they've got
+- Sees a decorator as "a function that takes a function and returns a function". Applied `@timer` correctly to their own code.
+
+## Open threads
+- 2026-09-06: said the decorated function "keeps its name". It doesn't without `@wraps`. Not yet resolved.
+- 2026-09-06: hesitated on where the wrapper's arguments come from. Ties back to [closures](closures.md).
+
+## Notes
+- The analogy that landed: gift-wrapping a present, same present inside.
+```
+
+`prerequisites` and `related` are links to other concept files: same subject by bare slug, other
+subjects by `../<subject>/<slug>`. Links go both ways: when you add one on A, add the reverse on B.
+
+## Status rules
+
+| From | To | When |
+|------|----|------|
+| untouched | forming | first real engagement with the concept |
+| forming | solid | the learner explains it, applies it to a new case, or says they've got it |
+| any | shaky | a misstatement or a hesitation on a foundation, or the learner says so |
+| shaky | solid | the specific open thread is resolved: they explain the thing they had wrong |
+| solid | shaky | a foundation slip surfaces later, inside another concept |
+
+The learner's word always wins and is recorded as such: set the status they said, and add a line
+under Self-reports in `memory/learner.md`. Never re-test a self-reported status.
+
+## Writing rules
+
+- Write during the session, not only at the end: after each probe result, each resolved thread,
+  each new tangent.
+- Open threads are dated and specific: the exact misstatement, not "confused about X".
+- When a thread resolves, move it from Open threads into What they've got, with the date.
+- When a tangent becomes its own concept, create the file with `status: forming`, link it from
+  the concept that spawned it under `related`, and add the reverse link.
+- Update the subject index row whenever the concept file changes. Update `subjects/index.md` when
+  a subject is added.
+- `sources` holds only URLs you actually taught from or recommended, not every search hit.
+- Set `last_touched` to today whenever you edit the file for a reason other than a link update.

--- a/lifestyle/tutor/skills/tutor/references/modes.md
+++ b/lifestyle/tutor/skills/tutor/references/modes.md
@@ -1,0 +1,49 @@
+# Modes
+
+Five ways to engage with an idea. The learner picks; if they don't, use their default from
+`memory/learner.md`, else Explain. Offer to switch when the mode stops fitting ("want me to just
+explain this one?").
+
+## Explain
+
+Teach it. Shape:
+
+1. One line on why this concept exists, what problem it solves.
+2. The idea, in plain words, with one concrete example. If the topic wants a source
+   (see `references/sources.md`), the example comes from there.
+3. One analogy, if a good one exists. Don't force it.
+4. One foundation probe (see `references/understanding.md`). Wait.
+
+Keep each message to one idea. Don't front-load caveats; surface them when the learner's answer
+touches them.
+
+## Socratic
+
+Don't state the concept. Lead to it with questions, starting from something they already hold
+solid (check the subject index). Each question moves one step; each answer decides the next. If
+they stall twice on the same step, give the smallest hint that unblocks, not the answer. When they
+arrive, have them state the concept in their own words and write that down under What they've got.
+
+One question per message, always.
+
+## Build
+
+Give them something to make or work through that uses two or three concepts together. Size it to
+one sitting. Say what it should do, not how. When they bring it back, review against the
+foundations: ask why they made the choices they made, not whether it runs. Slips go into Open
+threads on the concept they belong to; a clean build moves those concepts toward solid.
+
+## Explore
+
+They're curious; follow it. Ask what pulled them in, then go where the questions lead. Each new
+idea that comes up gets a concept file (`status: forming`) linked from the one that spawned it,
+so the map grows as a graph of what they actually wondered about. Cross-subject links are the
+prize here. Status updates are light: forming on first contact, nothing more unless a probe
+happens naturally. Search freely; this is where current sources shine.
+
+## Revisit
+
+Reopen shaky concepts and the oldest forming ones. Not a test: "we left decorators with a loose
+thread about `@wraps`, want to finish the thought?" Start from the open thread itself, pick
+whichever mode fits it, and close the thread when it's resolved. Two or three concepts per
+session at most.

--- a/lifestyle/tutor/skills/tutor/references/sources.md
+++ b/lifestyle/tutor/skills/tutor/references/sources.md
@@ -1,0 +1,43 @@
+# Sources
+
+Tavily gives you two tools: `tavily_search` (web search that returns page content) and
+`tavily_extract` (full content of given URLs). Use only these two, even if others appear.
+
+## When to search
+
+Search **before** teaching when the topic is:
+
+- **version-dependent**: any library, framework, tool, language feature, API, law, tax rule, price;
+- **recent**: anything that changed or happened in the last couple of years;
+- **documentation-shaped**: the learner wants the actual API, syntax, or spec, not the idea;
+- **asked for**: "where can I read more", "is this still true", "show me a source".
+
+Don't search for stable fundamentals (arithmetic, basic grammar, the water cycle) unless asked;
+teach from what you know and say so in a word ("from memory:").
+
+## How to search
+
+- `search_depth: "advanced"` for teaching material; `"basic"` for a quick fact check.
+- Prefer primary sources: official docs, the paper, the standard, the author. Then well-known
+  explainers. Skip content farms.
+- One search, read the results, pick one or two. Don't chain searches to be thorough; you're
+  looking for the best thing to teach from, not coverage.
+- Use `tavily_extract` when a specific page is the thing to teach from and the search snippet
+  isn't enough. Long pages go to a subagent that returns the relevant part.
+
+## Citing
+
+End the message with one line: `Source: <title>, <url>`. Two sources at most. If you taught from
+memory, no source line.
+
+## Saving
+
+Add URLs you actually taught from, or recommended, to the concept's `sources` frontmatter list.
+Not every hit; only what earned its place. These are what the weekly digest and Revisit draw on.
+
+## Keyless mode
+
+The template ships Tavily in keyless mode, a shared allowance. If a call fails with a quota or
+authorisation error, tell the learner in one plain sentence that the shared search allowance is
+used up for now, teach from what you know, and point them to the README section "Adding your own
+Tavily key". Don't retry in a loop.

--- a/lifestyle/tutor/skills/tutor/references/understanding.md
+++ b/lifestyle/tutor/skills/tutor/references/understanding.md
@@ -1,0 +1,41 @@
+# Checking understanding
+
+The question is never "did they read it". The question is whether the idea has a foundation under
+it. A foundation shows when the learner can do something with the idea that they couldn't do by
+pattern-matching your words.
+
+## Probes that work
+
+- **Explain it to a newcomer.** "How would you tell someone who's never seen a decorator what it does?"
+- **Predict.** "If I removed `@wraps`, what would `help(my_func)` show?"
+- **Break it.** "Give me a case where this approach stops working."
+- **Invert.** "What would have to be false for this not to hold?"
+- **Connect.** "Where have you seen this shape before?" Point to a solid concept on the map.
+- **Apply.** "Here's a new example; what happens?"
+- **Choose.** "Two ways to do this; which would you pick here, and why?"
+
+One probe, then wait. If the answer is partial, follow the gap; don't move on.
+
+## Never
+
+- "Does that make sense?" / "Do you follow?" / "Clear so far?"
+- "Can you repeat that back?"
+- Anything answerable with "yes".
+- Praise that carries no information ("Great question!", "Exactly right!"). When something was
+  good, say what: "You caught the late-binding issue before I raised it."
+- A probe on something the learner has self-reported as solid.
+
+## Reading the answer
+
+- **Right, with a reason.** The foundation is there. Move toward solid.
+- **Right, no reason.** Ask for the reason once. If it's there, fine. If not, forming stays forming.
+- **Hesitation on a prerequisite.** Note it as an open thread on the prerequisite's file, not this
+  one. Decide whether to detour now or leave it for Revisit.
+- **Confident and wrong.** The most useful signal you'll get. Don't correct straight away; ask one
+  predict-or-break probe that makes the contradiction visible, then explain. Record the exact
+  misstatement, dated, under Open threads.
+
+## Tone
+
+You're a peer who happens to know this, not an examiner. Ask because you're interested in how
+they see it. When they get it, move on; lingering reads as testing.

--- a/lifestyle/tutor/skills/welcome/SKILL.md
+++ b/lifestyle/tutor/skills/welcome/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: welcome
+description: Introduce yourself to a newly connected learner. Triggered automatically when the channel is first wired.
+---
+
+# Welcome: first meeting
+
+You've just been connected to someone who wants to learn. Say hi in one short message: who you
+are and, in one sentence, what you do: you teach, you keep track of what they know, and you pick
+up where you left off. No feature list.
+
+Then onboard. **One question per message**, and only what you need for the first session:
+
+1. Their name, and what they'd like to learn first.
+2. Why. What they want to be able to do with it. This shapes everything you pick.
+3. How they like to learn. Offer the five ways in one line: explained to you, led there with
+   questions, by building something, by wandering wherever curiosity goes, or by revisiting
+   things you half-know. Whatever they pick becomes their default, and they can name a different
+   one any time.
+4. Where they're starting from, in their own words. Whatever they say, that's the record. Don't
+   test it.
+
+Tell them up front they can skip anything.
+
+## As you go
+
+- **Seed memory from the first answer.** Create `memory/learner.md`, the subject folder and its
+  index, and a first concept file for wherever they said they're starting, all per the `tutor`
+  skill's `learner-model` reference. Set Core Memory and "Where we are" in `memory/index.md`.
+- **The weekly digest**, in plain words, near the end: "Once a week, if you've learned something
+  new, I'll send you a few genuinely good things to read or watch on it, for your own time. Quiet
+  weeks I stay quiet. Want that?" If yes, find the paused `weekly-digest` task, adjust the time if
+  they want, and resume it. If no, leave it paused.
+- **Then start.** Don't end onboarding with "let me know when you're ready". Go straight into the
+  first session in the mode they chose.
+
+## Tone
+
+Warm, plain, brief. This is the first conversation with a learning partner, not a form.

--- a/lifestyle/tutor/tools/map-viewer/index.html
+++ b/lifestyle/tutor/tools/map-viewer/index.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Tutor · learning map</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vis-network/9.1.9/dist/vis-network.min.js"></script>
+<style>
+  :root { --bg:#0f1115; --panel:#161a22; --line:#262c38; --fg:#e8ebf0; --dim:#8b93a3;
+          --untouched:#4b5563; --forming:#e0a52a; --shaky:#e5533d; --solid:#3ec27a; --subject:#5b8def; }
+  * { box-sizing:border-box }
+  body { margin:0; background:var(--bg); color:var(--fg); font:15px/1.45 -apple-system, "SF Pro Text", Inter, system-ui, sans-serif; height:100vh; display:grid; grid-template-rows:auto 1fr; }
+  header { display:flex; align-items:center; gap:22px; padding:12px 18px; border-bottom:1px solid var(--line); background:var(--panel); }
+  header h1 { font-size:17px; margin:0; font-weight:600; letter-spacing:.2px }
+  header h1 span { color:var(--dim); font-weight:400 }
+  #where { color:var(--fg); font-size:14px; flex:1; min-width:0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis }
+  #where b { color:var(--dim); font-weight:500; margin-right:6px }
+  .legend { display:flex; gap:14px; font-size:13px; color:var(--dim) }
+  .legend i { display:inline-block; width:10px; height:10px; border-radius:50%; margin-right:5px; vertical-align:-1px }
+  .legend b { color:var(--fg); font-weight:600 }
+  main { display:grid; grid-template-columns:1fr 380px; min-height:0 }
+  #graph { min-height:0 }
+  aside { border-left:1px solid var(--line); background:var(--panel); padding:18px 20px; overflow:auto }
+  aside h2 { margin:0 0 4px; font-size:20px }
+  .pill { display:inline-block; padding:2px 9px; border-radius:999px; font-size:12px; font-weight:600; color:#0f1115; margin-right:8px }
+  .meta { color:var(--dim); font-size:13px; margin:6px 0 14px }
+  aside h3 { font-size:12px; text-transform:uppercase; letter-spacing:.8px; color:var(--dim); margin:18px 0 6px }
+  aside ul { margin:0; padding-left:18px } aside li { margin:4px 0 }
+  aside li.thread { color:#f1b7ab } aside a { color:#8fb4ff; word-break:break-all; text-decoration:none } aside a:hover { text-decoration:underline }
+  .empty { color:var(--dim); font-style:italic }
+  #hint { color:var(--dim) }
+  .toast { position:fixed; left:18px; bottom:18px; background:#1f2633; border:1px solid var(--line); padding:8px 12px; border-radius:8px; font-size:13px; opacity:0; transition:opacity .3s }
+  .toast.on { opacity:1 }
+</style>
+</head>
+<body>
+<header>
+  <h1>Tutor <span>· learning map</span></h1>
+  <div id="where"><b>Where we are</b><span id="where-text">…</span></div>
+  <div class="legend">
+    <span><i style="background:var(--solid)"></i>solid <b id="c-solid">0</b></span>
+    <span><i style="background:var(--shaky)"></i>shaky <b id="c-shaky">0</b></span>
+    <span><i style="background:var(--forming)"></i>forming <b id="c-forming">0</b></span>
+    <span><i style="background:var(--untouched)"></i>untouched <b id="c-untouched">0</b></span>
+  </div>
+</header>
+<main>
+  <div id="graph"></div>
+  <aside id="side"><p id="hint">Click a concept. The map is read live from the agent's memory folder: one Markdown file per concept, links between them, statuses that move on evidence or on the learner's word.</p></aside>
+</main>
+<div class="toast" id="toast"></div>
+<script>
+const COLORS = { untouched:'#4b5563', forming:'#e0a52a', shaky:'#e5533d', solid:'#3ec27a', subject:'#5b8def' };
+const nodes = new vis.DataSet(), edges = new vis.DataSet();
+const net = new vis.Network(document.getElementById('graph'), {nodes, edges}, {
+  physics: { solver:'forceAtlas2Based', forceAtlas2Based:{ gravitationalConstant:-60, springLength:120, springConstant:0.06, avoidOverlap:0.8 }, stabilization:{ iterations:150 } },
+  interaction: { hover:true, tooltipDelay:120 },
+  nodes: { shape:'dot', font:{ color:'#e8ebf0', size:15, face:'-apple-system, Inter, system-ui' }, borderWidth:2, shadow:false },
+  edges: { color:{ color:'#3a4354', highlight:'#8fb4ff' }, smooth:{ type:'continuous' }, width:1.5 },
+});
+let prev = {}, selected = null, first = true;
+
+function nodeSpec(n) {
+  return { id:n.id, label:n.title, color:{ background:COLORS[n.status]||COLORS.untouched, border:'#0f1115', highlight:{ background:COLORS[n.status], border:'#fff' } },
+           size: n.status==='solid'?18: n.status==='shaky'?17: n.status==='forming'?15:12, title:`${n.title} · ${n.status}${n.threads.length?` · ${n.threads.length} open thread${n.threads.length>1?'s':''}`:''}`, kind:'concept' };
+}
+function subjectSpec(s) {
+  return { id:'subject:'+s.slug, label:s.title, shape:'box', color:{ background:'#1c2740', border:COLORS.subject, highlight:{ background:'#22304f', border:'#fff' } },
+           font:{ color:'#cfe0ff', size:16, bold:{ color:'#cfe0ff' } }, margin:10, kind:'subject', title:s.description||s.title };
+}
+function edgeSpec(e) {
+  const dashed = e.kind==='related';
+  return { id:`${e.kind}|${e.from}|${e.to}`, from:e.from, to:e.to, dashes:dashed, arrows: dashed?'':'to', color:{ color: dashed?'#4a5568':'#3a4354' }, title:e.kind };
+}
+function toast(msg) { const t=document.getElementById('toast'); t.textContent=msg; t.classList.add('on'); setTimeout(()=>t.classList.remove('on'), 2600); }
+
+async function refresh() {
+  let m; try { m = await (await fetch('/api/map')).json(); } catch { return; }
+  document.getElementById('where-text').textContent = m.where || 'nothing yet';
+  const counts = { solid:0, shaky:0, forming:0, untouched:0 };
+  const want = new Set();
+  for (const s of m.subjects) { const spec = subjectSpec(s); want.add(spec.id); nodes.get(spec.id) ? nodes.update(spec) : nodes.add(spec); }
+  for (const n of m.nodes) {
+    counts[n.status] = (counts[n.status]||0)+1; want.add(n.id);
+    const spec = nodeSpec(n);
+    if (nodes.get(n.id)) { nodes.update(spec); if (prev[n.id] && prev[n.id] !== n.status) toast(`${n.title}: ${prev[n.id]} → ${n.status}`); }
+    else { nodes.add(spec); if (!first) toast(`New concept: ${n.title}`); }
+    prev[n.id] = n.status;
+    const hub = `hub|${n.subject}|${n.id}`; want.add(hub);
+    if (!edges.get(hub)) edges.add({ id:hub, from:'subject:'+n.subject, to:n.id, color:{ color:'#232a37' }, width:1, dashes:[2,6] });
+  }
+  for (const e of m.edges) { const spec = edgeSpec(e); want.add(spec.id); edges.get(spec.id) ? edges.update(spec) : edges.add(spec); }
+  for (const id of nodes.getIds()) if (!want.has(id)) nodes.remove(id);
+  for (const id of edges.getIds()) if (!want.has(id)) edges.remove(id);
+  for (const k in counts) { const el = document.getElementById('c-'+k); if (el) el.textContent = counts[k]; }
+  if (selected) renderSide(m.nodes.find(n => n.id===selected));
+  if (first && m.nodes.length) { first=false; setTimeout(()=>net.fit({ animation:true }), 400); }
+}
+function md(s) { return s.replace(/`([^`]+)`/g,'<code>$1</code>').replace(/\[([^\]]+)\]\([^)]*\)/g,'$1'); }
+function renderSide(n) {
+  const side = document.getElementById('side');
+  if (!n) { side.innerHTML = '<p id="hint">Click a concept.</p>'; return; }
+  const li = (arr, cls='') => arr.length ? '<ul>'+arr.map(x=>`<li class="${cls}">${md(x)}</li>`).join('')+'</ul>' : '<p class="empty">nothing yet</p>';
+  side.innerHTML = `
+    <h2>${n.title}</h2>
+    <div><span class="pill" style="background:${COLORS[n.status]}">${n.status}</span><span class="meta">${n.subject}${n.last_touched?' · last touched '+n.last_touched:''}</span></div>
+    <h3>What they've got</h3>${li(n.got)}
+    <h3>Open threads</h3>${li(n.threads,'thread')}
+    ${n.notes.length?'<h3>Notes</h3>'+li(n.notes):''}
+    <h3>Sources</h3>${n.sources.length?'<ul>'+n.sources.map(u=>{const url=u.split(' ')[0];return `<li><a href="${url}" target="_blank">${url.replace(/^https?:\/\//,'')}</a>${u.includes('(digest)')?' <span class="meta">digest</span>':''}</li>`}).join('')+'</ul>':'<p class="empty">none saved</p>'}
+    <p class="meta"><a href="/api/file?p=${encodeURIComponent(n.id)}" target="_blank">open the Markdown file</a></p>`;
+}
+net.on('click', p => {
+  const id = p.nodes[0]; if (!id || id.startsWith('subject:')) { selected=null; renderSide(null); return; }
+  selected = id; fetch('/api/map').then(r=>r.json()).then(m=>renderSide(m.nodes.find(n=>n.id===id)));
+});
+refresh(); setInterval(refresh, 2500);
+</script>
+</body>
+</html>

--- a/lifestyle/tutor/tools/map-viewer/map_viewer.py
+++ b/lifestyle/tutor/tools/map-viewer/map_viewer.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tutor map viewer: renders a NanoClaw tutor agent's memory folder as a live concept graph.
+
+Usage: python3 map_viewer.py <path-to-memory-folder> [port]
+Then open http://127.0.0.1:<port>/ (default 8787). Stdlib only.
+"""
+import json
+import os
+import re
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+MEMORY = os.path.abspath(sys.argv[1] if len(sys.argv) > 1 else "memory")
+PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 8787
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def parse_frontmatter(text):
+    """Minimal YAML front matter: scalars, [a, b] lists, and '- item' lists."""
+    m = re.match(r"^---\n(.*?)\n---\n?(.*)$", text, re.S)
+    if not m:
+        return {}, text
+    fm, body = {}, m.group(2)
+    key = None
+    for line in m.group(1).splitlines():
+        if re.match(r"^\s+-\s", line) and key:
+            fm.setdefault(key, [])
+            if not isinstance(fm[key], list):
+                fm[key] = []
+            fm[key].append(line.split("-", 1)[1].strip().strip('"'))
+            continue
+        mm = re.match(r"^([A-Za-z_]+):\s*(.*)$", line)
+        if not mm:
+            continue
+        key, val = mm.group(1), mm.group(2).strip()
+        if val.startswith("[") and val.endswith("]"):
+            fm[key] = [v.strip().strip('"') for v in val[1:-1].split(",") if v.strip()]
+        elif val == "":
+            fm[key] = []
+        else:
+            fm[key] = val.strip('"')
+    return fm, body
+
+
+def sections(body):
+    """Split a markdown body into {heading: [bullet lines]}."""
+    out, cur = {}, None
+    for line in body.splitlines():
+        h = re.match(r"^##\s+(.*)$", line)
+        if h:
+            cur = h.group(1).strip()
+            out[cur] = []
+        elif cur and line.strip().startswith("- "):
+            out[cur].append(line.strip()[2:])
+    return out
+
+
+def slug_from_link(link, subject):
+    """'closures' -> ('python','closures'); '../math/induction' -> ('math','induction')."""
+    link = link.strip().strip('"')
+    link = re.sub(r"\.md$", "", link)
+    if link.startswith("../"):
+        parts = link[3:].split("/", 1)
+        if len(parts) == 2:
+            return parts[0], parts[1]
+        return subject, parts[0]
+    return subject, link.split("/")[-1]
+
+
+def read(path):
+    try:
+        with open(path, encoding="utf-8") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
+def build_map():
+    subjects_dir = os.path.join(MEMORY, "subjects")
+    nodes, edges, subjects = [], [], []
+    if os.path.isdir(subjects_dir):
+        for s in sorted(os.listdir(subjects_dir)):
+            sdir = os.path.join(subjects_dir, s)
+            if not os.path.isdir(sdir):
+                continue
+            sfm, _ = parse_frontmatter(read(os.path.join(sdir, "index.md")))
+            subjects.append({"slug": s, "title": sfm.get("title", s), "description": sfm.get("description", "")})
+            for fn in sorted(os.listdir(sdir)):
+                if not fn.endswith(".md") or fn == "index.md":
+                    continue
+                slug = fn[:-3]
+                fm, body = parse_frontmatter(read(os.path.join(sdir, fn)))
+                sec = sections(body)
+                nid = f"{s}/{slug}"
+                nodes.append({
+                    "id": nid, "subject": s, "slug": slug,
+                    "title": fm.get("title", slug.replace("-", " ")),
+                    "status": fm.get("status", "untouched"),
+                    "last_touched": fm.get("last_touched", ""),
+                    "sources": fm.get("sources", []) if isinstance(fm.get("sources"), list) else [],
+                    "got": sec.get("What they've got", []),
+                    "threads": sec.get("Open threads", []),
+                    "notes": sec.get("Notes", []),
+                })
+                for kind in ("prerequisites", "related"):
+                    for link in fm.get(kind, []) or []:
+                        ts, tslug = slug_from_link(link, s)
+                        edges.append({"from": f"{ts}/{tslug}", "to": nid, "kind": kind})
+    ids = {n["id"] for n in nodes}
+    edges = [e for e in edges if e["from"] in ids and e["to"] in ids]
+    # de-duplicate reverse 'related' pairs
+    seen, clean = set(), []
+    for e in edges:
+        key = (e["kind"],) + tuple(sorted([e["from"], e["to"]])) if e["kind"] == "related" else (e["kind"], e["from"], e["to"])
+        if key in seen:
+            continue
+        seen.add(key)
+        clean.append(e)
+    idx = read(os.path.join(MEMORY, "index.md"))
+    where = ""
+    m = re.search(r"Where we are:\s*(.*)", idx)
+    if m:
+        where = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", m.group(1)).strip()
+    learner = ""
+    m = re.search(r"Learner:\s*(.*)", idx)
+    if m:
+        learner = m.group(1).strip()
+    return {"subjects": subjects, "nodes": nodes, "edges": clean, "where": where, "learner": learner}
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def send(self, code, ctype, data):
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        if self.path.startswith("/api/map"):
+            self.send(200, "application/json", json.dumps(build_map()).encode())
+        elif self.path.startswith("/api/file"):
+            q = self.path.split("?", 1)[1] if "?" in self.path else ""
+            rel = dict(p.split("=", 1) for p in q.split("&") if "=" in p).get("p", "")
+            rel = rel.replace("%2F", "/")
+            full = os.path.normpath(os.path.join(MEMORY, "subjects", rel + ".md"))
+            if not full.startswith(MEMORY):
+                return self.send(403, "text/plain", b"no")
+            self.send(200, "text/plain; charset=utf-8", read(full).encode())
+        else:
+            self.send(200, "text/html; charset=utf-8", read(os.path.join(HERE, "index.html")).encode())
+
+
+if __name__ == "__main__":
+    print(f"Tutor map viewer: {MEMORY}\nhttp://127.0.0.1:{PORT}/")
+    HTTPServer(("127.0.0.1", PORT), H).serve_forever()


### PR DESCRIPTION
## What this template does

A learning partner for one adult who wants to learn something, any subject. It teaches from current sources via Tavily (search before teaching anything version-dependent, recent, or documentation-shaped; cite it; save the good sources on the concept), keeps a linked map of what the learner knows as one-concept-per-file Markdown in NanoClaw's native OKF memory (status, prerequisites, cross-subject links, open threads), checks understanding by probing foundations rather than asking "does that make sense?", and picks every session up from a "Where we are" line in memory. Five modes: Explain, Socratic, Build, Explore, Revisit. The learner's own self-report of where they stand always wins; this is for people who want to learn, not a school.


## Where it lives

`lifestyle/tutor/`

## Services and credentials

See the README's [Services and credentials](https://github.com/luzybry94/nanoclaw-templates/blob/lifestyle-tutor/lifestyle/tutor/README.md#services-and-credentials) section. One service: Tavily's hosted MCP server in keyless mode (`streamable-http`, no key, shared allowance), with instructions for adding a personal key through OneCLI. No paid tier required.

One recurring task ships paused: `weekly-digest` (Sunday 18:00 by default). If the learner touched nothing that week it sends nothing; otherwise it searches for three to five genuinely good follow-ups on what they actually engaged with and sends them with one line on the map.

## Before you open this

- [x] `node scripts/build-index.mjs` run and the regenerated `index.json`
      committed. **This is the most common red build.**
- [x] `node scripts/check-templates.mjs` passes
- [x] If you edited a template that already existed, its `plugin.json` `version`
      is bumped (n/a, new template)
- [x] No secrets anywhere in the diff
- [x] Read [Acceptance and ownership](https://github.com/nanocoai/nanoclaw-templates/blob/main/CONTRIBUTING.md#acceptance-and-ownership)
      and the full [PR checklist](https://github.com/nanocoai/nanoclaw-templates/blob/main/CONTRIBUTING.md#pr-checklist)


## Demo

https://github.com/user-attachments/assets/8c745536-8461-45a7-a0ea-55103fae8143


---

### Entering the September 2026 hackathon?

**Track (as chosen on the form):** Tavily
