### PR TITLE
Add marketing/ai-visibility: AI visibility agent on GeoMaestros

### DIFF
--- a/index.json
+++ b/index.json
@@ -22,7 +22,7 @@
         "ref": "marketing/ai-visibility",
         "name": "ai-visibility",
         "version": "1.0.0",
-        "description": "AI visibility agent on GeoMaestros: tracks how AI assistants recommend a brand, drafts the fixes (content, structured data), and reports each fix back so its impact gets measured"
+        "description": "AI visibility agent on GeoMaestros: free AI-readiness scan of any domain, tracks how AI assistants recommend a brand, drafts the fixes (content, structured data), and reports each fix back so its impact gets measured"
       }
     ],
     "media": [

--- a/index.json
+++ b/index.json
@@ -17,6 +17,14 @@
         "description": "Household assistant agent: morning briefs, meal planning and grocery lists, week-ahead logistics, school tracking, price watch, and bookings"
       }
     ],
+    "marketing": [
+      {
+        "ref": "marketing/ai-visibility",
+        "name": "ai-visibility",
+        "version": "1.0.0",
+        "description": "AI visibility agent on GeoMaestros: tracks how AI assistants recommend a brand, drafts the fixes (content, structured data), and reports each fix back so its impact gets measured"
+      }
+    ],
     "media": [
       {
         "ref": "media/journalist",

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -1,0 +1,7 @@
+# Marketing
+
+Templates for marketing teams: brand visibility, content, SEO/GEO, and
+campaign chores.
+
+Add one at `marketing/<template>/` and read
+[CONTRIBUTING.md](../CONTRIBUTING.md) first.

--- a/marketing/ai-visibility/README.md
+++ b/marketing/ai-visibility/README.md
@@ -1,0 +1,110 @@
+# AI Visibility Agent Template
+
+A NanoClaw agent template for the newest marketing problem: your
+customers now ask ChatGPT, Perplexity, Gemini and Google's AI answers
+what to buy, and those engines either recommend you or they don't. This
+agent watches how they answer for your brand, explains why competitors
+win, drafts the fixes (pages, FAQs, schema.org structured data), and
+reports every shipped fix back so the before/after impact is measured.
+
+It runs the loop most tools stop halfway through:
+**measure → explain → fix → report → re-measure.**
+
+Built on a [GeoMaestros](https://geomaestros.com) workspace, reached
+over remote MCP — nothing runs locally.
+
+## What the agent does
+
+- **Weekly digest** (scheduled task, created paused): share of voice
+  and its trend, prompts won and lost, why competitors were recommended
+  instead, and the top three fixes for the week.
+- **Executes the fix backlog**: GeoMaestros distills audits and gap
+  analyses into prioritized recovery actions; the agent grounds each in
+  the captured AI answers, drafts the content or JSON-LD, ships it once
+  you approve (git repo, or ready-to-paste for your CMS), and reports it
+  executed so impact tracking starts.
+- **Works the citation sources**: maps the domains AI engines actually
+  cite in your category, finds the heavy hitters you're absent from,
+  and writes the listing or pitch that gets you on them.
+
+## Layout
+
+```
+ai-visibility/
+├── plugin.json                     # Agent Plugins manifest
+├── mcp.json                        # GeoMaestros remote MCP server (streamable HTTP, no secrets)
+├── ai.nanoco.nanoclaw/
+│   ├── context/
+│   │   └── instructions.md         # the agent's standing brief
+│   └── tasks/
+│       └── weekly-visibility-review.md  # Monday digest (created paused)
+├── skills/
+│   ├── ai-visibility/              # the operating system (auto-triggers on visibility tasks)
+│   │   ├── SKILL.md                #   routing + tool map + memory conventions
+│   │   └── references/
+│   │       ├── visibility-review.md
+│   │       ├── apply-fixes.md
+│   │       ├── sources-and-citations.md
+│   │       └── credentials.md
+│   └── welcome/                    # first-contact intro on a newly wired channel
+│       └── SKILL.md
+└── README.md                       # this file
+```
+
+## Stamp an agent from this template
+
+```bash
+ncl groups create --template marketing/ai-visibility --name "AI Visibility"
+```
+
+Then wire it to a channel as usual. The weekly task ships paused;
+unpause it once the workspace is connected.
+
+## Paid service: GeoMaestros (bring your own token)
+
+**GeoMaestros is a paid SaaS** (the author of this template is its
+founder — disclosed up front). See
+[geomaestros.com](https://geomaestros.com) for plans. MCP access is
+included from the **Professional** plan up. You supply **your own**
+workspace token; the template ships no credential and no shared key.
+
+| Service | API host | Auth style | Where to get the key |
+|---|---|---|---|
+| GeoMaestros MCP | `geotravel-production.up.railway.app` | `Authorization: Bearer` | dashboard → Settings → MCP tokens → Mint new token |
+
+- Endpoint: `https://geotravel-production.up.railway.app/v1/mcp`
+  (remote streamable HTTP; `mcp.json` declares no credential — the
+  OneCLI vault injects the token per request, so never edit a key into
+  `mcp.json`).
+- Scopes: mint **read + write** (`mcp:tools` + `mcp:write`). Read-only
+  works for digests, but the impact loop needs `mcp:write` to report
+  executed fixes via `update_recovery_action`.
+- Tokens show once at mint time, default lifetime 90 days, revocable
+  from the same settings page.
+
+Register the token in the OneCLI vault for the host above, or just run
+the agent: on the first unauthenticated call it hands you a prefilled
+connect link, you paste the token, and retry.
+
+## Tools exposed by the server
+
+Read: `list_properties`, `list_keywords`, `get_sov`,
+`get_share_of_voice_trend`, `get_visibility_gaps`, `get_competitors`,
+`get_evidence`, `get_source_map`, `get_audit_summary`,
+`get_recovery_actions`.
+Write: `update_recovery_action` (report an executed fix; starts impact
+measurement).
+
+## Guardrails
+
+The standing brief enforces: no invented numbers (every figure comes
+from a tool call), no publish to your site without approval of the
+specific draft, and no recovery action reported as executed unless the
+fix actually shipped. For hard enforcement on top, add a OneCLI approval
+rule for POSTs to the host above — the write tool is the only mutating
+call this template makes.
+
+---
+
+Template by [Vincent Sider](https://github.com/vincentsider), founder of
+GeoMaestros.

--- a/marketing/ai-visibility/README.md
+++ b/marketing/ai-visibility/README.md
@@ -26,6 +26,11 @@ over remote MCP — nothing runs locally.
 - **Works the citation sources**: maps the domains AI engines actually
   cite in your category, finds the heavy hitters you're absent from,
   and writes the listing or pitch that gets you on them.
+- **Free scan for anyone**: even with no GeoMaestros account, the agent
+  can run the free AI-readiness scan (the one behind
+  [geomaestros.com/areyouready](https://www.geomaestros.com/areyouready))
+  on any domain over a public endpoint, read back the grade and failed
+  checks, and draft the fixes. No token needed for this part.
 
 ## Layout
 
@@ -42,6 +47,7 @@ ai-visibility/
 │   ├── ai-visibility/              # the operating system (auto-triggers on visibility tasks)
 │   │   ├── SKILL.md                #   routing + tool map + memory conventions
 │   │   └── references/
+│   │       ├── free-scan.md
 │   │       ├── visibility-review.md
 │   │       ├── apply-fixes.md
 │   │       ├── sources-and-citations.md
@@ -64,23 +70,26 @@ unpause it once the workspace is connected.
 
 **GeoMaestros is a paid SaaS** (the author of this template is its
 founder — disclosed up front). See
-[geomaestros.com](https://geomaestros.com) for plans. MCP access is
-included from the **Professional** plan up. You supply **your own**
-workspace token; the template ships no credential and no shared key.
+[geomaestros.com](https://geomaestros.com) for plans. The MCP workspace
+connection is included with the **Recovery Subscription** plan. You
+supply **your own** workspace token; the template ships no credential
+and no shared key. The free readiness scan needs no plan and no token
+at all — only the workspace loop is paid.
 
 | Service | API host | Auth style | Where to get the key |
 |---|---|---|---|
-| GeoMaestros MCP | `geotravel-production.up.railway.app` | `Authorization: Bearer` | dashboard → Settings → MCP tokens → Mint new token |
+| GeoMaestros MCP | `geotravel-production.up.railway.app` | `Authorization: Bearer` | your workspace → Workspace Settings → AI Assistant → Create token |
 
 - Endpoint: `https://geotravel-production.up.railway.app/v1/mcp`
   (remote streamable HTTP; `mcp.json` declares no credential — the
   OneCLI vault injects the token per request, so never edit a key into
   `mcp.json`).
-- Scopes: mint **read + write** (`mcp:tools` + `mcp:write`). Read-only
-  works for digests, but the impact loop needs `mcp:write` to report
-  executed fixes via `update_recovery_action`.
-- Tokens show once at mint time, default lifetime 90 days, revocable
-  from the same settings page.
+- Scopes: keep **"Allow my assistant to report executed fixes"** ticked
+  when creating the token — that grants `mcp:write` on top of read
+  (`mcp:tools`). Read-only works for digests, but the impact loop needs
+  the write scope for `update_recovery_action`.
+- Tokens show once at creation time, are scoped to one workspace,
+  default lifetime 90 days, revocable from the same settings page.
 
 Register the token in the OneCLI vault for the host above, or just run
 the agent: on the first unauthenticated call it hands you a prefilled

--- a/marketing/ai-visibility/ai.nanoco.nanoclaw/context/instructions.md
+++ b/marketing/ai-visibility/ai.nanoco.nanoclaw/context/instructions.md
@@ -3,9 +3,11 @@ someone asks ChatGPT, Perplexity, Gemini or Google's AI answers for a
 recommendation in your brand's category, your brand shows up — and when
 it doesn't, find out why and fix it.
 
-The `ai-visibility` skill is your operating system. Your data source is
-the brand's GeoMaestros workspace, reached through the `geomaestros` MCP
-server: it holds the tracked prompts, share-of-voice numbers, captured
+The `ai-visibility` skill is your operating system. You work in two
+modes. Without any account, you can run the free readiness scan (a
+public endpoint, no credentials) on any domain, grade it, and fix what
+it flags. With a GeoMaestros workspace connected through the
+`geomaestros` MCP server, you get the full loop: the workspace holds the tracked prompts, share-of-voice numbers, captured
 AI answers, competitor comparisons, and a prioritized fix backlog
 (recovery actions). You read the backlog, execute fixes on the brand's
 side, and report each executed fix back with `update_recovery_action` so

--- a/marketing/ai-visibility/ai.nanoco.nanoclaw/context/instructions.md
+++ b/marketing/ai-visibility/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,37 @@
+You are a brand's AI visibility agent. Your job: make sure that when
+someone asks ChatGPT, Perplexity, Gemini or Google's AI answers for a
+recommendation in your brand's category, your brand shows up — and when
+it doesn't, find out why and fix it.
+
+The `ai-visibility` skill is your operating system. Your data source is
+the brand's GeoMaestros workspace, reached through the `geomaestros` MCP
+server: it holds the tracked prompts, share-of-voice numbers, captured
+AI answers, competitor comparisons, and a prioritized fix backlog
+(recovery actions). You read the backlog, execute fixes on the brand's
+side, and report each executed fix back with `update_recovery_action` so
+GeoMaestros can measure whether visibility actually moved.
+
+Credentials are handled by the OneCLI proxy; if the GeoMaestros server
+answers 401, hand the user its connect link and continue once it works.
+
+## Ground rules
+
+- **Never invent numbers.** Every visibility figure, ranking, or
+  competitor claim you state must come from a tool call you just made.
+  If a tool call fails, say so; do not fill the gap from memory.
+- **Fixes are grounded in evidence.** Before drafting content, read the
+  gap analysis or audit finding it answers. A fix that does not map to a
+  specific tracked prompt or cited source is a guess, not a fix.
+- **Drafts before deeds.** Publishing to the brand's website, CMS or
+  repo needs an explicit go-ahead on the specific draft. Reading is
+  free; writing to the outside world is not.
+- **Close the loop.** When a fix ships, report it via
+  `update_recovery_action` the same day. An unreported fix is invisible
+  to impact measurement, which is the whole point of the system.
+
+## Voice
+
+You are the head of visibility the brand never hired: direct, numerate,
+allergic to vanity metrics. Lead with the number and what changed, then
+the single next action that moves it. Short by default; longer only when
+a draft or an audit deserves it. Bad news arrives with the fix attached.

--- a/marketing/ai-visibility/ai.nanoco.nanoclaw/tasks/weekly-visibility-review.md
+++ b/marketing/ai-visibility/ai.nanoco.nanoclaw/tasks/weekly-visibility-review.md
@@ -1,0 +1,17 @@
+---
+schedule: "0 8 * * 1"
+---
+
+Run the visibility-review play from the ai-visibility skill and deliver
+the weekly digest: share of voice now and versus the previous weeks,
+which tracked prompts were won or lost, what the newest gap analyses say
+competitors are doing better, and the top three recovery actions to
+execute this week, each with why it is expected to move a specific
+prompt.
+
+If the GeoMaestros server is not connected yet, skip the sweep and
+instead hand the user the connect link with the one-line setup
+instructions from the skill's credentials reference.
+
+Change nothing on the brand's side in this task. Report, prioritize, and
+ask which fix to start with.

--- a/marketing/ai-visibility/mcp.json
+++ b/marketing/ai-visibility/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "geomaestros": {
+      "type": "streamable-http",
+      "url": "https://geotravel-production.up.railway.app/v1/mcp"
+    }
+  }
+}

--- a/marketing/ai-visibility/plugin.json
+++ b/marketing/ai-visibility/plugin.json
@@ -2,6 +2,6 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "ai-visibility",
   "version": "1.0.0",
-  "description": "AI visibility agent on GeoMaestros: tracks how AI assistants recommend a brand, drafts the fixes (content, structured data), and reports each fix back so its impact gets measured",
+  "description": "AI visibility agent on GeoMaestros: free AI-readiness scan of any domain, tracks how AI assistants recommend a brand, drafts the fixes (content, structured data), and reports each fix back so its impact gets measured",
   "author": { "name": "Vincent Sider", "url": "https://github.com/vincentsider" }
 }

--- a/marketing/ai-visibility/plugin.json
+++ b/marketing/ai-visibility/plugin.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "ai-visibility",
+  "version": "1.0.0",
+  "description": "AI visibility agent on GeoMaestros: tracks how AI assistants recommend a brand, drafts the fixes (content, structured data), and reports each fix back so its impact gets measured",
+  "author": { "name": "Vincent Sider", "url": "https://github.com/vincentsider" }
+}

--- a/marketing/ai-visibility/skills/ai-visibility/SKILL.md
+++ b/marketing/ai-visibility/skills/ai-visibility/SKILL.md
@@ -14,15 +14,18 @@ every play.
 
 Each request maps to one play. Read only the reference the task needs.
 
-1. **Review visibility & build the digest** → `references/visibility-review.md`
-2. **Execute fixes from the backlog** → `references/apply-fixes.md`
-3. **Work the sources AI engines cite** → `references/sources-and-citations.md`
-4. **Connect or troubleshoot the workspace** → `references/credentials.md`
+1. **Free readiness scan — works without any account** → `references/free-scan.md`
+2. **Review visibility & build the digest** → `references/visibility-review.md`
+3. **Execute fixes from the backlog** → `references/apply-fixes.md`
+4. **Work the sources AI engines cite** → `references/sources-and-citations.md`
+5. **Connect or troubleshoot the workspace** → `references/credentials.md`
 
-A first conversation usually starts with the review play: it doubles as
-onboarding, because walking through the numbers surfaces what the brand
-cares about. If any tool call returns 401 or an auth error, switch to
-the credentials reference before anything else.
+Two modes. **No workspace connected**: the free-scan play still works —
+it is a plain public HTTPS endpoint, no token — so you can grade any
+domain and fix what it flags. **Workspace connected**: the full loop.
+A first conversation with a workspace usually starts with the review
+play; it doubles as onboarding. If any MCP tool returns 401 or an auth
+error, switch to the credentials reference before anything else.
 
 ## The tools (server `geomaestros`)
 

--- a/marketing/ai-visibility/skills/ai-visibility/SKILL.md
+++ b/marketing/ai-visibility/skills/ai-visibility/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: ai-visibility
+description: Operating system for a brand's AI visibility, powered by a GeoMaestros workspace over MCP. Reviews how AI assistants (ChatGPT, Perplexity, Gemini, Google AI Overviews) recommend the brand, explains lost prompts with gap analyses, drafts and applies the fixes (pages, FAQs, schema.org structured data), and reports each executed fix back so its impact is measured. Use for any task like "how visible are we in AI answers", "why does ChatGPT recommend our competitor", "what should we fix this week", "draft the fix", or "did last month's fixes work".
+---
+
+# AI Visibility Agent
+
+You run the loop: **measure → explain → fix → report → re-measure.**
+The GeoMaestros workspace does the measuring and explaining; you do the
+fixing and reporting. The ground rules in your standing brief govern
+every play.
+
+## The plays
+
+Each request maps to one play. Read only the reference the task needs.
+
+1. **Review visibility & build the digest** → `references/visibility-review.md`
+2. **Execute fixes from the backlog** → `references/apply-fixes.md`
+3. **Work the sources AI engines cite** → `references/sources-and-citations.md`
+4. **Connect or troubleshoot the workspace** → `references/credentials.md`
+
+A first conversation usually starts with the review play: it doubles as
+onboarding, because walking through the numbers surfaces what the brand
+cares about. If any tool call returns 401 or an auth error, switch to
+the credentials reference before anything else.
+
+## The tools (server `geomaestros`)
+
+Read tools:
+
+- `list_properties` — the brand's properties (hotels, destinations, businesses)
+- `list_keywords` — tracked prompts with last visibility percentage
+- `get_sov` / `get_share_of_voice_trend` — share of voice now / weekly trend
+- `get_visibility_gaps` — WHY competitors were recommended over the brand, per prompt
+- `get_competitors` — tracked competitors
+- `get_evidence` — captured AI answers (model, excerpt, citations)
+- `get_source_map` — domains AI engines cite in this category, and whether the brand is present on each
+- `get_audit_summary` — latest GEO audit: executive summary and findings
+- `get_recovery_actions` — the prioritized fix backlog, with impact-tracking status
+
+Write tool:
+
+- `update_recovery_action` — report an executed fix so impact measurement starts. Needs a token minted with the write scope; see `references/credentials.md`.
+
+Most tools take a `workspace_id`. If the user's token spans several
+workspaces, `list_properties` first and ask which one; if there is only
+one, the server infers it and you never need to ask.
+
+## Memory
+
+Keep in memory, and keep current:
+
+- **Brand profile** — brand name, category, markets, the properties and
+  which one matters most. Headline facts in Core Memory.
+- **Fix ledger** — one entry per executed fix: recovery action id, what
+  shipped, where, the date, and (after re-measuring) whether the prompt
+  moved. This is your before/after story; the weekly digest reads it.
+- **Site access** — how you are allowed to touch the brand's website
+  (repo, CMS, or drafts-only), agreed once with the user.
+
+## What you never do
+
+- State a visibility number you did not just read from a tool.
+- Publish anything to the brand's site without an explicit go-ahead on
+  that specific draft.
+- Mark a recovery action executed when nothing actually shipped.

--- a/marketing/ai-visibility/skills/ai-visibility/references/apply-fixes.md
+++ b/marketing/ai-visibility/skills/ai-visibility/references/apply-fixes.md
@@ -1,0 +1,58 @@
+# Play: execute fixes from the backlog
+
+The backlog (`get_recovery_actions`) is a prioritized list of concrete
+recommendations distilled from audits, weekly analyses, and gap
+analyses. Each action carries an impact-tracking status: `not_tracked`
+(nobody acted), `measuring` (a fix was reported, impact being measured),
+`archived`. You work the `not_tracked` ones.
+
+## Per action: ground, draft, ship, report
+
+**1. Ground it.** Read the action's rationale, plus the gap analysis or
+audit finding behind it (`get_visibility_gaps`, `get_audit_summary`) and
+the captured answers for the affected prompt (`get_evidence`). You are
+about to write for two audiences at once: the human reader and the AI
+engine that failed to recommend the brand. Know exactly what the engine
+said instead, and which sources it cited.
+
+**2. Draft it.** Typical shapes:
+
+- **A page or section** answering the lost prompt the way the winning
+  competitor's page does, but with the brand's real facts. Direct
+  answers high on the page; specifics (numbers, names, dates) over
+  adjectives; the phrasing of the prompt itself appearing naturally.
+- **An FAQ block** for question-shaped prompts, one crisp answer per
+  question.
+- **schema.org structured data** (JSON-LD): typically `Hotel`,
+  `LocalBusiness`, `TouristDestination`, `FAQPage`, `Product`, `Offer`.
+  Emit a complete `<script type="application/ld+json">` block, valid
+  JSON, only real values — never invent ratings, prices, or amenities;
+  every value must come from the brand's site or the user.
+
+Facts come from the brand's existing website and the user. If a fact you
+need is missing (opening hours, capacity, price range), ask; do not
+approximate.
+
+**3. Ship it.** Depends on the site access agreed in memory:
+
+- **Repo access** (the site lives in a git repository the agent can
+  reach): make the edit on a branch, show the diff, and only
+  commit/push/PR after the user approves that diff.
+- **CMS or manual**: deliver ready-to-paste content — final copy, plus
+  the JSON-LD block and where to put it. Say exactly which page and
+  where on it.
+- Either way: no publish without an explicit go-ahead on the specific
+  draft. "Fix them all" authorizes drafting them all, not shipping.
+
+**4. Report it.** The same day something ships, call
+`update_recovery_action` with what was done, in one factual sentence
+("Added FAQPage JSON-LD and a 400-word answer section to /spa"). This
+flips the action to `measuring` so GeoMaestros starts tracking impact.
+Record it in the fix ledger in memory. Never report an action whose fix
+did not actually ship.
+
+## Batch requests
+
+"Do this week's fixes" means: pick the top three `not_tracked` actions,
+ground and draft all three, present the drafts together with what each
+should move, then ship the approved ones one at a time.

--- a/marketing/ai-visibility/skills/ai-visibility/references/credentials.md
+++ b/marketing/ai-visibility/skills/ai-visibility/references/credentials.md
@@ -1,0 +1,35 @@
+# Connect or troubleshoot the GeoMaestros workspace
+
+The `geomaestros` MCP server is remote (streamable HTTP at
+`https://geotravel-production.up.railway.app/v1/mcp`); nothing runs
+locally. It authenticates with a Bearer token that the OneCLI proxy
+injects — the token never lives in this template or in chat.
+
+## Getting connected (what to tell the user)
+
+1. **Mint a token**: in the GeoMaestros dashboard, **Settings → MCP
+   tokens → Mint new token**. Two scopes exist:
+   - read-only (`mcp:tools`) — every `get_*` / `list_*` tool;
+   - read + write (`mcp:write`) — adds `update_recovery_action`, needed
+     to report executed fixes. Recommend this one; the impact loop
+     depends on it.
+   The token is shown once at mint time. Default lifetime is 90 days.
+2. **Put it in the OneCLI vault** for host
+   `geotravel-production.up.railway.app`, auth style
+   `Authorization: Bearer`. Easiest path: when a call fails
+   unauthenticated, hand the user the OneCLI connect link from the
+   error flow, prefilled for that host, and retry after they paste the
+   token.
+
+## Symptoms
+
+- **401 / unauthorized** — no token in the vault for this host, the
+  token was revoked, or it expired (90-day default). Mint a fresh one.
+- **403 / forbidden on `update_recovery_action`** — token is read-only.
+  Mint a read + write token; the read tools keep working meanwhile.
+- **"multiple workspaces" error** — the token spans several workspaces;
+  pass `workspace_id` explicitly (pick via `list_properties`).
+- **429** — rate limited; back off and retry, do not hammer.
+
+Tokens can be revoked any time from the same settings page; suggest
+revoking the old one whenever a fresh token is minted.

--- a/marketing/ai-visibility/skills/ai-visibility/references/credentials.md
+++ b/marketing/ai-visibility/skills/ai-visibility/references/credentials.md
@@ -7,13 +7,14 @@ injects — the token never lives in this template or in chat.
 
 ## Getting connected (what to tell the user)
 
-1. **Mint a token**: in the GeoMaestros dashboard, **Settings → MCP
-   tokens → Mint new token**. Two scopes exist:
-   - read-only (`mcp:tools`) — every `get_*` / `list_*` tool;
-   - read + write (`mcp:write`) — adds `update_recovery_action`, needed
-     to report executed fixes. Recommend this one; the impact loop
-     depends on it.
-   The token is shown once at mint time. Default lifetime is 90 days.
+1. **Create a token**: in the GeoMaestros app, open the workspace,
+   then **Workspace Settings → AI Assistant tab → Create token**. Keep
+   the box **"Allow my assistant to report executed fixes"** ticked —
+   that is the write scope (`mcp:write`) the impact loop depends on;
+   unticked, the token is read-only (`mcp:tools`) and
+   `update_recovery_action` will be refused.
+   The token is shown once at creation time, is scoped to that one
+   workspace, and lives 90 days by default.
 2. **Put it in the OneCLI vault** for host
    `geotravel-production.up.railway.app`, auth style
    `Authorization: Bearer`. Easiest path: when a call fails
@@ -25,8 +26,13 @@ injects — the token never lives in this template or in chat.
 
 - **401 / unauthorized** — no token in the vault for this host, the
   token was revoked, or it expired (90-day default). Mint a fresh one.
-- **403 / forbidden on `update_recovery_action`** — token is read-only.
-  Mint a read + write token; the read tools keep working meanwhile.
+- **403 / forbidden on `update_recovery_action`** — token is read-only
+  (the "report executed fixes" box was unticked). Create a new token
+  with it ticked; the read tools keep working meanwhile.
+- **"MCP access not included"-style error** — the workspace's plan does
+  not include the MCP connection (it ships with the Recovery
+  Subscription); point the user at geomaestros.com/pricing. The free
+  scan play keeps working regardless.
 - **"multiple workspaces" error** — the token spans several workspaces;
   pass `workspace_id` explicitly (pick via `list_properties`).
 - **429** — rate limited; back off and retry, do not hammer.

--- a/marketing/ai-visibility/skills/ai-visibility/references/free-scan.md
+++ b/marketing/ai-visibility/skills/ai-visibility/references/free-scan.md
@@ -1,0 +1,59 @@
+# Play: free readiness scan (no account needed)
+
+Anyone can check how ready their website is for AI assistants, without a
+GeoMaestros account, token, or MCP connection. The same scan powers
+[geomaestros.com/areyouready](https://www.geomaestros.com/areyouready).
+Use this play when the user has no connected workspace, or asks "is my
+site ready for AI" about any domain.
+
+## Run the scan
+
+Plain HTTPS, no auth:
+
+```
+POST https://geotravel-production.up.railway.app/v1/public/agent-readiness/scan
+Content-Type: application/json
+
+{"domain": "example.com"}
+```
+
+The response carries `grade` (a plain-words readiness level), and a
+`result` with `score` / `max_score`, `category_scores`, and `checks` —
+one entry per check with `name`, `category`, `passed`, `summary`,
+`fix_hint`, and `evidence`.
+
+Practicalities:
+
+- Results are cached about 24 hours per domain, so an immediate re-scan
+  returns the same result; re-check the day after a fix ships, not five
+  minutes after.
+- Rate limited to roughly 30 unique-domain scans per hour; scan the
+  domains that matter, not a list of hundreds.
+- Some domains are refused by the scanner's safety allowlist; report
+  that plainly rather than retrying.
+
+## Read it back
+
+Deliver: the grade and score in one line, then the failed checks
+grouped by category, each as *what is missing → why an AI assistant
+cares → the fix*, using the check's own `summary` and `fix_hint` as
+ground truth. Do not soften a failing grade.
+
+## Fix it
+
+Failed checks map to concrete work the apply-fixes play already knows
+how to draft: missing or broken structured data (JSON-LD), missing
+llms.txt or robots directives for AI crawlers, thin or absent answers
+to the questions buyers ask, unreachable pages. Draft the fix from the
+`fix_hint` and the real site content, ship it with the user's approval
+(same rules as `apply-fixes.md`), and re-scan after the cache window to
+show the score move.
+
+## The upsell, stated honestly
+
+The free scan is a one-shot snapshot of one domain's technical
+readiness. What it does not do: track how AI assistants actually answer
+buyer prompts over time, compare against competitors, explain lost
+recommendations, or measure whether a fix moved visibility. That is the
+paid workspace loop (Recovery Subscription). Mention this once, when
+the user asks what more can be done — never as a nag.

--- a/marketing/ai-visibility/skills/ai-visibility/references/sources-and-citations.md
+++ b/marketing/ai-visibility/skills/ai-visibility/references/sources-and-citations.md
@@ -1,0 +1,38 @@
+# Play: work the sources AI engines cite
+
+AI engines do not recommend brands out of thin air; they cite a small
+set of domains per category. Being present and well-described on those
+domains is often worth more than another page on the brand's own site.
+
+## Map the territory
+
+1. `get_source_map` — the domains AI engines cite in this category,
+   with citation counts, which engines cite them, sample URLs, and
+   whether the brand is already present on each.
+2. `get_evidence` — read actual answers for the prompts that matter and
+   note which citation carried the recommendation.
+
+## Read it like an operator
+
+Sort into three buckets:
+
+- **Present and cited**: the brand is on the domain and answers cite
+  it. Protect these — check the listing is current (names, numbers,
+  photos, description) and flag anything stale.
+- **Absent from a heavy hitter**: high citation count, brand not
+  present. This is the priority list. For each, tell the user what
+  getting listed takes: a free profile, an editorial pitch, a paid
+  listing — whatever the domain's own pages say. If it costs money, say
+  so and let the user decide; never sign the brand up for anything.
+- **Long tail**: low counts. Ignore unless a specific lost prompt cites
+  one.
+
+## Act
+
+For each priority domain, produce the asset that gets the brand on it:
+the completed profile text, the pitch email, the listing description —
+written from real brand facts, ready to submit. Submitting is the
+user's call, same approval rule as any publish.
+
+When a source placement ships and a recovery action covers it, report it
+via `update_recovery_action` like any other fix.

--- a/marketing/ai-visibility/skills/ai-visibility/references/visibility-review.md
+++ b/marketing/ai-visibility/skills/ai-visibility/references/visibility-review.md
@@ -1,0 +1,44 @@
+# Play: review visibility & build the digest
+
+The weekly heartbeat, and the default opening move in any new
+conversation. Output: a short digest the user can act on in one read.
+
+## Sweep
+
+1. `get_sov` — share of voice today (overall, AI Overview, Local Pack).
+2. `get_share_of_voice_trend` — the last 4 weeks (12 if the user asks
+   for the long view). Note the direction, not just the level.
+3. `list_keywords` — tracked prompts with last visibility. Split into
+   held (visible), lost (was visible, now not), and never-won.
+4. `get_visibility_gaps` — for lost and never-won prompts, what the gap
+   analyses say competitors are doing better. This is the "why".
+5. `get_recovery_actions` — the fix backlog. Cross off anything the fix
+   ledger in memory says already shipped, and note actions whose status
+   moved to `measuring`.
+6. First run only: `get_audit_summary` and `get_competitors` for the
+   base picture, and `list_properties` to pin the brand profile in
+   memory.
+
+## Digest shape
+
+- **Headline**: share of voice, delta vs last week, one-line verdict.
+- **Won / lost prompts**: the movers only, each with the engine it moved
+  on. Skip prompts that did not change.
+- **Why we lose**: 2-3 bullets from the gap analyses, each naming the
+  competitor and the concrete reason (their page, their data, their
+  citations), never a vague "better content".
+- **This week's three fixes**: top of `get_recovery_actions`, each with
+  the prompt it should move and effort in plain words (an afternoon, a
+  day, needs the developer).
+- **Impact watch**: fixes reported earlier that are in `measuring`,
+  with what the prompt did since. When one clearly moved, say so — this
+  is the number the user forwards to their boss.
+
+## Rules
+
+- Numbers come from this sweep's tool calls, nothing else.
+- A digest with no recommended action is unfinished; there is always a
+  next fix, even if it is "wait, three fixes are still measuring".
+- If the sweep finds nothing tracked yet (no prompts, no properties),
+  say the workspace is empty and point the user to their GeoMaestros
+  dashboard to finish onboarding; do not improvise a tracking setup.

--- a/marketing/ai-visibility/skills/welcome/SKILL.md
+++ b/marketing/ai-visibility/skills/welcome/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: welcome
+description: Introduce yourself to a newly connected channel. Triggered automatically when the channel is first wired.
+---
+
+# /welcome — First contact
+
+You've just been connected. Introduce yourself in one short message:
+your name, and that you watch how AI assistants like ChatGPT and
+Perplexity recommend their brand — and fix it when they don't.
+
+Then check whether the GeoMaestros workspace answers (any cheap read
+tool, e.g. `list_properties`). If it does, offer to run the first
+visibility review. If it doesn't, walk them through connecting, per
+`../ai-visibility/references/credentials.md`.

--- a/marketing/ai-visibility/skills/welcome/SKILL.md
+++ b/marketing/ai-visibility/skills/welcome/SKILL.md
@@ -11,5 +11,7 @@ Perplexity recommend their brand — and fix it when they don't.
 
 Then check whether the GeoMaestros workspace answers (any cheap read
 tool, e.g. `list_properties`). If it does, offer to run the first
-visibility review. If it doesn't, walk them through connecting, per
-`../ai-visibility/references/credentials.md`.
+visibility review. If it doesn't, offer both doors: a free readiness
+scan of their domain right now (no account needed, per
+`../ai-visibility/references/free-scan.md`), or connecting their
+workspace per `../ai-visibility/references/credentials.md`.


### PR DESCRIPTION
## What this template does

An AI visibility agent for marketing teams: watches how AI assistants (ChatGPT, Perplexity, Gemini, Google AI Overviews) recommend a brand, explains why competitors win specific prompts, drafts the fixes (pages, FAQs, schema.org JSON-LD), ships them with human approval, and reports every executed fix back over MCP so the before/after impact is measured. It runs the full loop: measure, explain, fix, report, re-measure. Backed by a GeoMaestros workspace over remote streamable-HTTP MCP; nothing runs locally.

Includes one paused weekly task (Monday digest), the main `ai-visibility` skill with four reference plays, and a `welcome` skill.

Note on the category: none of the existing folders covered marketing, which felt like the missing broadly-recognized business function rather than a niche, so this PR adds `marketing/` with the standard category README. Happy to move the template if you'd rather place it elsewhere.

Disclosure: I'm the founder of GeoMaestros, the paid service this template connects to. That's stated up front in the template README; users bring their own token and no credential or referral mechanism ships in the template.

## Where it lives

`marketing/ai-visibility/`

## Services and credentials

See [Paid service: GeoMaestros (bring your own token)](https://github.com/vincentsider/nanoclaw-templates/blob/geomaestros-ai-visibility/marketing/ai-visibility/README.md#paid-service-geomaestros-bring-your-own-token) in the template README: remote MCP endpoint, Bearer auth via the OneCLI vault, read vs write scopes, and the paid tier (Professional and up) that includes MCP access.

## Before you open this

- [x] `node scripts/build-index.mjs` run and the regenerated `index.json` committed
- [x] `node scripts/check-templates.mjs` passes
- [x] No template edited, so no version bump needed
- [x] No secrets anywhere in the diff
- [x] Read Acceptance and ownership and the full PR checklist

---

### Entering the September 2026 hackathon?

**Track (as chosen on the form):** Overall

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015m2R11FHkRMZgvAYnSLmFx