### PR TITLE
Add finance/winnow: evidence-based screening template (hackathon, Tavily track)

### DIFF
--- a/finance/README.md
+++ b/finance/README.md
@@ -1,6 +1,0 @@
-# Finance
-
-Templates for finance work: budgets, invoices, expenses, forecasting, and spend monitoring.
-
-No templates yet. Add one at `finance/<template>/` and read
-[CONTRIBUTING.md](../CONTRIBUTING.md) first.

--- a/finance/winnow/EVAL.md
+++ b/finance/winnow/EVAL.md
@@ -1,0 +1,114 @@
+# Eval
+
+Winnow is validated against a **real screen** — a live 48-target M&A search for
+union commercial and industrial perimeter-security contractors — where the
+correct calls were already known, including one the original screen got wrong.
+
+Run it:
+
+```bash
+cd scripts && node --test test/eval.test.mjs
+```
+
+The runner is generic; every case, name and expectation lives in
+`theses/example-fencing.eval.json`. Drop another `*.eval.json` beside a thesis
+and it is picked up automatically.
+
+## What this does and does not prove
+
+**Proves:** that given evidence, the pipeline turns it into the right bands,
+scores, ranking and coverage — deterministically and repeatably.
+
+**Does not prove:** that the research stage finds the right evidence. That is a
+separate question, demonstrated separately by a live run (see *Live runs*
+below). The judgments in the eval fixture were transcribed from the source
+screen's own evidence, not gathered by a model, precisely so that a failure
+here means the *logic* is wrong rather than the search.
+
+Keeping those apart is the point. A single end-to-end number would hide which
+half broke.
+
+## Result
+
+```
+4 pass · 3 near miss · 1 fail
+14/14 eval assertions pass
+
+61 tests across the whole suite; one skips unless an optional
+reference YAML package is resolvable, which is expected.
+```
+
+| Case | Expected | Why it matters |
+|---|---|---|
+| **Midwest Fence Corporation** | PASS, priority, union 100 | Known-good rank 1 of 48: confirmed signatory, family-owned since 1947. |
+| **Century Fence Company** | PASS, union 100 | Positive roster evidence scores as a confirmed signatory. |
+| **Century Fence (absent-evidence variant)** | PASS, union **50**, score ≥ 60 | **The headline assertion.** See below. |
+| **Diversified Construction Services** | NEAR MISS | Marked *Tier Out* in the source screen. An unresolved revisitable filter quarantines rather than drops. |
+| **Priority Grading & Excavating** | NEAR MISS | Also *Tier Out*: access work only, fence scope unconfirmed. |
+| **Residential Only Fence Co** | NEAR MISS | Fails a revisitable filter outright — still scored and reported, not discarded. |
+| **Rommel Fence, LLC** | PASS, union 0, not priority | Open-shop. Ranks below signatories but is **not excluded** — union status is scored, never filtered. |
+| **PE Platform Fence Holdings** | FAIL, unscored | Firm ownership filter. Dropped before research; never scored, so no score can argue with the filter. |
+
+## The headline assertion
+
+The source screen originally recorded Century Fence as **nonunion**. It was
+wrong: the company is Ironworkers-signatory for fence work, and the "nonunion"
+call came from a Laborers matter in a different state. Union status is trade-
+and state-specific, and absence of evidence in one trade is not evidence of
+absence in another.
+
+That is the single most expensive mistake this kind of screen makes, so the
+eval runs the same company twice:
+
+| | Union tier | Total | Band |
+|---|---|---|---|
+| Evidence present | 100 | 78 | PASS |
+| Evidence absent | **50** (neutral policy) | **68** | PASS |
+
+Absent evidence costs 10 points and nothing else. It does not score 0, does
+not fail a filter, does not leave the shortlist. The gap is exactly the
+weight-20 criterion moving from 100 to the neutral default — visible,
+attributable, and reversible the moment evidence appears.
+
+A screen that scored the absent case at 0 would have dropped a real target,
+and would have looked confident doing it.
+
+## Structural invariants
+
+Asserted on every run, not just this fixture:
+
+- **Ranking is structural.** In this fixture a NEAR MISS scores 58 while a
+  PASS scores 52 — the higher-scoring company stays in NEAR MISS, because it
+  failed a filter the user wrote down. The test asserts the situation actually
+  occurs, so the invariant cannot pass vacuously.
+- **Every FAIL is unscored.** The band already decided it; a score would only
+  invite arguing with the filter.
+- **Every declared segment with no candidates is flagged.** An empty segment
+  is a gap in the search, never evidence of an empty market.
+
+## Live runs
+
+Two runs against the real install, driven end to end by the agent:
+
+**Universe building** — a narrow single-state thesis on the keyless Tavily
+tier. The full example thesis had recorded that state as returning **zero**
+candidates. Search alone surfaced roughly 30, and the adjacency sweep found a
+qualifying company trading under a structural-steel name that no fence keyword
+reaches. The empty segment was a coverage artifact, exactly as the thesis
+predicted — and the run reported the declared registry it could *not* reach as
+an open gap rather than quietly falling back to search.
+
+**Screening** — the agent located the plugin, validated the thesis, ran the
+script, and reported the brief by quoting it rather than retyping numbers. It
+volunteered the coverage reading unprompted: *"Illinois is 67% single-source …
+that's the thesis working as designed."*
+
+## Reproducing
+
+```bash
+cd scripts && node --test test/*.test.mjs   # 61 tests incl. this eval
+node scripts/winnow.mjs screen theses/example-fencing.yaml \
+  theses/example-fencing.eval.judgments.json --out /tmp/eval
+```
+
+Deterministic: same judgments in, byte-identical brief, CSV and JSON out.

--- a/finance/winnow/README.md
+++ b/finance/winnow/README.md
@@ -1,0 +1,169 @@
+# Winnow Screen (pun intended)
+
+Creates an industry-agnostic search agent leveraging Tavily to identify and screen candidates (M&A, procurement, etc) based on user-tunable criteria. Turn a written thesis into a ranked, cited shortlist — **source → filter → rank → explain**. Built on [Agent Plugins 1.0.0](https://agent-plugins.org).
+
+**Runs on Tavily with no API key by default.** Add a Tavily API key to unlock higher rate limits and site crawling and enumeration tools.
+
+## What it does
+
+You write a thesis: what disqualifies a candidate, what makes one better than
+another, what you want investigated either way. Winnow sources candidates,
+applies it, and returns three bands — never a flat yes/no list:
+
+- **PASS** — Clears every hard filter. Ranked by score.
+- **NEAR MISS** — Failed *only* filters you marked `revisitable`, or has a
+  filter the evidence could not settle. Researched and ranked separately, each
+  naming what would settle it.
+- **FAIL** — Failed a firm filter. Dropped before research, listed with the
+  reason so you can audit the filter.
+
+The near-miss band helps with criteria tuning: it is where a firm-but-negotiable rule shows you what it costs, instead of silently discarding candidates.
+
+It also reports **what it could not see** — which sources fed each segment, and
+which segments returned nothing. See [Coverage](#coverage) below.
+
+## Who it's for
+
+Anyone turning a large, messy candidate space into a defensible shortlist:
+corporate development, procurement and vendor qualification, partnership
+sourcing, grant and RFP triage, market landscaping.
+
+You need a screen you can write down. If your criteria live only in your head
+and shift per candidate, no tool helps.
+
+## Run it
+
+```bash
+ncl groups create --template winnow --name "Winnow"
+```
+
+No credentials required. Then, in the agent's channel:
+
+```
+Run the shipped quickstart thesis from scratch and show me the brief.
+```
+
+`theses/quickstart-arizona.yaml` is one state, five metro segments, small
+caps — about eleven minutes in fast mode, fifteen to twenty in standard.
+`theses/example-fencing.yaml` is the full worked example (nine segments, eight
+criteria, from a real 48-target screen) and takes an hour or more. Output
+lands in `runs/<timestamp>/`: `brief.md`, `screen.csv`, `screen.json`, and
+one evidence file per candidate.
+
+## Credentials
+
+| Tier | Setup | Tools |
+|---|---|---|
+| **Keyless** (default) | none | `tavily_search`, `tavily_extract` |
+| **Keyed** | key in a user-owned server | adds `tavily_map`, `tavily_crawl`, `tavily_research` |
+
+The template's own `tavily` server never carries a key — that is what stops a
+template acquiring a secret. To add one, add a second server:
+
+```bash
+ncl groups config add-mcp-server --id <group-id> --name tavily-keyed \
+  --command npx --args '["-y","tavily-mcp@latest"]' \
+  --env '{"TAVILY_API_KEY":"<your-key>"}'
+ncl groups restart --id <group-id>
+```
+
+## What it deliberately doesn't do
+
+Winnow researches **companies from public sources** and stops.
+
+- **No outreach.** It never contacts a target, drafts outreach, or looks up
+  personal contact details. Approaching a company is your decision and action.
+- **No gated or paid sources.** Public web only; no paywall or login bypass.
+- **No individuals as subjects.** Named people appear only in their public
+  business role where it bears on ownership or succession.
+- **No numbers it cannot source.** No revenue, headcount or ownership estimate
+  without saying what it rests on.
+
+## Layout
+
+```
+winnow/
+├── plugin.json            manifest
+├── mcp.json               Tavily, the only declared tool
+├── EVAL.md                validation against a real screen
+├── ai.nanoco.nanoclaw/    the agent's persona
+├── skills/
+│   ├── define-thesis/     interviews you, writes the thesis
+│   ├── build-universe/    thesis → candidate list
+│   ├── research-target/   cited evidence on one company
+│   ├── screen-target/     filters, bands, scores, ranks
+│   │   └── references/    thesis schema, evidence policy, scoring, judgments format
+│   └── produce-brief/     ranked table, briefs, CSV/JSON
+├── scripts/               the deterministic core (node, zero deps, 61 tests)
+│   └── winnow.mjs         init-run · validate · screen · status
+└── theses/
+    ├── quickstart-arizona.yaml   small, fast, no API key
+    └── example-fencing.yaml      the full worked example
+```
+
+## Configuration is a thesis file
+
+The plugin contains no industry knowledge; a thesis YAML holds all of it.
+`define-thesis` interviews you and sorts each criterion into one of three:
+
+| Question | Goes in |
+|---|---|
+| Does failing this take the candidate out? | `hard_filters` |
+| Does this make one acceptable candidate better? | `scored_preferences` |
+| Do I want this determined and reported either way? | `research_questions` |
+
+Full schema: `skills/screen-target/references/thesis-schema.md`.
+
+### The dials you'll change
+
+```yaml
+research_settings:
+  execution: { mode: fast }        # fast: subagents, minutes, more tokens
+                                   # standard: one agent, slower, cheaper
+  target_limits:
+    initial_universe: 12           # candidates carried forward
+    deep_research_limit: 5         # of those, how many get researched
+```
+
+The limits bound runtime and spend, nothing else. **A cap is not a filter**: a
+candidate dropped by a cap was never judged, so a cap that bites is reported
+above the results as a coverage event. For a shorter shortlist raise the bar
+(`hard_filters`, `minimum_score_for_priority`) — those leave a reason behind.
+
+## Coverage
+
+Results reflect which sources are indexed, not the shape of the market. In
+the screen behind the worked example, 27 of 48 targets came from one union
+roster while a declared segment returned nothing and said so nowhere. So the
+brief opens with candidates per segment, the top source, and flags for
+**single-source dominance** and **empty segments** — the universe-level form
+of *never infer from absence*. The fix for a gap is enumeration, not search:
+declare a licensing database or roster under `source_preferences.registries`
+and the keyed tier crawls it.
+
+## Is it right?
+
+[`EVAL.md`](EVAL.md) replays a real 48-target screen where the correct calls
+were known, including one the original screen got wrong: a company recorded
+as nonunion that was in fact signatory. Screened with that evidence absent, it
+loses 10 points and nothing else — it does not fail, score zero, or leave the
+shortlist. Every band, score, rank and coverage figure comes from the tested
+script, never the model: `cd scripts && node --test test/*.test.mjs` (61 tests).
+
+## When things go wrong
+
+| Failure | What you see | What to do |
+|---|---|---|
+| Thesis malformed | `validate` names the field and line | Fix it; it is not active until it passes |
+| Judgment malformed, over a length cap, or outside the depth profile | `screen` exits non-zero and lists every company and field | Fix the judgment; never hand-compute around it |
+| Filter unresolvable | Company lands in **NEAR MISS** | Decide the open question, or accept the band |
+| No evidence for a criterion | Scored per `missing_data_policy`, flagged | Nothing — the flag is the point |
+| Declared segment returns nothing | `⚠ no coverage` | Add a registry, or accept the gap knowingly |
+| One source dominates | `⚠ single source N%` | Treat the spread as unproven |
+| Tavily rate cap or 401 | Retry-after / auth error | Wait or add a key / check the key |
+
+The rule behind all of these: **the agent never silently guesses.**
+
+## Licence
+
+MIT.

--- a/finance/winnow/ai.nanoco.nanoclaw/context/instructions.md
+++ b/finance/winnow/ai.nanoco.nanoclaw/context/instructions.md
@@ -1,0 +1,136 @@
+# Winnow
+
+You are a screening analyst. You take a large, messy set of candidates,
+apply a written thesis, and return a ranked shortlist where every placement
+is traceable to evidence.
+
+Your pipeline is always: **source → filter → rank → explain.**
+
+## The thesis is the configuration
+
+You hold no opinions about any industry. Everything specific to a search —
+what counts, what disqualifies, what to investigate — comes from a thesis
+file. The active thesis lives at `${PLUGIN_DATA}/theses/<name>.yaml`.
+Read-only examples ship at `${PLUGIN_ROOT}/theses/`.
+
+If no thesis is active, run the `define-thesis` skill. Never screen against
+an implied thesis you inferred from conversation, and never edit a thesis
+mid-run — if the user changes their mind about a criterion, say so, amend
+the thesis, and re-run.
+
+## Three kinds of criteria
+
+Keep these distinct at all times:
+
+- **Hard filter** — failing it takes the company out of the funnel.
+- **Scored preference** — makes one acceptable company better than another.
+- **Research question** — must be determined and reported, but does not
+  decide anything by itself.
+
+When a user states a criterion, ask which one it is before recording it.
+Most screening failures come from a preference being treated as absolute,
+or a genuine disqualifier being outvoted by a good score elsewhere.
+
+## Three bands, always reported
+
+- **PASS** — cleared every hard filter. Ranked by score.
+- **NEAR MISS** — failed *only* filters marked `revisitable`, or has a hard
+  filter that evidence could not resolve. Researched and scored, ranked in
+  its own band, each entry naming the filter and what would settle it.
+- **FAIL** — failed a firm filter. Dropped before research, listed with the
+  reason.
+
+Report all three every time. The near-miss band is the point: it is where a
+firm-but-negotiable criterion shows the user what it costs.
+
+## Evidence discipline
+
+This matters more than anything else you do. A ranked list nobody can audit
+is worse than no list.
+
+- **Cite everything.** Every claim that affects a band or a score carries a
+  source URL. No citation, no claim.
+- **Never infer from absence.** Not finding evidence of X means "unknown",
+  never "not X". This is the single most common way a screen goes wrong.
+- **The same rule applies to the whole funnel.** Finding no candidates in a
+  segment is not evidence the segment is empty — it usually means nothing
+  there is indexed the way you searched. Report coverage beside results,
+  flag single-source dominance and empty segments, and never present a
+  concentrated funnel as a market finding.
+- **Separate fact from inference.** Say "the site lists four Illinois offices"
+  (fact) or "likely 40–60 employees, inferred from crew photos and fleet
+  size" (inference). Never blur them.
+- **Confidence is per-claim, not per-company.** State it where it varies.
+- **Missing data is a finding.** Report it. Do not quietly score around it.
+
+Follow `evidence-policy.md` in the `screen-target` skill for the full rules.
+
+## Cost discipline
+
+Research is the expensive step. Filter before you research:
+
+1. Build the universe (cheap, broad).
+2. Apply hard filters on what you already know — drop FAIL candidates now.
+3. Research only PASS and NEAR MISS candidates.
+4. Score, rank, brief.
+
+Respect `research_settings.target_limits`. If the universe exceeds the limit,
+say so and ask whether to widen the budget or tighten the thesis — do not
+silently truncate.
+
+## Execution mode
+
+`research_settings.execution.mode` decides who does the work, not what is
+done:
+
+- **`standard`** — you run every stage yourself, in sequence.
+- **`fast`** — you delegate: the search sweep to one subagent, and each
+  candidate's research to its own subagent, at most four at a time. You
+  never read a raw search result yourself; a sweep's results are 100–300KB
+  and in your own context they cost a compaction before research starts.
+  Each skill says exactly what to hand a subagent and what to expect back.
+
+Either way the judgments, the files and the script are the same. A brief
+does not say which mode produced it and should not need to.
+
+## What you do not do
+
+- **No outreach.** You never contact a target, draft outreach to one, or
+  look up personal contact details for individuals at one. You produce
+  research on companies; approaching them is the user's decision and the
+  user's action.
+- **No gated or paid sources.** Public web only. Do not attempt to bypass
+  paywalls, logins, or scraping controls.
+- **No individuals as subjects.** You research companies. Named people
+  appear only in their public business role (owner, founder, president)
+  where it bears on ownership or succession — never their personal lives,
+  home addresses, or finances.
+- **No numbers you cannot source.** Never estimate revenue, headcount, or
+  ownership stake without saying what the estimate rests on.
+
+## Working style
+
+Terse. Lead with the answer. When you report a screen, the shape is: the
+counts first ("14 passed, 6 near miss, 20 failed"), then the ranked table,
+then the briefs. Never bury the counts under preamble.
+
+Everything you want the user to read must sit inside a delivery block
+addressed to a destination. A bare report outside one is discarded silently —
+the run succeeds and the user sees nothing.
+
+A screen takes minutes. Acknowledge in one line **before** you start work —
+not after validating, not after the first search — so the user knows it is
+running rather than wondering whether it broke. Say what you are about to do
+and roughly how long it will take. Then go quiet and work; report when there
+is a result. Do not narrate each stage: every interim message is a round trip
+that makes the run longer.
+
+When a run is large, show progress as you go rather than going silent.
+
+## Skills
+
+- `define-thesis` — interview the user and write a thesis file.
+- `build-universe` — turn a thesis into a candidate list.
+- `research-target` — gather cited evidence on one company.
+- `screen-target` — apply filters, assign bands, score, rank.
+- `produce-brief` — the ranked table, per-target briefs, CSV/JSON export.

--- a/finance/winnow/mcp.json
+++ b/finance/winnow/mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "tavily": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "tavily-mcp@latest"]
+    }
+  }
+}

--- a/finance/winnow/plugin.json
+++ b/finance/winnow/plugin.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "winnow",
+  "version": "1.0.0",
+  "description": "Screening agent: turns a written thesis into a ranked, cited shortlist of companies — reporting the near-misses that failed one negotiable rule, and the segments the search never reached. Runs with no API key.",
+  "author": {
+    "url": "https://github.com/BuckG71"
+  },
+  "keywords": [
+    "screening",
+    "research",
+    "due-diligence",
+    "sourcing",
+    "m-and-a",
+    "tavily"
+  ],
+  "license": "MIT",
+  "extensions": {
+    "ai.nanoco.nanoclaw": {
+      "agentName": "Winnow"
+    }
+  }
+}

--- a/finance/winnow/scripts/lib/render.mjs
+++ b/finance/winnow/scripts/lib/render.mjs
@@ -1,0 +1,166 @@
+// Render a screen result as Markdown (the brief), CSV, and JSON.
+// Pure formatting -- every number here was computed in screen.mjs.
+
+const pad = (s, n) => String(s).padEnd(n);
+const num = (s, n) => String(s).padStart(n);
+
+export function markdown(result) {
+  const { counts, bands, coverage, settings: cfg } = result;
+  const L = [];
+  L.push(`**${counts.PASS} pass · ${counts['NEAR MISS']} near miss · ${counts.FAIL} fail**  —  ${result.thesis}`);
+  L.push('');
+
+  if (result.universe?.truncated > 0) {
+    const u = result.universe;
+    L.push(`> ⚠ **Universe truncated.** ${u.found} candidates were found; ${u.carried_forward} were carried forward` +
+      (u.cap != null ? ` at the \`initial_universe\` cap of ${u.cap}` : '') +
+      `. The ${u.truncated} dropped are whatever the search ordered last, not a random sample — raise the cap to screen them.` +
+      (u.note ? ` ${u.note}` : ''));
+    L.push('');
+  }
+
+  if (cfg.output.coverage && Object.keys(coverage).length) {
+    for (const [dim, cov] of Object.entries(coverage)) {
+      L.push(`## Coverage · ${cov.table.length} declared ${dim} segments`);
+      L.push('');
+      L.push('| Segment | Candidates | Sources | Top contributor | Flag |');
+      L.push('|---|---|---|---|---|');
+      for (const r of cov.table) {
+        const top = r.top ? `${r.top.source} (${r.top.count})` : r.candidates === 0 ? 'no source answered' : '';
+        L.push(`| ${r.segment} | ${r.candidates} | ${r.sources} | ${top} | ${r.flags.map((f) => `⚠ ${f}`).join(', ')} |`);
+      }
+      const flagged = cov.table.filter((r) => r.flags.length);
+      if (flagged.length) {
+        L.push('');
+        L.push(`> ${flagged.length} of ${cov.table.length} segments flagged. A single-source segment maps that source's reach, not the market; an empty declared segment is a gap in the search, not evidence of an empty market. Treat the ${dim} spread of this funnel as unproven.`);
+      }
+      if (cov.undeclared.length) L.push(`> Candidates found outside declared segments: ${cov.undeclared.join(', ')}.`);
+      L.push('');
+    }
+  }
+
+  L.push(`## PASS · ${counts.PASS} ranked`);
+  L.push('');
+  if (bands.PASS.length) {
+    L.push('| # | Company | Score | Conf | Location | Why |');
+    L.push('|---|---|---|---|---|---|');
+    bands.PASS.forEach((c, i) => {
+      const why = topWhy(c);
+      L.push(`| ${i + 1} | ${c.priority ? '★ ' : ''}${link(c)} | ${c.scoring.total}${c.scoring.excluded ? ' ✗' : ''} | ${conf(c.scoring)} | ${c.location} | ${why} |`);
+    });
+    const legend = [];
+    if (cfg.priorityMin !== null) legend.push(`★ priority: score ≥ ${cfg.priorityMin}.`);
+    if (bands.PASS.some((c) => c.scoring.lowestConfidence !== c.scoring.confidence)) {
+      legend.push('▾ confidence is weighted by criterion weight; at least one criterion is weaker than the headline — see that company\'s breakdown.');
+    }
+    if (bands.PASS.some((c) => c.scoring.excluded)) legend.push('✗ excluded under missing-data policy.');
+    if (legend.length) L.push('\n' + legend.join(' '));
+  } else L.push('_None._');
+  L.push('');
+
+  if (cfg.output.nearMiss) {
+    L.push(`## NEAR MISS · ${counts['NEAR MISS']}`);
+    L.push('');
+    if (bands['NEAR MISS'].length) {
+      L.push('| Company | Score | Filter | Status | What would settle it |');
+      L.push('|---|---|---|---|---|');
+      for (const c of bands['NEAR MISS']) for (const r of c.reasons) {
+        L.push(`| ${link(c)} | ${c.scoring.total} | ${r.filter} | ${r.outcome}${r.revisitable ? ' (revisitable)' : ''} | ${r.settle || r.evidence} |`);
+      }
+    } else L.push('_None._');
+    L.push('');
+  }
+
+  if (cfg.output.failures) {
+    L.push(`## FAIL · ${counts.FAIL}`);
+    L.push('');
+    if (bands.FAIL.length) {
+      L.push('| Company | Filter | Evidence |');
+      L.push('|---|---|---|');
+      for (const c of bands.FAIL) {
+        const firm = c.reasons.filter((r) => r.outcome === 'fail' && !r.revisitable);
+        const shown = firm.length ? firm : c.reasons;
+        L.push(`| ${link(c)} | ${shown.map((r) => r.filter).join('; ')} | ${shown.map((r) => r.evidence).filter(Boolean).join('; ')} |`);
+      }
+    } else L.push('_None._');
+    L.push('');
+  }
+
+  if (cfg.output.briefs) {
+    L.push('---');
+    for (const c of [...bands.PASS, ...bands['NEAR MISS']]) L.push(...brief(c, cfg));
+  }
+  return L.join('\n');
+}
+
+function link(c) { return c.url ? `[${c.name}](${c.url})` : c.name; }
+/**
+ * Weighted confidence, with a compact marker when some single criterion is
+ * materially weaker than the headline. The marker is explained under the
+ * table; the exact weak criterion is named in that company's breakdown.
+ */
+function conf(s) {
+  return s.lowestConfidence && s.lowestConfidence !== s.confidence ? `${s.confidence} ▾` : s.confidence;
+}
+function topWhy(c) {
+  const best = [...c.scoring.rows].filter((r) => !r.policy).sort((a, b) => b.contribution - a.contribution)[0];
+  return best?.why || (best ? `${best.criterion} ${best.score}` : '');
+}
+
+function brief(c, cfg) {
+  const L = [];
+  L.push('', `## ${c.name}  ·  ${c.scoring.total}/100  ·  ${c.band}${c.priority ? '  ·  ★ priority' : ''}`);
+  if (cfg.output.confidence) {
+    L.push(`Confidence: **${c.scoring.confidence}** (weighted)` +
+      (c.scoring.lowestConfidence !== c.scoring.confidence ? ` · weakest input: ${c.scoring.lowestConfidence}` : ''));
+  }
+  L.push([c.url, c.location].filter(Boolean).join(' · '));
+  if (c.reasons.length) {
+    L.push('', '**Band reasons**');
+    for (const r of c.reasons) L.push(`- ${r.filter}: ${r.outcome}${r.revisitable ? ' (revisitable)' : ''}${r.settle ? ` — would settle it: ${r.settle}` : ''}${r.url ? ` — ${r.url}` : ''}`);
+  }
+  if (cfg.output.breakdown) {
+    L.push('', '**Score breakdown**');
+    for (const r of c.scoring.rows) {
+      const pol = r.policy ? ` _(no evidence; ${r.policy} policy)_` : '';
+      L.push(`- ${r.criterion}: **${r.score}** (weight ${r.weight})${cfg.output.confidence ? ` [${r.confidence}]` : ''}${r.why ? ` — ${r.why}` : ''}${pol}${cfg.output.citations && r.url ? ` — ${r.url}` : ''}`);
+    }
+  }
+  if (c.findings.length) {
+    L.push('', '**Findings**');
+    for (const f of c.findings) {
+      L.push(`- ${f.question}: ${f.answer ?? '_unanswered_'}${cfg.output.confidence && f.confidence ? ` [${f.confidence}]` : ''}`);
+      for (const x of f.facts ?? []) L.push(`    - fact: ${x.claim}${cfg.output.citations && x.url ? ` — ${x.url}` : ''}`);
+      for (const x of f.inferences ?? []) L.push(`    - inference: ${x.claim}${x.basis ? ` — from ${x.basis}` : ''}`);
+    }
+  }
+  L.push('', '**Open questions**');
+  if (c.open_questions.length) for (const q of c.open_questions) L.push(`- ${q.question}${q.what_would_settle_it ? ` — ${q.what_would_settle_it}` : ''}`);
+  else L.push('- _none recorded_');
+  return L;
+}
+
+const csvCell = (v) => {
+  const s = v === null || v === undefined ? '' : String(v);
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+};
+
+export function csv(result) {
+  const crit = result.criteria.map((c) => c.name);
+  const header = ['rank', 'band', 'priority', 'company', 'url', 'location', 'score', 'confidence', ...crit, 'band_reasons', 'thesis', 'run_at'];
+  const rows = [header];
+  for (const band of ['PASS', 'NEAR MISS', 'FAIL']) result.bands[band].forEach((c, i) => {
+    rows.push([
+      i + 1, band, c.priority ? 'yes' : '', c.name, c.url, c.location,
+      c.scoring ? c.scoring.total : '', c.scoring ? c.scoring.confidence : '',
+      ...crit.map((n) => c.scoring ? c.scoring.rows.find((r) => r.criterion === n)?.score ?? '' : ''),
+      c.reasons.map((r) => `${r.filter}=${r.outcome}`).join('; '), result.thesis, result.run_at,
+    ]);
+  });
+  return rows.map((r) => r.map(csvCell).join(',')).join('\n') + '\n';
+}
+
+export function json(result) {
+  const { filters, criteria, settings, ...rest } = result;
+  return JSON.stringify({ ...rest, criteria: criteria.map(({ name, weight }) => ({ name, weight })) }, null, 2) + '\n';
+}

--- a/finance/winnow/scripts/lib/run.mjs
+++ b/finance/winnow/scripts/lib/run.mjs
@@ -1,0 +1,197 @@
+// Run lifecycle. The script owns it, so nothing about a run is invented by
+// the agent: not the directory, not the timestamp, not whether the evidence
+// on disk actually matches the universe it came from.
+//
+// _run.json records the thesis and its fingerprint at init. If the thesis
+// changes mid-run, the evidence was gathered against a different screen and
+// the run is refused rather than silently mixed.
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+export class RunError extends Error {}
+
+export const fingerprint = (file) =>
+  createHash('sha256').update(readFileSync(file)).digest('hex').slice(0, 16);
+
+/**
+ * A thesis under PLUGIN_DATA can shadow a shipped one of the same name. That
+ * copy is not updated when the template is, so a run can silently use an old
+ * screen. Detect it and report; never guess which the user meant.
+ */
+export function shadowWarning(thesisFile, pluginRoot) {
+  if (!pluginRoot) return null;
+  const shipped = path.join(pluginRoot, 'theses', path.basename(thesisFile));
+  if (path.resolve(shipped) === path.resolve(thesisFile)) return null;
+  if (!existsSync(shipped)) return null;
+  if (fingerprint(shipped) === fingerprint(thesisFile)) return null;
+  return `this thesis shadows a shipped one that differs: ${shipped}\n` +
+         `  The copy under plugin-data is not updated when the template is. Re-copy it to\n` +
+         `  pick up template changes, or run the shipped thesis directly if you have not edited it.`;
+}
+
+/** Create a run directory and return its absolute path. */
+export function initRun(thesisFile, rootDir) {
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const dir = path.resolve(rootDir, 'runs', stamp);
+  const candidates = path.join(dir, 'candidates');
+  mkdirSync(candidates, { recursive: true });
+  const meta = {
+    thesis: path.resolve(thesisFile),
+    thesis_sha: fingerprint(thesisFile),
+    started_at: new Date().toISOString(),
+    universe: null,
+  };
+  writeFileSync(path.join(candidates, '_run.json'), JSON.stringify(meta, null, 2) + '\n');
+  return { dir, candidates, meta };
+}
+
+/** Record what universe-building found, so completeness becomes checkable. */
+export function setUniverse(candidatesDir, { found, carried, cap, note }) {
+  const f = path.join(candidatesDir, '_run.json');
+  if (!existsSync(f)) throw new RunError(`no _run.json in ${candidatesDir} — run "init-run" first`);
+  const meta = JSON.parse(readFileSync(f, 'utf8'));
+  if (!Number.isInteger(carried) || carried < 0) throw new RunError('--carried must be a non-negative integer');
+  meta.universe = {
+    found: Number.isInteger(found) ? found : null,
+    carried_forward: carried,
+    ...(Number.isInteger(cap) ? { cap } : {}),
+    ...(note ? { note } : {}),
+  };
+  writeFileSync(f, JSON.stringify(meta, null, 2) + '\n');
+  return meta.universe;
+}
+
+export const slug = (name) => name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'candidate';
+
+const domainOf = (url) => {
+  try { return new URL(/^https?:/.test(url) ? url : `https://${url}`).hostname.replace(/^www\./, '').toLowerCase(); }
+  catch { return null; }
+};
+
+/**
+ * Build the universe from a sweep file, deterministically. The sweep (a
+ * subagent, or the agent itself) writes universe.json; everything that
+ * follows is arithmetic and so belongs here, not in a model's context:
+ * dedup, segment validation, firm-filter drops it already called, the
+ * initial_universe cap taken round-robin across declared segments so every
+ * segment is represented, and the deep_research_limit. Stubs are written
+ * for candidates that will not be researched, so coverage counts them and
+ * the brief says why they carry no evidence. Returns the rows to research.
+ *
+ * universe.json:
+ *   { "tier": "keyless", "queries": [...],
+ *     "candidates": [ { "name", "url", "location", "segment", "source",
+ *                       "note", "fail": { "filter", "evidence" } } ] }
+ */
+export function applyUniverse(candidatesDir, universeFile, thesis, { filters, declaredSegments, limits }) {
+  const f = path.join(candidatesDir, '_run.json');
+  if (!existsSync(f)) throw new RunError(`no _run.json in ${candidatesDir} — run "init-run" first`);
+  let u;
+  try { u = JSON.parse(readFileSync(universeFile, 'utf8')); } catch (e) { throw new RunError(`${universeFile}: ${e.message}`); }
+  if (!Array.isArray(u.candidates)) throw new RunError(`${universeFile}: "candidates" must be a list`);
+  const [dim, segments] = Object.entries(declaredSegments)[0] ?? [null, []];
+  const firm = new Map(filters.filter((x) => !x.revisitable).map((x) => [x.name, x]));
+  const problems = [];
+
+  // Dedup on domain, then on normalised name. First occurrence wins.
+  const seen = new Set(); const rows = [];
+  u.candidates.forEach((c, i) => {
+    if (!c || typeof c.name !== 'string' || !c.name.trim()) { problems.push(`candidates[${i}]: name is required`); return; }
+    const seg = Array.isArray(c.segment) ? c.segment[0] : c.segment;
+    if (dim && !segments.includes(seg)) { problems.push(`"${c.name}": segment "${seg}" is not one of ${dim}.include`); return; }
+    if (c.fail && !firm.has(c.fail.filter)) { problems.push(`"${c.name}": fail.filter "${c.fail?.filter}" is not a firm filter (revisitable ones are researched, not dropped)`); return; }
+    const key = domainOf(c.url ?? '') ?? `name:${slug(c.name)}`;
+    const nameKey = `name:${slug(c.name)}`;
+    if (seen.has(key) || seen.has(nameKey)) return;
+    seen.add(key); seen.add(nameKey);
+    rows.push({ name: c.name.trim(), url: c.url ?? '', location: c.location ?? '', segment: seg, source: c.source ?? 'web search', note: c.note ?? '', fail: c.fail ?? null });
+  });
+  if (problems.length) throw new RunError(`universe.json has ${problems.length} problem(s):\n  - ${problems.join('\n  - ')}`);
+
+  const fails = rows.filter((r) => r.fail);
+  const pool = rows.filter((r) => !r.fail);
+  // Round-robin across declared segments, input order within a segment.
+  const bySeg = new Map((segments.length ? segments : [undefined]).map((s) => [s, pool.filter((r) => r.segment === s)]));
+  const ordered = [];
+  while (ordered.length < pool.length) for (const q of bySeg.values()) { const r = q.shift(); if (r) ordered.push(r); }
+  const carried = ordered.slice(0, limits.initialUniverse ?? ordered.length);
+  const research = carried.slice(0, limits.deepResearchLimit ?? carried.length);
+  const shallow = carried.slice(research.length);
+  const uncarried = ordered.slice(carried.length);
+
+  const base = (r) => ({ name: r.name, url: r.url, location: r.location, segments: dim ? { [dim]: r.segment } : {}, sources: [r.source] });
+  const unresolved = (why) => Object.fromEntries(filters.map((x) => [x.name, { outcome: 'unresolved', what_would_settle_it: why }]));
+  for (const r of fails) {
+    const filtersOut = unresolved('not researched: dropped at the universe stage by a firm filter');
+    filtersOut[r.fail.filter] = { outcome: 'fail', evidence: r.fail.evidence ?? '', url: r.url };
+    writeFileSync(path.join(candidatesDir, `${slug(r.name)}.json`), JSON.stringify({ ...base(r), filters: filtersOut, note: 'dropped by a firm filter at the universe stage' }, null, 2) + '\n');
+  }
+  for (const r of shallow) {
+    writeFileSync(path.join(candidatesDir, `${slug(r.name)}.json`), JSON.stringify({ ...base(r), filters: unresolved('not researched: past deep_research_limit; raise it to research this candidate'), scores: {}, note: 'carried forward but not researched (deep_research_limit)' }, null, 2) + '\n');
+  }
+
+  const meta = JSON.parse(readFileSync(f, 'utf8'));
+  // carried_forward is the cap's count; files_expected adds the firm-filter
+  // drops, which have files (they count toward coverage) but were not carried.
+  meta.universe = {
+    found: rows.length,
+    carried_forward: carried.length,
+    files_expected: carried.length + fails.length,
+    ...(limits.initialUniverse != null ? { cap: limits.initialUniverse } : {}),
+    note: `${research.length} researched, ${shallow.length} carried without research (deep_research_limit ${limits.deepResearchLimit ?? '∞'}), ${fails.length} dropped by firm filters, ${uncarried.length} past the initial_universe cap` +
+      (uncarried.length ? `: ${uncarried.map((r) => r.name).join(', ')}` : '') +
+      (u.tier ? `. Tavily tier: ${u.tier}` : '') + (Array.isArray(u.queries) ? `. ${u.queries.length} queries` : ''),
+  };
+  writeFileSync(f, JSON.stringify(meta, null, 2) + '\n');
+  return { found: rows.length, fails, carried, research: research.map((r) => ({ ...r, file: path.join(candidatesDir, `${slug(r.name)}.json`) })), shallow, uncarried, universe: meta.universe };
+}
+
+const candidateFiles = (dir) =>
+  readdirSync(dir).filter((f) => f.endsWith('.json') && f !== '_run.json').sort();
+
+/** What is on disk vs what the universe stage said should be. */
+export function runStatus(candidatesDir) {
+  const f = path.join(candidatesDir, '_run.json');
+  const meta = existsSync(f) ? JSON.parse(readFileSync(f, 'utf8')) : {};
+  const files = candidateFiles(candidatesDir);
+  const expected = meta.universe?.files_expected ?? meta.universe?.carried_forward ?? null;
+  const ageHours = meta.started_at ? (Date.now() - Date.parse(meta.started_at)) / 3.6e6 : null;
+  return { meta, files, written: files.length, expected, ageHours };
+}
+
+/**
+ * Gate a run before it is screened. Returns warnings; throws on anything that
+ * would make the brief wrong rather than merely stale.
+ */
+export function checkRun(candidatesDir, thesisFile, { staleHours = 24, force = false } = {}) {
+  const { meta, written, expected, ageHours } = runStatus(candidatesDir);
+  const warnings = [];
+
+  if (meta.thesis_sha) {
+    const now = fingerprint(thesisFile);
+    if (now !== meta.thesis_sha && !force) {
+      throw new RunError(
+        `the thesis changed after this run started (was ${meta.thesis_sha}, now ${now}).\n` +
+        `  The evidence on disk was gathered against a different screen. Start a new run,\n` +
+        `  or pass --force if you are certain the change does not affect the judgments.`);
+    }
+    if (now !== meta.thesis_sha) warnings.push('thesis changed after the run started; forced');
+  }
+
+  if (expected !== null && written < expected && !force) {
+    throw new RunError(
+      `incomplete run: universe carried ${expected} candidates forward but only ${written} ` +
+      `judgment file(s) are written.\n` +
+      `  Research the remaining ${expected - written}, or re-record the universe with ` +
+      `"set-universe --carried ${written}" if the run was deliberately cut short.`);
+  }
+  if (expected !== null && written < expected) warnings.push(`incomplete: ${written}/${expected} candidates; forced`);
+  if (expected !== null && written > expected) warnings.push(`${written} judgment files but universe recorded ${expected} carried forward`);
+
+  if (ageHours !== null && ageHours > staleHours) {
+    warnings.push(`evidence is ${Math.round(ageHours)}h old (gathered ${meta.started_at}) — re-run to refresh`);
+  }
+  if (written === 0) throw new RunError(`no candidate files in ${candidatesDir}`);
+  return warnings;
+}

--- a/finance/winnow/scripts/lib/screen.mjs
+++ b/finance/winnow/scripts/lib/screen.mjs
@@ -1,0 +1,207 @@
+// The deterministic core: bands, scoring, ranking, coverage.
+// Input is a judgments document produced by the model (see
+// skills/screen-target/references/judgments-format.md). Nothing here
+// exercises judgment; it only combines judgments the model already made.
+import { filterList, criteriaList, settings } from './thesis.mjs';
+
+export const BANDS = ['PASS', 'NEAR MISS', 'FAIL'];
+const CONF_RANK = { high: 3, medium: 2, low: 1 };
+const OUTCOMES = new Set(['pass', 'fail', 'unresolved']);
+
+export class JudgmentsError extends Error {}
+
+/**
+ * Length caps on the prose fields, in characters. These bound the model's
+ * output: a `why` is one clause and an `evidence` is one line, and measured
+ * model output that ran past these was restating the same sentence in three
+ * places. A file over a cap is refused, never trimmed -- the model shortens
+ * the field and re-runs, so nothing is ever cut mid-sentence by the script.
+ */
+export const CAPS = {
+  'filters.*.evidence': 240,
+  'filters.*.what_would_settle_it': 240,
+  'scores.*.why': 160,
+  'findings[].answer': 300,
+  'findings[].facts[].claim': 240,
+  'findings[].inferences[].claim': 240,
+  'findings[].inferences[].basis': 240,
+  'open_questions[].question': 240,
+  'open_questions[].what_would_settle_it': 240,
+};
+
+/**
+ * Every cap or profile violation in one candidate, as strings. All of them
+ * are reported together so one edit round fixes the file.
+ *
+ * Profile: at research depth `fast`, findings are written only for the
+ * thesis's custom questions. The standard questions are still researched --
+ * they inform the filter and score judgments -- but are not written up
+ * individually, which is most of a candidate file's bulk.
+ */
+export function checkShape(c, { depth = 'standard', standardQuestions = [] } = {}) {
+  const out = [];
+  const cap = (key, value, where) => {
+    if (typeof value === 'string' && value.length > CAPS[key]) out.push(`${where}: ${value.length} chars, cap ${CAPS[key]}`);
+  };
+  for (const [name, f] of Object.entries(c.filters ?? {})) {
+    cap('filters.*.evidence', f?.evidence, `filters."${name}".evidence`);
+    cap('filters.*.what_would_settle_it', f?.what_would_settle_it, `filters."${name}".what_would_settle_it`);
+  }
+  for (const [name, s] of Object.entries(c.scores ?? {})) cap('scores.*.why', s?.why, `scores."${name}".why`);
+  const std = new Set(standardQuestions);
+  const stdWritten = (c.findings ?? []).map((f) => f?.question).filter((q) => std.has(q));
+  if (depth === 'fast' && stdWritten.length) out.push(`findings: ${stdWritten.length} standard-question write-up(s) (${stdWritten.join(', ')}) — at research depth fast, write findings only for custom questions`);
+  (c.findings ?? []).forEach((f, i) => {
+    cap('findings[].answer', f?.answer, `findings[${i}].answer`);
+    (f?.facts ?? []).forEach((x, j) => cap('findings[].facts[].claim', x?.claim, `findings[${i}].facts[${j}].claim`));
+    (f?.inferences ?? []).forEach((x, j) => {
+      cap('findings[].inferences[].claim', x?.claim, `findings[${i}].inferences[${j}].claim`);
+      cap('findings[].inferences[].basis', x?.basis, `findings[${i}].inferences[${j}].basis`);
+    });
+  });
+  (c.open_questions ?? []).forEach((q, i) => {
+    cap('open_questions[].question', q?.question, `open_questions[${i}].question`);
+    cap('open_questions[].what_would_settle_it', q?.what_would_settle_it, `open_questions[${i}].what_would_settle_it`);
+  });
+  return out;
+}
+
+/**
+ * Band from per-filter outcomes.
+ *   any firm fail                      -> FAIL
+ *   any revisitable fail or unresolved -> NEAR MISS  (unresolved -> FAIL when missingMode === 'exclude')
+ *   otherwise                          -> PASS
+ * Returns { band, reasons: [{filter, outcome, revisitable}] }.
+ */
+export function assignBand(filterOutcomes, filters, missingMode) {
+  const reasons = [];
+  let firmFail = false, soft = false;
+  for (const f of filters) {
+    const o = filterOutcomes[f.name];
+    if (!o) throw new JudgmentsError(`missing outcome for filter "${f.name}"`);
+    if (!OUTCOMES.has(o.outcome)) throw new JudgmentsError(`filter "${f.name}": outcome must be pass, fail or unresolved`);
+    if (o.outcome === 'pass') continue;
+    reasons.push({ filter: f.name, outcome: o.outcome, revisitable: f.revisitable, evidence: o.evidence ?? '', url: o.url ?? '', settle: o.what_would_settle_it ?? '' });
+    if (o.outcome === 'fail' && !f.revisitable) firmFail = true;
+    else if (o.outcome === 'unresolved' && missingMode === 'exclude') firmFail = true;
+    else soft = true;
+  }
+  return { band: firmFail ? 'FAIL' : soft ? 'NEAR MISS' : 'PASS', reasons };
+}
+
+/**
+ * Weighted score. Missing (null) criterion scores follow missingMode:
+ *   neutral  -> 50, flagged, confidence low
+ *   penalize -> 0, flagged
+ *   exclude  -> company marked excluded; still scored (neutral) for display
+ */
+export function scoreCompany(scores, criteria, missingMode) {
+  const rows = [];
+  let total = 0, excluded = false, lowest = 3;
+  for (const c of criteria) {
+    const s = scores[c.name];
+    let value, confidence, policy = null, why = s?.why ?? '', url = s?.url ?? '';
+    if (!s || s.score === null || s.score === undefined) {
+      policy = missingMode;
+      if (missingMode === 'exclude') excluded = true;
+      value = missingMode === 'penalize' ? 0 : 50;
+      confidence = 'low';
+    } else {
+      if (typeof s.score !== 'number' || s.score < 0 || s.score > 100) throw new JudgmentsError(`criterion "${c.name}": score must be 0-100 or null`);
+      value = s.score;
+      confidence = s.confidence ?? 'low';
+      if (!(confidence in CONF_RANK)) throw new JudgmentsError(`criterion "${c.name}": confidence must be high, medium or low`);
+    }
+    lowest = Math.min(lowest, CONF_RANK[confidence]);
+    const contribution = (value * c.normalised) / 100;
+    total += contribution;
+    rows.push({ criterion: c.name, score: value, weight: c.weight, normalised: c.normalised, contribution, confidence, policy, why, url });
+  }
+  // Headline confidence is weighted by the same weights that produced the
+  // score, so a thin minor criterion cannot mask a well-evidenced case. The
+  // lowest is carried alongside it, never replaced by it -- a strong average
+  // hiding one weak input is exactly what a reader needs to see.
+  const weighted = rows.reduce((a, r) => a + CONF_RANK[r.confidence] * r.normalised, 0) / 100;
+  const confidence = weighted >= 2.5 ? 'high' : weighted >= 1.5 ? 'medium' : 'low';
+  const lowestConfidence = Object.keys(CONF_RANK).find((k) => CONF_RANK[k] === lowest) ?? 'low';
+  return { total: Math.round(total), rows, confidence, lowestConfidence, excluded };
+}
+
+/** Sort within a band: score desc, confidence desc, a "scale" criterion desc, then name. */
+export function rank(companies) {
+  const scaleOf = (c) => c.scoring?.rows.find((r) => /scale/i.test(r.criterion))?.score ?? -1;
+  return [...companies].sort((a, b) =>
+    (b.scoring?.total ?? -1) - (a.scoring?.total ?? -1) ||
+    (CONF_RANK[b.scoring?.confidence] ?? 0) - (CONF_RANK[a.scoring?.confidence] ?? 0) ||
+    scaleOf(b) - scaleOf(a) ||
+    a.name.localeCompare(b.name));
+}
+
+/**
+ * Coverage per declared segment: candidate count, per-source counts, flags.
+ * Every candidate counts (FAIL included) -- coverage is about what was found.
+ */
+export function coverage(candidates, declaredSegments, threshold, flagEmpty) {
+  const out = {};
+  for (const [dim, segs] of Object.entries(declaredSegments)) {
+    const table = [];
+    for (const seg of segs) {
+      const inSeg = candidates.filter((c) => (c.segments?.[dim] ?? '') === seg);
+      const bySource = {};
+      for (const c of inSeg) {
+        const srcs = Array.isArray(c.sources) && c.sources.length ? c.sources : ['(unattributed)'];
+        for (const s of srcs) bySource[s] = (bySource[s] ?? 0) + 1;
+      }
+      const sorted = Object.entries(bySource).sort((a, b) => b[1] - a[1]);
+      const top = sorted[0] ?? null;
+      const flags = [];
+      if (inSeg.length === 0) { if (flagEmpty) flags.push('no coverage'); }
+      else if (top && top[1] / inSeg.length > threshold && sorted.length >= 1) flags.push(`single source ${Math.round((top[1] / inSeg.length) * 100)}%`);
+      table.push({ segment: seg, candidates: inSeg.length, sources: sorted.length, top: top ? { source: top[0], count: top[1] } : null, flags });
+    }
+    const undeclared = [...new Set(candidates.map((c) => c.segments?.[dim]).filter((s) => s && !segs.includes(s)))];
+    out[dim] = { table, undeclared };
+  }
+  return out;
+}
+
+/** Run the whole engine over a judgments document. */
+export function screen(thesis, judgments) {
+  if (!judgments || !Array.isArray(judgments.candidates)) throw new JudgmentsError('judgments.candidates must be a list');
+  const filters = filterList(thesis), criteria = criteriaList(thesis), cfg = settings(thesis);
+  const seen = new Set();
+  // Shape first, across every candidate, so the error names all of it at once.
+  const shape = [];
+  judgments.candidates.forEach((c, i) => {
+    if (!c || typeof c.name !== 'string' || !c.name.trim()) throw new JudgmentsError(`candidates[${i}].name is required`);
+    for (const v of checkShape(c, cfg)) shape.push(`"${c.name}": ${v}`);
+  });
+  if (shape.length) throw new JudgmentsError(`${shape.length} field(s) over cap or outside the profile — shorten, never trim by hand:\n  - ${shape.join('\n  - ')}`);
+  const companies = judgments.candidates.map((c) => {
+    if (seen.has(c.name.toLowerCase())) throw new JudgmentsError(`duplicate candidate "${c.name}"`);
+    seen.add(c.name.toLowerCase());
+    const { band, reasons } = assignBand(c.filters ?? {}, filters, cfg.missingMode);
+    const scoring = band === 'FAIL' ? null : scoreCompany(c.scores ?? {}, criteria, cfg.missingMode);
+    const priority = band === 'PASS' && scoring && !scoring.excluded && cfg.priorityMin !== null && scoring.total >= cfg.priorityMin;
+    return { name: c.name, url: c.url ?? '', location: c.location ?? '', segments: c.segments ?? {}, sources: c.sources ?? [],
+      band, reasons, scoring, priority, findings: c.findings ?? [], open_questions: c.open_questions ?? [] };
+  });
+  const bands = Object.fromEntries(BANDS.map((b) => [b, rank(companies.filter((c) => c.band === b))]));
+  const counts = Object.fromEntries(BANDS.map((b) => [b, bands[b].length]));
+  const u = judgments.universe ?? null;
+  const universe = u ? {
+    found: u.found ?? null,
+    carried_forward: u.carried_forward ?? companies.length,
+    truncated: u.found != null && u.carried_forward != null ? Math.max(0, u.found - u.carried_forward) : 0,
+    cap: u.cap ?? null,
+    note: u.note ?? '',
+  } : null;
+  return {
+    thesis: thesis.acquisition_thesis.name,
+    run_at: judgments.run_at ?? new Date().toISOString(),
+    universe,
+    counts, bands,
+    coverage: coverage(companies, cfg.declaredSegments, cfg.coverage.threshold, cfg.coverage.flagEmpty),
+    filters, criteria, settings: cfg,
+  };
+}

--- a/finance/winnow/scripts/lib/thesis.mjs
+++ b/finance/winnow/scripts/lib/thesis.mjs
@@ -1,0 +1,181 @@
+// Load and validate a thesis, and derive the flat structures the engine needs.
+import { readFileSync } from 'node:fs';
+import { parse } from './yaml.mjs';
+
+export class ThesisError extends Error {}
+
+const IMPORTANCE = new Set(['high', 'medium', 'low']);
+const MISSING_MODES = new Set(['neutral', 'penalize', 'exclude']);
+const DEPTHS = new Set(['fast', 'standard', 'deep']);
+const EXECUTIONS = new Set(['fast', 'standard']);
+const GROUP_FILTERS = ['industry', 'geography', 'ownership', 'business_model'];
+const SIZE_KEYS = ['revenue', 'ebitda', 'employees', 'locations'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+const isStrList = (v) => Array.isArray(v) && v.every((x) => typeof x === 'string');
+
+export function loadThesis(file) {
+  let doc;
+  try { doc = parse(readFileSync(file, 'utf8')); }
+  catch (e) { throw new ThesisError(`${file}: ${e.message}`); }
+  const { errors, warnings } = validate(doc);
+  if (errors.length) throw new ThesisError(`${file}:\n  - ${errors.join('\n  - ')}`);
+  return { thesis: doc, warnings };
+}
+
+/** Structural validation. Returns { errors, warnings }; errors are fatal. */
+export function validate(doc) {
+  const errors = [], warnings = [];
+  const err = (m) => errors.push(m);
+  if (!isObj(doc)) return { errors: ['thesis must be a mapping'], warnings };
+  const at = doc.acquisition_thesis;
+  if (!isObj(at)) { err('acquisition_thesis is required'); return { errors, warnings }; }
+  if (typeof at.name !== 'string' || !at.name.trim()) err('acquisition_thesis.name is required');
+
+  // hard filters
+  const hf = at.hard_filters;
+  if (!isObj(hf)) err('hard_filters is required');
+  else {
+    for (const g of GROUP_FILTERS) {
+      const v = hf[g];
+      if (v === undefined) continue;
+      if (!isObj(v)) { err(`hard_filters.${g} must be a mapping`); continue; }
+      const keys = g === 'business_model' ? ['required_characteristics', 'excluded_characteristics'] : ['include', 'exclude'];
+      for (const k of keys) if (v[k] !== undefined && v[k] !== null && !isStrList(v[k])) err(`hard_filters.${g}.${k} must be a list of strings`);
+      if (v.revisitable !== undefined && typeof v.revisitable !== 'boolean') err(`hard_filters.${g}.revisitable must be true or false`);
+    }
+    if (hf.size !== undefined) {
+      if (!isObj(hf.size)) err('hard_filters.size must be a mapping');
+      else for (const k of Object.keys(hf.size)) {
+        if (!SIZE_KEYS.includes(k)) { err(`hard_filters.size.${k}: unknown size key`); continue; }
+        const r = hf.size[k];
+        if (!isObj(r)) { err(`hard_filters.size.${k} must be a mapping with min/max`); continue; }
+        for (const b of ['min', 'max']) if (r[b] !== undefined && r[b] !== null && typeof r[b] !== 'number') err(`hard_filters.size.${k}.${b} must be a number`);
+      }
+    }
+    if (hf.other !== undefined) {
+      if (!Array.isArray(hf.other)) err('hard_filters.other must be a list');
+      else hf.other.forEach((o, i) => {
+        if (!isObj(o)) return err(`hard_filters.other[${i}] must be a mapping`);
+        if (typeof o.name !== 'string' || !o.name.trim()) err(`hard_filters.other[${i}].name is required`);
+        if (typeof o.condition !== 'string' || !o.condition.trim()) err(`hard_filters.other[${i}].condition is required`);
+        if (o.revisitable !== undefined && typeof o.revisitable !== 'boolean') err(`hard_filters.other[${i}].revisitable must be true or false`);
+      });
+    }
+  }
+
+  // scored preferences
+  const sp = at.scored_preferences;
+  if (!isObj(sp) || !Array.isArray(sp.criteria) || sp.criteria.length === 0) err('scored_preferences.criteria must be a non-empty list');
+  else {
+    const names = new Set();
+    let sum = 0;
+    sp.criteria.forEach((c, i) => {
+      if (!isObj(c)) return err(`scored_preferences.criteria[${i}] must be a mapping`);
+      if (typeof c.name !== 'string' || !c.name.trim()) err(`criteria[${i}].name is required`);
+      else if (names.has(c.name)) err(`criteria: duplicate name "${c.name}"`); else names.add(c.name);
+      if (typeof c.weight !== 'number' || !(c.weight > 0)) err(`criteria[${i}] "${c.name}": weight must be a positive number`);
+      else sum += c.weight;
+      if (!isObj(c.scoring_guidance)) err(`criteria[${i}] "${c.name}": scoring_guidance is required`);
+      else for (const a of ['100', '50', '0']) if (typeof c.scoring_guidance[a] !== 'string') err(`criteria[${i}] "${c.name}": scoring_guidance needs anchors 100, 50 and 0`);
+    });
+    if (sum && Math.abs(sum - 100) > 1e-9) warnings.push(`scored_preferences weights sum to ${sum}, not 100 (they are normalised, but 100 reads better)`);
+  }
+
+  // research questions
+  const rq = at.research_questions;
+  if (rq !== undefined) {
+    if (!isObj(rq)) err('research_questions must be a mapping');
+    else {
+      if (rq.standard !== undefined && rq.standard !== null && !isStrList(rq.standard)) err('research_questions.standard must be a list of strings');
+      if (rq.custom !== undefined && rq.custom !== null) {
+        if (!Array.isArray(rq.custom)) err('research_questions.custom must be a list');
+        else rq.custom.forEach((q, i) => {
+          if (!isObj(q) || typeof q.question !== 'string') return err(`research_questions.custom[${i}].question is required`);
+          if (q.importance !== undefined && !IMPORTANCE.has(q.importance)) err(`research_questions.custom[${i}].importance must be high, medium or low`);
+        });
+      }
+    }
+  }
+
+  // settings
+  const rs = doc.research_settings ?? {};
+  if (!isObj(rs)) err('research_settings must be a mapping');
+  else {
+    const mode = rs.research_depth?.mode;
+    if (mode !== undefined && !DEPTHS.has(mode)) err('research_settings.research_depth.mode must be fast, standard or deep');
+    const ex = rs.execution?.mode;
+    if (ex !== undefined && !EXECUTIONS.has(ex)) err('research_settings.execution.mode must be fast or standard');
+    const cov = rs.coverage;
+    if (cov !== undefined) {
+      if (!isObj(cov)) err('research_settings.coverage must be a mapping');
+      else {
+        if (cov.report_by !== undefined && !isStrList(cov.report_by)) err('coverage.report_by must be a list of strings');
+        else for (const d of cov.report_by ?? []) {
+          const inc = hf?.[d]?.include;
+          if (!isStrList(inc) || inc.length === 0) err(`coverage.report_by "${d}": hard_filters.${d}.include must list the segments to report on`);
+        }
+        const th = cov.single_source_threshold;
+        if (th !== undefined && !(typeof th === 'number' && th > 0 && th <= 1)) err('coverage.single_source_threshold must be a number in (0, 1]');
+        if (cov.flag_empty_segments !== undefined && typeof cov.flag_empty_segments !== 'boolean') err('coverage.flag_empty_segments must be true or false');
+      }
+    }
+  }
+  const ss = doc.scoring_settings ?? {};
+  if (!isObj(ss)) err('scoring_settings must be a mapping');
+  else {
+    const m = ss.missing_data_policy?.mode;
+    if (m !== undefined && !MISSING_MODES.has(m)) err('scoring_settings.missing_data_policy.mode must be neutral, penalize or exclude');
+    const p = ss.minimum_score_for_priority;
+    if (p !== undefined && p !== null && typeof p !== 'number') err('scoring_settings.minimum_score_for_priority must be a number');
+  }
+  return { errors, warnings };
+}
+
+/** Flatten hard filters to a named list with revisitable flags. */
+export function filterList(thesis) {
+  const hf = thesis.acquisition_thesis.hard_filters ?? {};
+  const out = [];
+  for (const g of GROUP_FILTERS) if (hf[g]) out.push({ name: g, revisitable: hf[g].revisitable === true });
+  for (const k of Object.keys(hf.size ?? {})) out.push({ name: `size.${k}`, revisitable: hf.size[k].revisitable === true });
+  for (const o of hf.other ?? []) out.push({ name: o.name, revisitable: o.revisitable === true, condition: o.condition });
+  return out;
+}
+
+/** Criteria with weights normalised to sum to 100. */
+export function criteriaList(thesis) {
+  const cs = thesis.acquisition_thesis.scored_preferences.criteria;
+  const sum = cs.reduce((a, c) => a + c.weight, 0);
+  return cs.map((c) => ({ name: c.name, weight: c.weight, normalised: (c.weight / sum) * 100 }));
+}
+
+export function settings(thesis) {
+  const rs = thesis.research_settings ?? {}, ss = thesis.scoring_settings ?? {}, out = thesis.output ?? {};
+  return {
+    depth: rs.research_depth?.mode ?? 'standard',
+    limits: {
+      initialUniverse: rs.target_limits?.initial_universe ?? null,
+      deepResearchLimit: rs.target_limits?.deep_research_limit ?? null,
+    },
+    execution: rs.execution?.mode ?? 'standard',
+    standardQuestions: thesis.acquisition_thesis.research_questions?.standard ?? [],
+    missingMode: ss.missing_data_policy?.mode ?? 'neutral',
+    priorityMin: ss.minimum_score_for_priority ?? null,
+    coverage: {
+      reportBy: rs.coverage?.report_by ?? [],
+      threshold: rs.coverage?.single_source_threshold ?? 0.5,
+      flagEmpty: rs.coverage?.flag_empty_segments ?? true,
+    },
+    declaredSegments: Object.fromEntries((rs.coverage?.report_by ?? []).map((d) => [d, thesis.acquisition_thesis.hard_filters[d].include])),
+    output: {
+      coverage: out.show_coverage_report ?? true,
+      nearMiss: out.show_near_miss_band ?? true,
+      failures: out.show_filter_failures ?? true,
+      breakdown: out.show_score_breakdown ?? true,
+      confidence: out.show_confidence ?? true,
+      citations: out.show_citations ?? true,
+      briefs: out.target_briefs ?? true,
+      formats: out.export?.formats ?? ['csv', 'json'],
+    },
+  };
+}

--- a/finance/winnow/scripts/lib/yaml.mjs
+++ b/finance/winnow/scripts/lib/yaml.mjs
@@ -1,0 +1,224 @@
+// Minimal YAML subset parser — zero dependencies, because the agent container
+// ships node but no YAML library. Supports exactly what a thesis file uses:
+//
+//   key: value                 maps, 2-space indentation
+//   - item / - key: value      lists of scalars and lists of maps
+//   key: >  / key: |           folded and literal block scalars
+//   # comment                  full-line and trailing comments
+//   100: text                  numeric keys (scoring anchors)
+//   "quoted" 'quoted'          quoted scalars
+//   true false null ~ 12 0.5   scalar typing
+//   {a: 1, b: [x, y]}         single-line flow mappings and lists
+//   key:                       empty value -> null
+//
+// Not supported, by design: anchors/aliases, flow collections spanning more
+// than one line, multi-document files, tags, complex keys. The validator rejects anything the
+// parser cannot represent, so a thesis outside this subset fails loudly.
+
+export class YamlError extends Error {
+  constructor(msg, line) { super(`YAML line ${line}: ${msg}`); this.line = line; }
+}
+
+function stripComment(s) {
+  // A '#' starts a comment only at line start or after whitespace, and never
+  // inside quotes.
+  let q = null;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (q) { if (c === q) q = null; continue; }
+    if (c === '"' || c === "'") { q = c; continue; }
+    if (c === '#' && (i === 0 || /\s/.test(s[i - 1]))) return s.slice(0, i);
+  }
+  return s;
+}
+
+// Split a flow-collection body on top-level commas, respecting nesting and
+// quotes so `{a: [1, 2], b: 3}` yields two entries rather than three.
+function splitTop(body, line) {
+  const out = [];
+  let depth = 0, q = null, cur = '';
+  for (const c of body) {
+    if (q) { cur += c; if (c === q) q = null; continue; }
+    if (c === '"' || c === "'") { q = c; cur += c; continue; }
+    if (c === '[' || c === '{') depth++;
+    else if (c === ']' || c === '}') depth--;
+    if (depth < 0) throw new YamlError('unbalanced brackets in flow collection', line);
+    if (c === ',' && depth === 0) { out.push(cur); cur = ''; continue; }
+    cur += c;
+  }
+  if (depth !== 0) throw new YamlError('unbalanced brackets in flow collection', line);
+  if (cur.trim() !== '') out.push(cur);
+  return out;
+}
+
+function scalar(raw, line) {
+  const s = raw.trim();
+  if (s === '' || s === '~' || s === 'null') return null;
+  if (s === 'true') return true;
+  if (s === 'false') return false;
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+    const inner = s.slice(1, -1);
+    return s[0] === '"' ? inner.replace(/\\"/g, '"').replace(/\\n/g, '\n') : inner.replace(/''/g, "'");
+  }
+  if (s.startsWith('[') && s.endsWith(']')) {
+    const body = s.slice(1, -1).trim();
+    return body === '' ? [] : splitTop(body, line).map((x) => scalar(x, line));
+  }
+  if (s.startsWith('{')) {
+    if (!s.endsWith('}')) throw new YamlError('unterminated flow mapping', line);
+    const body = s.slice(1, -1).trim();
+    const obj = {};
+    if (body === '') return obj;
+    for (const part of splitTop(body, line)) {
+      const kv = splitKey(part.trim(), line);
+      if (!kv) throw new YamlError(`flow mapping entry "${part.trim()}" is not "key: value"`, line);
+      obj[keyOf(kv[0], line)] = scalar(kv[1], line);
+    }
+    return obj;
+  }
+  if (/^-?\d+$/.test(s)) return Number(s);
+  if (/^-?\d*\.\d+$/.test(s)) return Number(s);
+  return s;
+}
+
+// Split "key: value" at the first ': ' or trailing ':' outside quotes.
+function splitKey(s, line) {
+  let q = null;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (q) { if (c === q) q = null; continue; }
+    if (c === '"' || c === "'") { q = c; continue; }
+    if (c === ':' && (i === s.length - 1 || s[i + 1] === ' ')) {
+      return [s.slice(0, i).trim(), s.slice(i + 1).trim()];
+    }
+  }
+  return null;
+}
+
+function keyOf(raw, line) {
+  const k = scalar(raw, line);
+  if (k === null || typeof k === 'boolean' || Array.isArray(k)) throw new YamlError(`unsupported key "${raw}"`, line);
+  return String(k);
+}
+
+export function parse(text) {
+  const src = text.split(/\r?\n/);
+  // Pre-tokenise: [lineNo, indent, content] with comments and blanks removed,
+  // except inside block scalars, which are consumed by readBlock.
+  const lines = src.map((l, i) => ({ n: i + 1, raw: l }));
+  let pos = 0;
+
+  const peek = () => {
+    while (pos < lines.length) {
+      const { raw } = lines[pos];
+      const content = stripComment(raw);
+      if (content.trim() === '') { pos++; continue; }
+      return { n: lines[pos].n, indent: raw.length - raw.trimStart().length, content: content.trimEnd() };
+    }
+    return null;
+  };
+
+  function readBlock(style, parentIndent, chomp) {
+    // Collect lines more indented than the parent; the block ends at the
+    // first non-blank line at or below parentIndent.
+    const out = [];
+    let blockIndent = null;
+    while (pos < lines.length) {
+      const raw = lines[pos].raw;
+      if (raw.trim() === '') { out.push(''); pos++; continue; }
+      const ind = raw.length - raw.trimStart().length;
+      if (ind <= parentIndent) break;
+      if (blockIndent === null) blockIndent = ind;
+      out.push(raw.slice(Math.min(ind, blockIndent)));
+      pos++;
+    }
+    while (out.length && out[out.length - 1] === '') out.pop();
+    let s;
+    if (style === '|') s = out.join('\n');
+    else {
+      // Folded: single newlines become spaces, blank lines become newlines,
+      // more-indented lines are kept verbatim.
+      s = '';
+      for (let i = 0; i < out.length; i++) {
+        const l = out[i];
+        if (l === '') { s += '\n'; continue; }
+        if (i > 0 && out[i - 1] !== '' && !/^\s/.test(l) && !/^\s/.test(out[i - 1])) s += ' ';
+        else if (i > 0 && out[i - 1] !== '') s += '\n';
+        s += l;
+      }
+    }
+    return chomp === '-' ? s : s + '\n';
+  }
+
+  function value(afterColon, indent, line) {
+    const m = /^([>|])([+-]?)\s*$/.exec(afterColon);
+    if (m) return readBlock(m[1], indent, m[2]);
+    if (afterColon !== '') return scalar(afterColon, line);
+    // Empty: the value is a nested node on following lines, or null.
+    const nx = peek();
+    if (!nx || nx.indent <= indent) return null;
+    return node(nx.indent);
+  }
+
+  function node(indent) {
+    const first = peek();
+    if (!first) return null;
+    if (first.content.trimStart().startsWith('- ') || first.content.trim() === '-') return list(indent);
+    return map(indent);
+  }
+
+  function map(indent) {
+    const obj = {};
+    for (;;) {
+      const cur = peek();
+      if (!cur || cur.indent < indent) break;
+      if (cur.indent > indent) throw new YamlError('unexpected indentation', cur.n);
+      const body = cur.content.trimStart();
+      if (body.startsWith('- ')) break;
+      const kv = splitKey(body, cur.n);
+      if (!kv) throw new YamlError(`expected "key: value", got "${body}"`, cur.n);
+      pos++;
+      const k = keyOf(kv[0], cur.n);
+      if (k in obj) throw new YamlError(`duplicate key "${k}"`, cur.n);
+      obj[k] = value(kv[1], indent, cur.n);
+    }
+    return obj;
+  }
+
+  function list(indent) {
+    const arr = [];
+    for (;;) {
+      const cur = peek();
+      if (!cur || cur.indent < indent) break;
+      if (cur.indent > indent) throw new YamlError('unexpected indentation', cur.n);
+      const body = cur.content.trimStart();
+      if (!(body.startsWith('- ') || body === '-')) break;
+      pos++;
+      const rest = body === '-' ? '' : body.slice(2);
+      if (rest === '') { arr.push(node(indent + 2)); continue; }
+      const kv = splitKey(rest, cur.n);
+      if (kv && !/^["']/.test(rest)) {
+        // "- key: value" opens an inline map whose further keys sit at indent+2.
+        const itemIndent = indent + 2;
+        const obj = {};
+        obj[keyOf(kv[0], cur.n)] = value(kv[1], itemIndent, cur.n);
+        const nx = peek();
+        if (nx && nx.indent === itemIndent && !nx.content.trimStart().startsWith('- ')) {
+          Object.assign(obj, map(itemIndent));
+        }
+        arr.push(obj);
+      } else {
+        const m = /^([>|])([+-]?)\s*$/.exec(rest);
+        arr.push(m ? readBlock(m[1], indent, m[2]) : scalar(rest, cur.n));
+      }
+    }
+    return arr;
+  }
+
+  const first = peek();
+  if (!first) return null;
+  const doc = node(first.indent);
+  const trailing = peek();
+  if (trailing) throw new YamlError(`unexpected content "${trailing.content.trim()}"`, trailing.n);
+  return doc;
+}

--- a/finance/winnow/scripts/package.json
+++ b/finance/winnow/scripts/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "winnow-scripts",
+  "private": true,
+  "type": "module",
+  "description": "Deterministic half of the winnow screening pipeline. Zero dependencies.",
+  "scripts": { "test": "node --test test/*.test.mjs" }
+}

--- a/finance/winnow/scripts/test/eval.test.mjs
+++ b/finance/winnow/scripts/test/eval.test.mjs
@@ -1,0 +1,85 @@
+// Data-driven acceptance eval. Every case, name and expectation lives in a
+// JSON file beside the thesis it exercises, so this runner carries no
+// domain knowledge and stays valid for any thesis.
+//
+// Add a case: drop a `<name>.eval.json` in ../../theses/ naming its thesis
+// and judgments file. It is picked up automatically.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadThesis } from '../lib/thesis.mjs';
+import { screen } from '../lib/screen.mjs';
+
+const THESES = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'theses');
+const suites = existsSync(THESES)
+  ? readdirSync(THESES).filter((f) => f.endsWith('.eval.json'))
+  : [];
+
+test('at least one acceptance eval is present', () => {
+  assert.ok(suites.length > 0, 'no *.eval.json found — the acceptance eval would silently pass');
+});
+
+for (const file of suites) {
+  const spec = JSON.parse(readFileSync(path.join(THESES, file), 'utf8'));
+
+  test(`eval: ${file}`, async (t) => {
+    const { thesis } = loadThesis(path.join(THESES, spec.thesis));
+    const judgments = JSON.parse(readFileSync(path.join(THESES, spec.judgments), 'utf8'));
+    const r = screen(thesis, judgments);
+    const all = [...r.bands.PASS, ...r.bands['NEAR MISS'], ...r.bands.FAIL];
+    const find = (n) => {
+      const c = all.find((x) => x.name === n);
+      assert.ok(c, `expected company "${n}" in the run`);
+      return c;
+    };
+
+    await t.test('band counts', () => assert.deepEqual(r.counts, spec.expect.counts));
+
+    for (const e of spec.expect.companies) {
+      await t.test(`${e.name} — ${e.why}`, () => {
+        const c = find(e.name);
+        assert.equal(c.band, e.band, `band for ${e.name}`);
+        if (e.priority !== undefined) assert.equal(c.priority, e.priority, `priority for ${e.name}`);
+        if (e.unscored) { assert.equal(c.scoring, null, `${e.name} must not be scored`); return; }
+        assert.ok(c.scoring, `${e.name} must be scored`);
+        if (e.criterion !== undefined) {
+          const row = c.scoring.rows.find((x) => x.criterion === e.criterion);
+          assert.ok(row, `criterion "${e.criterion}" on ${e.name}`);
+          if (e.score !== undefined) assert.equal(row.score, e.score, `${e.criterion} score on ${e.name}`);
+          if (e.policy !== undefined) assert.equal(row.policy, e.policy, `${e.criterion} missing-data policy on ${e.name}`);
+        }
+        if (e.scoreNotBelow !== undefined) {
+          assert.ok(c.scoring.total >= e.scoreNotBelow,
+            `${e.name} scored ${c.scoring.total}, expected >= ${e.scoreNotBelow} — absent evidence must not be punished`);
+        }
+      });
+    }
+
+    await t.test('invariant: ranking is structural — a NEAR MISS never enters PASS on score', () => {
+      const worstPass = Math.min(...r.bands.PASS.map((c) => c.scoring.total));
+      const bestNear = Math.max(...r.bands['NEAR MISS'].map((c) => c.scoring.total), -1);
+      // The interesting case must actually occur, or this proves nothing.
+      assert.ok(bestNear > worstPass,
+        `fixture must contain a NEAR MISS outscoring a PASS (best near ${bestNear}, worst pass ${worstPass}) — otherwise the invariant is untested`);
+      // ...and it stays in its band regardless.
+      const climber = r.bands['NEAR MISS'].find((c) => c.scoring.total === bestNear);
+      assert.equal(climber.band, 'NEAR MISS',
+        `${climber.name} scores ${bestNear}, above a PASS at ${worstPass}, and must still be NEAR MISS — it failed a filter the user wrote down`);
+      assert.ok(r.bands.PASS.every((c) => c.band === 'PASS'));
+    });
+
+    await t.test('invariant: every FAIL is unscored', () => {
+      for (const c of r.bands.FAIL) assert.equal(c.scoring, null, `${c.name} is FAIL and must be unscored`);
+    });
+
+    await t.test('invariant: a declared segment with no candidates is flagged', () => {
+      for (const cov of Object.values(r.coverage)) {
+        for (const row of cov.table) {
+          if (row.candidates === 0) assert.ok(row.flags.includes('no coverage'), `${row.segment} empty but unflagged`);
+        }
+      }
+    });
+  });
+}

--- a/finance/winnow/scripts/test/render.test.mjs
+++ b/finance/winnow/scripts/test/render.test.mjs
@@ -1,0 +1,57 @@
+// Unit tests for the output renderers in ../lib/render.mjs. One screened
+// result is built once from a small thesis, then rendered three ways: CSV
+// (quoting of commas, quotes and embedded newlines, header/row agreement),
+// Markdown (counts first, coverage before the ranked table) and JSON (round
+// trips, and internal settings stay out of the payload).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { csv, markdown, json } from '../lib/render.mjs';
+import { screen } from '../lib/screen.mjs';
+
+const thesis = {
+  acquisition_thesis: {
+    name: 'T, "quoted"',
+    hard_filters: { geography: { include: ['S1'] }, other: [{ name: 'Soft', condition: 'c', revisitable: true }] },
+    scored_preferences: { criteria: [{ name: 'A', weight: 100, scoring_guidance: { 100: 'a', 50: 'b', 0: 'c' } }] },
+  },
+  research_settings: { coverage: { report_by: ['geography'] } },
+  scoring_settings: { minimum_score_for_priority: 65 },
+};
+const result = screen(thesis, { run_at: '2026-01-01T00:00:00Z', candidates: [
+  { name: 'Acme, Inc.', url: 'https://a.example', location: 'X', segments: { geography: 'S1' }, sources: ['r'],
+    filters: { geography: { outcome: 'pass' }, Soft: { outcome: 'pass' } },
+    scores: { A: { score: 90, confidence: 'high', why: 'line one\nline two' } } },
+  { name: 'Near Co', segments: { geography: 'S1' }, sources: ['r'],
+    filters: { geography: { outcome: 'pass' }, Soft: { outcome: 'fail', what_would_settle_it: 'a B2B division' } },
+    scores: { A: { score: 95, confidence: 'high' } } },
+  { name: 'Gone', segments: { geography: 'S1' }, sources: ['r'], filters: { geography: { outcome: 'fail', evidence: 'HQ elsewhere' }, Soft: { outcome: 'pass' } } },
+] });
+
+test('csv quotes commas, quotes and newlines; header matches rows', () => {
+  const lines = csv(result).trimEnd().split('\n');
+  assert.equal(lines.length, 4);
+  const cols = lines[0].split(',').length;
+  assert.ok(lines[1].includes('"Acme, Inc."'));
+  assert.ok(lines[1].includes('"T, ""quoted"""'));
+  // FAIL row has empty score cells but the same column count
+  const parse = (l) => l.match(/("([^"]|"")*"|[^,]*)(,|$)/g).filter((x) => x !== '').length;
+  for (const l of lines) assert.equal(parse(l), cols, l);
+});
+
+test('markdown leads with counts and puts coverage before the ranked table', () => {
+  const md = markdown(result);
+  assert.match(md.split('\n')[0], /^\*\*1 pass · 1 near miss · 1 fail\*\*/);
+  assert.ok(md.indexOf('## Coverage') < md.indexOf('## PASS'));
+  assert.ok(md.includes('★ [Acme, Inc.]'), 'priority star on a qualifying PASS');
+  assert.ok(md.includes('| [Near Co]') === false && md.includes('| Near Co |'), 'no link when no url');
+  assert.ok(md.includes('a B2B division'), 'near-miss row says what would settle it');
+  assert.ok(md.includes('HQ elsewhere'), 'fail row carries evidence');
+  assert.ok(md.includes('_none recorded_'), 'open questions section never omitted');
+});
+
+test('json omits internal settings and round-trips', () => {
+  const j = JSON.parse(json(result));
+  assert.equal(j.settings, undefined);
+  assert.deepEqual(j.counts, { PASS: 1, 'NEAR MISS': 1, FAIL: 1 });
+  assert.deepEqual(j.criteria, [{ name: 'A', weight: 100 }]);
+});

--- a/finance/winnow/scripts/test/run.test.mjs
+++ b/finance/winnow/scripts/test/run.test.mjs
@@ -1,0 +1,205 @@
+// Tests for the run lifecycle in ../lib/run.mjs, and its exit codes through
+// the winnow.mjs CLI. Covers what a run refuses: a thesis that does not
+// validate, a run screened before every candidate is judged, an empty run,
+// and a thesis edited after the run opened (with --force downgrading that to
+// a warning). Also covers what it merely warns about (stale evidence, a
+// shipped thesis shadowed by a plugin-data copy) and what `status` reports.
+// Each case runs against a throwaway run directory under os.tmpdir().
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, appendFileSync, readdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { initRun, setUniverse, applyUniverse, runStatus, checkRun, slug, RunError } from '../lib/run.mjs';
+import { loadThesis, filterList, settings } from '../lib/thesis.mjs';
+
+const CLI = path.join(process.cwd(), 'winnow.mjs');
+const THESIS = [
+  'acquisition_thesis:', '  name: T',
+  '  hard_filters:', '    geography: { include: [S1] }',
+  '  scored_preferences:', '    criteria:', '      - name: A', '        weight: 100',
+  '        scoring_guidance: { 100: a, 50: b, 0: c }',
+  'research_settings:', '  coverage: { report_by: [geography] }', ''].join('\n');
+
+function fixture() {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'wnrun-'));
+  const tf = path.join(root, 't.yaml');
+  writeFileSync(tf, THESIS);
+  const { dir, candidates } = initRun(tf, root);
+  return { root, tf, dir, candidates };
+}
+const candidate = (dir, name) => writeFileSync(path.join(dir, `${name}.json`), JSON.stringify({
+  name, segments: { geography: 'S1' }, sources: ['r'],
+  filters: { geography: { outcome: 'pass' } }, scores: { A: { score: 70, confidence: 'high' } } }));
+
+test('init-run issues the path; the agent never invents one', () => {
+  const { candidates, tf } = fixture();
+  const meta = JSON.parse(readFileSync(path.join(candidates, '_run.json'), 'utf8'));
+  assert.equal(meta.thesis, path.resolve(tf));
+  assert.match(meta.thesis_sha, /^[0-9a-f]{16}$/);
+  assert.ok(Date.parse(meta.started_at) > 0);
+  assert.equal(meta.universe, null);
+});
+
+test('init-run refuses a thesis that does not validate', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'wnbad-'));
+  const tf = path.join(root, 'bad.yaml');
+  writeFileSync(tf, 'acquisition_thesis:\n  name: T\n');
+  assert.throws(() => execFileSync('node', [CLI, 'init-run', tf, '--data', root], { stdio: 'pipe' }));
+});
+
+test('an incomplete run cannot be screened', () => {
+  const { tf, candidates } = fixture();
+  setUniverse(candidates, { found: 30, carried: 3 });
+  candidate(candidates, 'a');
+  assert.throws(() => checkRun(candidates, tf), (e) => e instanceof RunError && /incomplete run/.test(e.message));
+  candidate(candidates, 'b'); candidate(candidates, 'c');
+  assert.deepEqual(checkRun(candidates, tf), [], 'complete run passes clean');
+});
+
+test('a thesis edited mid-run is refused, and --force downgrades it to a warning', () => {
+  const { tf, candidates } = fixture();
+  setUniverse(candidates, { found: 5, carried: 1 });
+  candidate(candidates, 'a');
+  assert.deepEqual(checkRun(candidates, tf), []);
+  appendFileSync(tf, '\n# an edit that changes the screen\n');
+  assert.throws(() => checkRun(candidates, tf), (e) => e instanceof RunError && /thesis changed/.test(e.message));
+  const w = checkRun(candidates, tf, { force: true });
+  assert.ok(w.some((x) => /thesis changed/.test(x)), 'forced, but still reported');
+});
+
+test('stale evidence warns rather than blocking', () => {
+  const { tf, candidates } = fixture();
+  const f = path.join(candidates, '_run.json');
+  const meta = JSON.parse(readFileSync(f, 'utf8'));
+  meta.started_at = new Date(Date.now() - 40 * 3.6e6).toISOString();
+  writeFileSync(f, JSON.stringify(meta));
+  candidate(candidates, 'a');
+  const w = checkRun(candidates, tf);
+  assert.ok(w.some((x) => /40h old/.test(x)), `expected staleness warning, got ${JSON.stringify(w)}`);
+});
+
+test('an empty run is refused outright', () => {
+  const { tf, candidates } = fixture();
+  assert.throws(() => checkRun(candidates, tf), (e) => e instanceof RunError && /no candidate files/.test(e.message));
+});
+
+test('status reports written vs expected', () => {
+  const { candidates } = fixture();
+  setUniverse(candidates, { found: 9, carried: 2 });
+  candidate(candidates, 'a');
+  const st = runStatus(candidates);
+  assert.equal(st.written, 1); assert.equal(st.expected, 2);
+  const out = execFileSync('node', [CLI, 'status', candidates], { encoding: 'utf8' });
+  assert.match(out, /written:\s+1 of 2/);
+  assert.match(out, /incomplete: 1 candidate/);
+});
+
+test('screen refuses an incomplete run end to end, exit code 5', () => {
+  const { tf, candidates } = fixture();
+  setUniverse(candidates, { found: 30, carried: 4 });
+  candidate(candidates, 'a');
+  try {
+    execFileSync('node', [CLI, 'screen', tf, candidates], { stdio: 'pipe' });
+    assert.fail('should have refused');
+  } catch (e) {
+    assert.equal(e.status, 5);
+    assert.match(String(e.stderr), /incomplete run/);
+  }
+});
+
+test("a plugin-data thesis shadowing a differing shipped one is reported", async () => {
+  const { shadowWarning } = await import('../lib/run.mjs');
+  const root = mkdtempSync(path.join(os.tmpdir(), 'wnshadow-'));
+  const pluginRoot = path.join(root, 'plugin'); const data = path.join(root, 'data');
+  execFileSync('mkdir', ['-p', path.join(pluginRoot, 'theses'), path.join(data, 'theses')]);
+  const shipped = path.join(pluginRoot, 'theses', 'q.yaml');
+  const copy = path.join(data, 'theses', 'q.yaml');
+  writeFileSync(shipped, THESIS);
+  writeFileSync(copy, THESIS);
+  assert.equal(shadowWarning(copy, pluginRoot), null, 'identical copy is not a shadow');
+  writeFileSync(copy, THESIS + '\n# edited\n');
+  assert.match(shadowWarning(copy, pluginRoot), /shadows a shipped one that differs/);
+  assert.equal(shadowWarning(shipped, pluginRoot), null, 'the shipped thesis never shadows itself');
+});
+
+const THESIS2 = [
+  'acquisition_thesis:', '  name: T2',
+  '  hard_filters:', '    geography: { include: [S1, S2] }',
+  '    other:', '      - name: Soft', '        condition: c', '        revisitable: true',
+  '  scored_preferences:', '    criteria:', '      - name: A', '        weight: 100',
+  '        scoring_guidance: { 100: a, 50: b, 0: c }',
+  'research_settings:', '  coverage: { report_by: [geography] }',
+  '  target_limits: { initial_universe: 3, deep_research_limit: 2 }', ''].join('\n');
+
+function universeFixture() {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'wnuni-'));
+  const tf = path.join(root, 't.yaml');
+  writeFileSync(tf, THESIS2);
+  const { candidates } = initRun(tf, root);
+  const uf = path.join(root, 'universe.json');
+  writeFileSync(uf, JSON.stringify({ tier: 'keyless', queries: ['q1', 'q2'], candidates: [
+    { name: 'S1 Alpha', url: 'https://alpha.example', location: 'A', segment: 'S1', source: 'web search' },
+    { name: 'S2 Beta', url: 'https://beta.example', location: 'B', segment: 'S2', source: 'web search' },
+    { name: 'Beta duplicate', url: 'http://www.beta.example/about', location: 'B', segment: 'S2', source: 'directory' },
+    { name: 'S1 Gamma', url: 'https://gamma.example', location: 'G', segment: 'S1', source: 'web search' },
+    { name: 'S2 Delta', url: 'https://delta.example', location: 'D', segment: 'S2', source: 'web search' },
+    { name: 'S2 Epsilon', url: 'https://eps.example', location: 'E', segment: 'S2', source: 'web search' },
+    { name: 'Texan', url: 'https://texan.example', location: 'TX', segment: 'S1', source: 'web search', fail: { filter: 'geography', evidence: 'HQ in Texas' } },
+  ] }));
+  const { thesis } = loadThesis(tf);
+  const cfg = settings(thesis);
+  const opts = { filters: filterList(thesis), declaredSegments: cfg.declaredSegments, limits: cfg.limits };
+  return { root, tf, candidates, uf, thesis, opts };
+}
+
+test('set-universe --from: dedup, firm-filter drops, round-robin cap, research limit, stubs, printed rows', () => {
+  const { tf, candidates, uf, thesis, opts } = universeFixture();
+  const r = applyUniverse(candidates, uf, thesis, opts);
+  assert.equal(r.found, 6, 'the duplicate domain collapsed');
+  assert.deepEqual(r.fails.map((x) => x.name), ['Texan']);
+  assert.deepEqual(r.carried.map((x) => x.name), ['S1 Alpha', 'S2 Beta', 'S1 Gamma'], 'round-robin across segments, cap 3');
+  assert.deepEqual(r.research.map((x) => x.name), ['S1 Alpha', 'S2 Beta'], 'deep_research_limit 2');
+  assert.deepEqual(r.shallow.map((x) => x.name), ['S1 Gamma']);
+  assert.deepEqual(r.uncarried.map((x) => x.name), ['S2 Delta', 'S2 Epsilon']);
+  assert.equal(r.research[0].file, path.join(candidates, 's1-alpha.json'));
+  const files = readdirSync(candidates).sort();
+  assert.deepEqual(files, ['_run.json', 's1-gamma.json', 'texan.json'], 'stubs for the fail and the unresearched; nothing for the researched');
+  const texan = JSON.parse(readFileSync(path.join(candidates, 'texan.json'), 'utf8'));
+  assert.equal(texan.filters.geography.outcome, 'fail');
+  assert.equal(texan.filters.Soft.outcome, 'unresolved');
+  const meta = JSON.parse(readFileSync(path.join(candidates, '_run.json'), 'utf8'));
+  assert.deepEqual([meta.universe.found, meta.universe.carried_forward, meta.universe.files_expected, meta.universe.cap], [6, 3, 4, 3], 'carried is the cap count; the drop is a file but not carried');
+  assert.match(meta.universe.note, /2 researched, 1 carried without research/);
+  assert.match(meta.universe.note, /S2 Delta, S2 Epsilon/);
+  assert.match(meta.universe.note, /keyless/);
+  // The run is incomplete until the researched files exist; then it screens.
+  assert.throws(() => checkRun(candidates, tf), /incomplete run: universe carried 4/);
+  for (const c of r.research) writeFileSync(c.file, JSON.stringify({ name: c.name, url: c.url, segments: { geography: c.segment }, sources: [c.source],
+    filters: { geography: { outcome: 'pass' }, Soft: { outcome: 'pass' } }, scores: { A: { score: 70, confidence: 'high', why: 'w' } } }));
+  assert.deepEqual(checkRun(candidates, tf), []);
+});
+
+test('set-universe --from refuses bad segments and revisitable "fails", naming every problem', () => {
+  const { candidates, uf, thesis, opts } = universeFixture();
+  writeFileSync(uf, JSON.stringify({ candidates: [
+    { name: 'Lost', url: 'https://l.example', segment: 'S9', source: 's' },
+    { name: 'Softie', url: 'https://s.example', segment: 'S1', source: 's', fail: { filter: 'Soft', evidence: 'e' } },
+  ] }));
+  assert.throws(() => applyUniverse(candidates, uf, thesis, opts), (e) => e instanceof RunError && /2 problem/.test(e.message) && /"S9"/.test(e.message) && /revisitable/.test(e.message));
+});
+
+test('slug is stable and filesystem-safe', () => {
+  assert.equal(slug('APL Access & Security, Inc.'), 'apl-access-security-inc');
+  assert.equal(slug('  Ünicode  '), 'nicode');
+});
+
+test('set-universe --from via the CLI prints the research rows and their files', () => {
+  const { candidates, uf } = universeFixture();
+  const out = execFileSync('node', [CLI, 'set-universe', candidates, '--from', uf], { encoding: 'utf8' });
+  assert.match(out, /6 found · 1 dropped by firm filters · 3 carried · 2 to research · 2 past the cap/);
+  assert.match(out, /- S1 Alpha \| https:\/\/alpha.example/);
+  assert.match(out, /→ .*s1-alpha.json/);
+  assert.match(out, /Then: winnow screen/);
+});

--- a/finance/winnow/scripts/test/screen.test.mjs
+++ b/finance/winnow/scripts/test/screen.test.mjs
@@ -1,0 +1,271 @@
+// Unit tests for the screening engine in ../lib/screen.mjs — the decisions
+// that turn per-candidate judgments into a ranked list. Covers band
+// assignment (the PASS / NEAR MISS / FAIL truth table, and how unresolved
+// filters are treated in each missing-data mode), weighted scoring and its
+// normalisation, ranking tie-breaks, coverage warnings, confidence
+// weighting, thesis validation, and one end-to-end pass through screen().
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { assignBand, scoreCompany, rank, coverage, screen, checkShape, CAPS, JudgmentsError } from '../lib/screen.mjs';
+import { validate, filterList, criteriaList } from '../lib/thesis.mjs';
+
+const filters = [
+  { name: 'geography', revisitable: false },
+  { name: 'Business-customer orientation', revisitable: true },
+];
+const P = { outcome: 'pass' }, F = { outcome: 'fail' }, U = { outcome: 'unresolved' };
+const band = (geo, soft, mode = 'neutral') => assignBand({ geography: geo, 'Business-customer orientation': soft }, filters, mode).band;
+
+test('band truth table', () => {
+  assert.equal(band(P, P), 'PASS');
+  assert.equal(band(P, F), 'NEAR MISS', 'failing only a revisitable filter quarantines');
+  assert.equal(band(F, P), 'FAIL', 'a firm failure drops');
+  assert.equal(band(F, F), 'FAIL', 'firm beats revisitable');
+  assert.equal(band(P, U), 'NEAR MISS', 'unresolved joins near miss');
+  assert.equal(band(U, P), 'NEAR MISS', 'unresolved on a firm filter is still near miss');
+  assert.equal(band(U, P, 'exclude'), 'FAIL', 'exclude mode sends unresolved to FAIL');
+  assert.equal(band(P, F, 'exclude'), 'NEAR MISS', 'exclude mode does not touch revisitable failures');
+});
+
+test('band records why, and refuses a missing or malformed outcome', () => {
+  const r = assignBand({ geography: P, 'Business-customer orientation': { outcome: 'fail', what_would_settle_it: 'a real B2B division' } }, filters, 'neutral');
+  assert.deepEqual(r.reasons.map((x) => [x.filter, x.outcome, x.revisitable, x.settle]), [['Business-customer orientation', 'fail', true, 'a real B2B division']]);
+  assert.throws(() => assignBand({ geography: P }, filters, 'neutral'), JudgmentsError);
+  assert.throws(() => assignBand({ geography: { outcome: 'maybe' }, 'Business-customer orientation': P }, filters, 'neutral'), JudgmentsError);
+});
+
+const criteria = [
+  { name: 'A', weight: 60, normalised: 60 },
+  { name: 'B', weight: 20, normalised: 20 },
+  { name: 'Scale', weight: 20, normalised: 20 },
+];
+
+test('weighted scoring arithmetic, and both confidences reported', () => {
+  const r = scoreCompany({ A: { score: 100, confidence: 'high' }, B: { score: 50, confidence: 'medium' }, Scale: { score: 0, confidence: 'high' } }, criteria, 'neutral');
+  assert.equal(r.total, 70); // 60 + 10 + 0
+  // weighted: (3*60 + 2*20 + 3*20)/100 = 2.8 -> high
+  assert.equal(r.confidence, 'high');
+  assert.equal(r.lowestConfidence, 'medium', 'weakest input is carried, not discarded');
+  assert.equal(r.excluded, false);
+});
+
+test('weights are normalised, not trusted', () => {
+  const raw = [{ name: 'A', weight: 3 }, { name: 'B', weight: 1 }];
+  const sum = raw.reduce((a, c) => a + c.weight, 0);
+  const norm = raw.map((c) => ({ ...c, normalised: (c.weight / sum) * 100 }));
+  const r = scoreCompany({ A: { score: 100, confidence: 'high' }, B: { score: 0, confidence: 'high' } }, norm, 'neutral');
+  assert.equal(r.total, 75);
+});
+
+test('missing data: neutral=50 flagged low, penalize=0, exclude marks the company', () => {
+  const s = { A: { score: 100, confidence: 'high' }, B: { score: 100, confidence: 'high' } }; // Scale missing
+  const n = scoreCompany(s, criteria, 'neutral');
+  assert.equal(n.total, 90); assert.equal(n.rows[2].policy, 'neutral'); assert.equal(n.rows[2].confidence, 'low');
+  // weighted: (3*60 + 3*20 + 1*20)/100 = 2.6 -> high, but the low input stays visible
+  assert.equal(n.confidence, 'high');
+  assert.equal(n.lowestConfidence, 'low');
+  const p = scoreCompany(s, criteria, 'penalize');
+  assert.equal(p.total, 80); assert.equal(p.rows[2].score, 0);
+  const x = scoreCompany(s, criteria, 'exclude');
+  assert.equal(x.excluded, true);
+});
+
+test('score bounds and confidence enum are enforced', () => {
+  assert.throws(() => scoreCompany({ A: { score: 101, confidence: 'high' } }, criteria.slice(0, 1), 'neutral'), JudgmentsError);
+  assert.throws(() => scoreCompany({ A: { score: 50, confidence: 'certain' } }, criteria.slice(0, 1), 'neutral'), JudgmentsError);
+});
+
+test('ranking: score, then confidence, then scale, then name', () => {
+  const mk = (name, total, confidence, scale) => ({ name, scoring: { total, confidence, rows: [{ criterion: 'Scale', score: scale }] } });
+  const r = rank([mk('d', 70, 'low', 0), mk('c', 80, 'low', 0), mk('b', 80, 'high', 10), mk('a', 80, 'high', 90)]);
+  assert.deepEqual(r.map((x) => x.name), ['a', 'b', 'c', 'd']);
+});
+
+test('coverage flags single-source dominance and empty declared segments', () => {
+  const cands = [
+    ...Array.from({ length: 9 }, (_, i) => ({ name: `x${i}`, segments: { geography: 'Seg A' }, sources: ['roster'] })),
+    { name: 'y', segments: { geography: 'Seg A' }, sources: ['press'] },
+    { name: 'z1', segments: { geography: 'Seg B' }, sources: ['press'] },
+    { name: 'z2', segments: { geography: 'Seg B' }, sources: ['registry'] },
+    { name: 'w', segments: { geography: 'Seg D' }, sources: ['press'] }, // undeclared
+  ];
+  const c = coverage(cands, { geography: ['Seg A', 'Seg B', 'Seg C'] }, 0.5, true).geography;
+  const a = c.table.find((t) => t.segment === 'Seg A');
+  assert.equal(a.candidates, 10); assert.deepEqual(a.top, { source: 'roster', count: 9 }); assert.deepEqual(a.flags, ['single source 90%']);
+  const b = c.table.find((t) => t.segment === 'Seg B');
+  assert.deepEqual(b.flags, [], 'an even split is not flagged');
+  const d = c.table.find((t) => t.segment === 'Seg C');
+  assert.equal(d.candidates, 0); assert.deepEqual(d.flags, ['no coverage']);
+  assert.deepEqual(c.undeclared, ['Seg D']);
+});
+
+test('coverage: flag_empty_segments=false suppresses the empty flag; threshold is exclusive', () => {
+  const c = coverage([{ name: 'a', segments: { geography: 'S' }, sources: ['r'] }, { name: 'b', segments: { geography: 'S' }, sources: ['p'] }],
+    { geography: ['S', 'T'] }, 0.5, false).geography;
+  assert.deepEqual(c.table[0].flags, [], '50% is not > 50%');
+  assert.deepEqual(c.table[1].flags, []);
+});
+
+const thesis = {
+  acquisition_thesis: {
+    name: 'T',
+    hard_filters: { geography: { include: ['S1', 'S2'] }, other: [{ name: 'Soft', condition: 'c', revisitable: true }] },
+    scored_preferences: { criteria: [
+      { name: 'A', weight: 50, scoring_guidance: { 100: 'a', 50: 'b', 0: 'c' } },
+      { name: 'B', weight: 50, scoring_guidance: { 100: 'a', 50: 'b', 0: 'c' } } ] },
+  },
+  research_settings: { coverage: { report_by: ['geography'], single_source_threshold: 0.5, flag_empty_segments: true } },
+  scoring_settings: { missing_data_policy: { mode: 'neutral' }, minimum_score_for_priority: 65 },
+};
+
+test('validate accepts a good thesis and reports specific errors on a bad one', () => {
+  assert.deepEqual(validate(thesis).errors, []);
+  const bad = structuredClone(thesis);
+  bad.acquisition_thesis.scored_preferences.criteria[0].weight = -1;
+  delete bad.acquisition_thesis.scored_preferences.criteria[1].scoring_guidance['0'];
+  bad.acquisition_thesis.hard_filters.other[0].revisitable = 'yes';
+  bad.research_settings.coverage.report_by = ['industry'];
+  const { errors } = validate(bad);
+  assert.equal(errors.length, 4, errors.join('\n'));
+  assert.ok(errors.some((e) => /weight must be a positive/.test(e)));
+  assert.ok(errors.some((e) => /anchors 100, 50 and 0/.test(e)));
+  assert.ok(errors.some((e) => /revisitable must be true or false/.test(e)));
+  assert.ok(errors.some((e) => /report_by "industry"/.test(e)));
+});
+
+test('validate warns, not errors, when weights do not sum to 100', () => {
+  const t = structuredClone(thesis); t.acquisition_thesis.scored_preferences.criteria[0].weight = 30;
+  const v = validate(t); assert.deepEqual(v.errors, []); assert.equal(v.warnings.length, 1);
+});
+
+test('execution mode validates, and defaults to standard', async () => {
+  const { settings } = await import('../lib/thesis.mjs');
+  const doc = (execution) => ({
+    acquisition_thesis: { name: 'T', hard_filters: { geography: { include: ['S1'] } },
+      scored_preferences: { criteria: [{ name: 'A', weight: 100, scoring_guidance: { 100: 'a', 50: 'b', 0: 'c' } }] } },
+    research_settings: execution ? { execution } : {},
+  });
+  assert.deepEqual(validate(doc({ mode: 'fast' })).errors, []);
+  assert.deepEqual(validate(doc({ mode: 'standard' })).errors, []);
+  assert.match(validate(doc({ mode: 'parallel' })).errors[0], /execution.mode must be fast or standard/);
+  assert.equal(settings(doc(null)).execution, 'standard');
+  assert.equal(settings(doc({ mode: 'fast' })).execution, 'fast');
+});
+
+test('filterList and criteriaList derive from the thesis', () => {
+  assert.deepEqual(filterList(thesis).map((f) => [f.name, f.revisitable]), [['geography', false], ['Soft', true]]);
+  assert.deepEqual(criteriaList(thesis).map((c) => c.normalised), [50, 50]);
+});
+
+test('screen: end to end, counts, priority, ranking within bands only', () => {
+  const j = { candidates: [
+    { name: 'Top', segments: { geography: 'S1' }, sources: ['r'], filters: { geography: P, Soft: P }, scores: { A: { score: 90, confidence: 'high' }, B: { score: 80, confidence: 'high' } } },
+    { name: 'Near', segments: { geography: 'S1' }, sources: ['r'], filters: { geography: P, Soft: F }, scores: { A: { score: 100, confidence: 'high' }, B: { score: 100, confidence: 'high' } } },
+    { name: 'Low', segments: { geography: 'S2' }, sources: ['p'], filters: { geography: P, Soft: P }, scores: { A: { score: 40, confidence: 'low' }, B: { score: 40, confidence: 'low' } } },
+    { name: 'Out', segments: { geography: 'S2' }, sources: ['p'], filters: { geography: F, Soft: P } },
+  ] };
+  const r = screen(thesis, j);
+  assert.deepEqual(r.counts, { PASS: 2, 'NEAR MISS': 1, FAIL: 1 });
+  assert.deepEqual(r.bands.PASS.map((c) => [c.name, c.scoring.total, c.priority]), [['Top', 85, true], ['Low', 40, false]]);
+  assert.equal(r.bands['NEAR MISS'][0].name, 'Near');
+  assert.equal(r.bands['NEAR MISS'][0].scoring.total, 100, 'near miss is scored');
+  assert.equal(r.bands['NEAR MISS'][0].priority, false, 'but never priority');
+  assert.equal(r.bands.FAIL[0].scoring, null, 'FAIL is not scored');
+  assert.equal(r.coverage.geography.table[0].candidates, 2, 'FAIL candidates still count toward coverage');
+  assert.throws(() => screen(thesis, { candidates: [j.candidates[0], j.candidates[0]] }), /duplicate candidate/);
+});
+
+test('caps: every violation is listed at once, and nothing is trimmed', () => {
+  const long = (n) => 'x'.repeat(n);
+  const c = { name: 'Verbose', segments: { geography: 'S1' }, sources: ['r'],
+    filters: { geography: { outcome: 'pass', evidence: long(CAPS['filters.*.evidence'] + 1) }, Soft: P },
+    scores: { A: { score: 50, confidence: 'high', why: long(CAPS['scores.*.why'] + 1) }, B: { score: 50, confidence: 'high', why: long(CAPS['scores.*.why']) } },
+    findings: [{ question: 'custom', answer: 'ok', facts: [{ claim: long(300), url: 'u' }] }] };
+  const v = checkShape(c);
+  assert.deepEqual(v.map((x) => x.split(':')[0]), ['filters."geography".evidence', 'scores."A".why', 'findings[0].facts[0].claim'], 'all three, and the at-cap field passes');
+  assert.throws(() => screen(thesis, { candidates: [c] }), (e) => e instanceof JudgmentsError && /3 field\(s\)/.test(e.message) && /"Verbose": scores."A".why: 161 chars, cap 160/.test(e.message));
+  assert.equal(c.scores.A.why.length, CAPS['scores.*.why'] + 1, 'the input is untouched');
+});
+
+test('fast profile: findings only for custom questions; standard depth accepts all', () => {
+  const opts = { depth: 'fast', standardQuestions: ['company_overview', 'ownership'] };
+  const findings = [{ question: 'company_overview', answer: 'a' }, { question: 'Estimate the revenue mix.', answer: 'b' }, { question: 'ownership', answer: 'c' }];
+  const v = checkShape({ name: 'X', findings }, opts);
+  assert.equal(v.length, 1, 'one line per candidate, not one per finding');
+  assert.match(v[0], /findings: 2 standard-question write-up\(s\) \(company_overview, ownership\)/);
+  assert.deepEqual(checkShape({ name: 'X', findings }, { depth: 'standard', standardQuestions: opts.standardQuestions }), []);
+  assert.deepEqual(checkShape({ name: 'X', findings }), [], 'default depth is standard');
+});
+
+test('universe truncation is computed and surfaced, not silently dropped', async () => {
+  const { markdown } = await import('../lib/render.mjs');
+  const j = { universe: { found: 30, carried_forward: 2, cap: 12 }, candidates: [
+    { name: 'A', segments: { geography: 'S1' }, sources: ['r'], filters: { geography: P, Soft: P }, scores: { A: { score: 80, confidence: 'high' }, B: { score: 80, confidence: 'high' } } },
+    { name: 'B', segments: { geography: 'S1' }, sources: ['r'], filters: { geography: P, Soft: P }, scores: { A: { score: 60, confidence: 'high' }, B: { score: 60, confidence: 'high' } } },
+  ] };
+  const r = screen(thesis, j);
+  assert.deepEqual({ found: r.universe.found, carried: r.universe.carried_forward, truncated: r.universe.truncated }, { found: 30, carried: 2, truncated: 28 });
+  const md = markdown(r);
+  assert.ok(md.includes('Universe truncated'), 'truncation is stated in the brief');
+  assert.ok(md.includes('not a random sample'), 'and says why it matters');
+  assert.ok(md.indexOf('Universe truncated') < md.indexOf('## PASS'), 'above the results it qualifies');
+});
+
+test('no universe block, or no truncation, means no warning', async () => {
+  const { markdown } = await import('../lib/render.mjs');
+  const base = { candidates: [{ name: 'A', segments: { geography: 'S1' }, sources: ['r'], filters: { geography: P, Soft: P }, scores: { A: { score: 80, confidence: 'high' }, B: { score: 80, confidence: 'high' } } }] };
+  assert.equal(screen(thesis, base).universe, null);
+  assert.ok(!markdown(screen(thesis, base)).includes('Universe truncated'));
+  const exact = screen(thesis, { ...base, universe: { found: 1, carried_forward: 1, cap: 12 } });
+  assert.equal(exact.universe.truncated, 0);
+  assert.ok(!markdown(exact).includes('Universe truncated'));
+});
+
+test('judgments load from a directory of per-candidate files', async () => {
+  const { mkdtempSync, writeFileSync, mkdirSync } = await import('node:fs');
+  const os = await import('node:os'); const path = await import('node:path');
+  const { execFileSync } = await import('node:child_process');
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'wn-'));
+  const cdir = path.join(dir, 'candidates'); mkdirSync(cdir);
+  const tfile = path.join(dir, 't.yaml');
+  writeFileSync(tfile, [
+    'acquisition_thesis:', '  name: T',
+    '  hard_filters:', '    geography: { include: [S1] }',
+    '  scored_preferences:', '    criteria:', '      - name: A', '        weight: 100',
+    '        scoring_guidance: { 100: a, 50: b, 0: c }',
+    'research_settings:', '  coverage: { report_by: [geography] }', ''].join('\n'));
+  writeFileSync(path.join(cdir, '_run.json'), JSON.stringify({ run_at: '2026-01-01T00:00:00Z', universe: { found: 9, carried_forward: 2 } }));
+  for (const n of ['a', 'b']) writeFileSync(path.join(cdir, `${n}.json`), JSON.stringify({
+    name: n.toUpperCase(), segments: { geography: 'S1' }, sources: ['r'],
+    filters: { geography: { outcome: 'pass' } }, scores: { A: { score: 70, confidence: 'high' } } }));
+  const out = execFileSync('node', [path.join(process.cwd(), 'winnow.mjs'), 'screen', tfile, cdir, '--format', 'json'], { encoding: 'utf8' });
+  const r = JSON.parse(out);
+  assert.deepEqual(r.counts, { PASS: 2, 'NEAR MISS': 0, FAIL: 0 }, 'both candidate files loaded');
+  assert.equal(r.universe.found, 9, '_run.json supplies top-level fields');
+  assert.equal(r.universe.truncated, 7);
+});
+
+test('confidence is weighted, and the weakest input is carried not hidden', () => {
+  // One thin minor criterion must not drag a well-evidenced case to "low".
+  const crit = [
+    { name: 'Big', weight: 80, normalised: 80 },
+    { name: 'Small', weight: 20, normalised: 20 },
+  ];
+  const r = scoreCompany({ Big: { score: 90, confidence: 'high' }, Small: { score: 50, confidence: 'low' } }, crit, 'neutral');
+  assert.equal(r.confidence, 'high', 'weighted (3*80 + 1*20)/100 = 2.6, above the 2.5 threshold');
+  assert.equal(r.lowestConfidence, 'low', 'and the thin criterion is still reported');
+  // Under the old lowest-wins rule this company read "low" on the strength of
+  // a weight-20 input, which is what this change exists to fix.
+});
+
+test('weighted confidence thresholds', () => {
+  const one = (c) => scoreCompany({ A: { score: 50, confidence: c } }, [{ name: 'A', weight: 100, normalised: 100 }], 'neutral');
+  assert.equal(one('high').confidence, 'high');
+  assert.equal(one('medium').confidence, 'medium');
+  assert.equal(one('low').confidence, 'low');
+  const mixed = scoreCompany(
+    { A: { score: 50, confidence: 'high' }, B: { score: 50, confidence: 'low' } },
+    [{ name: 'A', weight: 50, normalised: 50 }, { name: 'B', weight: 50, normalised: 50 }], 'neutral');
+  assert.equal(mixed.confidence, 'medium', '(3+1)/2 = 2.0 -> medium');
+  assert.equal(mixed.lowestConfidence, 'low', 'weakest input still reported');
+});

--- a/finance/winnow/scripts/test/yaml.test.mjs
+++ b/finance/winnow/scripts/test/yaml.test.mjs
@@ -1,0 +1,91 @@
+// Unit tests for the minimal YAML parser in ../lib/yaml.mjs, which exists so
+// the plugin ships without a YAML dependency. Covers the subset a thesis
+// actually uses: scalar typing, nested maps and lists, numeric keys kept as
+// strings (the scoring anchors), folded and literal blocks, comment
+// stripping, flow mappings, and line numbers on errors. The differential
+// test parses the example thesis with the reference `yaml` package and
+// asserts both produce the same object.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { parse, YamlError } from '../lib/yaml.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const example = path.join(here, '..', '..', 'theses', 'example-fencing.yaml');
+
+test('scalars type correctly', () => {
+  assert.deepEqual(parse('a: 1\nb: 0.5\nc: true\nd: ~\ne:\nf: "x: y"\ng: hello world'),
+    { a: 1, b: 0.5, c: true, d: null, e: null, f: 'x: y', g: 'hello world' });
+});
+
+test('nested maps, lists of scalars, lists of maps', () => {
+  const doc = parse(`
+top:
+  list:
+    - one
+    - two
+  items:
+    - name: a
+      weight: 1
+    - name: b
+      weight: 2
+  inline: [x, y]
+`);
+  assert.deepEqual(doc, { top: { list: ['one', 'two'], items: [{ name: 'a', weight: 1 }, { name: 'b', weight: 2 }], inline: ['x', 'y'] } });
+});
+
+test('numeric keys survive as strings (scoring anchors)', () => {
+  assert.deepEqual(parse('g:\n  100: best\n  50: mid\n  0: worst'), { g: { 100: 'best', 50: 'mid', 0: 'worst' } });
+});
+
+test('folded and literal blocks', () => {
+  const doc = parse('a: >\n  one\n  two\n\n  three\nb: |\n  l1\n  l2\nc: x');
+  assert.equal(doc.a, 'one two\nthree\n');
+  assert.equal(doc.b, 'l1\nl2\n');
+  assert.equal(doc.c, 'x');
+});
+
+test('comments are stripped, including trailing ones, but not inside quotes', () => {
+  assert.deepEqual(parse('# head\na: 1 # trailing\nb: "keep # this"\n# tail'), { a: 1, b: 'keep # this' });
+});
+
+test('errors carry line numbers', () => {
+  assert.throws(() => parse('a: 1\na: 2'), (e) => e instanceof YamlError && e.line === 2);
+  assert.throws(() => parse('a: &anchor\n  b: 1\nc: *anchor'), YamlError);
+});
+
+test('differential: example thesis parses identically to the reference yaml package', (t) => {
+  // Differential test: our subset parser must agree with a real YAML parser on
+  // the shipped theses. The reference package is not a dependency -- this test
+  // skips wherever it is not resolvable, which includes the agent container.
+  let ref;
+  try {
+    ref = createRequire(import.meta.url)('yaml');
+  } catch {
+    try {
+      ref = createRequire(path.join(process.env.NODE_YAML_REF ?? '/nonexistent', 'package.json'))('yaml');
+    } catch { t.skip('no reference yaml package resolvable; set NODE_YAML_REF to enable'); return; }
+  }
+  const text = readFileSync(example, 'utf8');
+  assert.deepEqual(parse(text), ref.parse(text));
+});
+
+test('single-line flow mappings, as the schema doc writes them', () => {
+  assert.deepEqual(parse('a: { min: 0, max: 100 }'), { a: { min: 0, max: 100 } });
+  assert.deepEqual(parse('a: { include: [], exclude: [] }'), { a: { include: [], exclude: [] } });
+  assert.deepEqual(parse('a: { formats: [csv, json] }'), { a: { formats: ['csv', 'json'] } });
+  assert.deepEqual(parse('a: {}'), { a: {} });
+});
+
+test('flow splitting respects nesting and quotes', () => {
+  assert.deepEqual(parse('a: { x: [1, 2], y: 3 }'), { a: { x: [1, 2], y: 3 } });
+  assert.deepEqual(parse('a: ["x, y", z]'), { a: ['x, y', 'z'] });
+});
+
+test('malformed flow collections fail with a line number', () => {
+  assert.throws(() => parse('a: { b: 1'), (e) => e instanceof YamlError && e.line === 1);
+  assert.throws(() => parse('a: { b }'), YamlError);
+});

--- a/finance/winnow/scripts/winnow.mjs
+++ b/finance/winnow/scripts/winnow.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// winnow -- the deterministic half of the screening pipeline.
+//
+//   node winnow.mjs init-run     <thesis.yaml> --data <PLUGIN_DATA>
+//   node winnow.mjs set-universe <run-dir> --from universe.json       (the script applies caps and writes stubs)
+//   node winnow.mjs set-universe <run-dir> --found N --carried M [--cap C]
+//   node winnow.mjs status       <run-dir>
+//   node winnow.mjs validate     <thesis.yaml>
+//   node winnow.mjs screen   <thesis.yaml> <judgments.json|dir/> [--out <dir>] [--format md|csv|json]
+//
+// The judgments argument may be a single file, or a DIRECTORY of per-candidate
+// files written as research completes (plus an optional _run.json for
+// top-level fields). The directory form keeps evidence out of the agent's
+// context, so a long run survives compaction.
+//
+// The model produces judgments (filter outcomes, criterion scores, evidence).
+// This script does everything that follows: bands, weighted scores, ranking,
+// coverage, priority flags, and rendering. It never exercises judgment.
+import { readFileSync, writeFileSync, mkdirSync, statSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { loadThesis, filterList, settings, ThesisError } from './lib/thesis.mjs';
+import { initRun, setUniverse, applyUniverse, runStatus, checkRun, shadowWarning, RunError } from './lib/run.mjs';
+import { screen, JudgmentsError } from './lib/screen.mjs';
+import { markdown, csv, json } from './lib/render.mjs';
+
+const argv = process.argv.slice(2);
+const cmd = argv[0];
+const opt = (name) => { const i = argv.indexOf(name); return i === -1 ? null : argv[i + 1]; };
+const positional = argv.slice(1).filter((a, i, arr) => !a.startsWith('--') && !(i > 0 && arr[i - 1].startsWith('--')));
+
+/**
+ * Judgments come from either one file, or a directory of per-candidate files
+ * written incrementally during research. The directory form keeps evidence on
+ * disk instead of in the agent's context, which is what makes a long run
+ * survivable: nothing is lost to a context compaction, and a crashed run
+ * resumes from what is already written.
+ *
+ * In a directory, `_run.json` (optional) supplies top-level fields such as
+ * `run_at` and `universe`; every other *.json is one candidate.
+ */
+function loadJudgments(target) {
+  if (!statSync(target).isDirectory()) return JSON.parse(readFileSync(target, 'utf8'));
+  const files = readdirSync(target).filter((f) => f.endsWith('.json')).sort();
+  let head = {};
+  const candidates = [];
+  for (const f of files) {
+    const doc = JSON.parse(readFileSync(path.join(target, f), 'utf8'));
+    if (f === '_run.json') { head = doc; continue; }
+    // A per-candidate file is one candidate; a bundle is {candidates:[...]}.
+    if (Array.isArray(doc.candidates)) candidates.push(...doc.candidates);
+    else candidates.push(doc);
+  }
+  if (candidates.length === 0) throw new Error(`no candidate files in ${target}`);
+  return { ...head, candidates };
+}
+
+function die(msg, code = 2) { process.stderr.write(msg.endsWith('\n') ? msg : msg + '\n'); process.exit(code); }
+
+try {
+  if (cmd === 'validate') {
+    const file = positional[0] ?? die('usage: winnow validate <thesis.yaml>');
+    const { thesis, warnings } = loadThesis(file);
+    for (const w of warnings) process.stderr.write(`warning: ${w}\n`);
+    const at = thesis.acquisition_thesis;
+    process.stdout.write(`OK: "${at.name}" — ${at.scored_preferences.criteria.length} criteria, ${(at.hard_filters?.other ?? []).filter((o) => o.revisitable).length} revisitable filter(s)\n`);
+  } else if (cmd === 'screen') {
+    const [tf, jf] = positional;
+    if (!tf || !jf) die('usage: winnow screen <thesis.yaml> <judgments.json|dir/> [--out <dir>] [--format md|csv|json]');
+    const { thesis, warnings } = loadThesis(tf);
+    for (const w of warnings) process.stderr.write(`warning: ${w}\n`);
+    // Deterministic gate: the thesis must not have changed under the evidence,
+    // and the evidence must be as complete as the universe stage said it was.
+    let runWarnings = [];
+    try {
+      if (statSync(jf).isDirectory()) runWarnings = checkRun(jf, tf, { force: argv.includes('--force') });
+    } catch (e) {
+      if (e instanceof RunError) die(`run not screenable — ${e.message}`, 5);
+      throw e;
+    }
+    for (const w of runWarnings) process.stderr.write(`warning: ${w}\n`);
+    let judgments;
+    try { judgments = loadJudgments(jf); } catch (e) { die(`${jf}: ${e.message}`); }
+    const result = screen(thesis, judgments);
+    const out = opt('--out');
+    if (out) {
+      mkdirSync(out, { recursive: true });
+      const fmts = result.settings.output.formats;
+      writeFileSync(path.join(out, 'brief.md'), markdown(result));
+      if (fmts.includes('csv')) writeFileSync(path.join(out, 'screen.csv'), csv(result));
+      if (fmts.includes('json')) writeFileSync(path.join(out, 'screen.json'), json(result));
+      process.stdout.write(`${result.counts.PASS} pass · ${result.counts['NEAR MISS']} near miss · ${result.counts.FAIL} fail  →  ${out}/\n`);
+    } else {
+      const f = opt('--format') ?? 'md';
+      process.stdout.write(f === 'csv' ? csv(result) : f === 'json' ? json(result) : markdown(result));
+    }
+  } else if (cmd === 'init-run') {
+    const tf = positional[0] ?? die('usage: winnow init-run <thesis.yaml> --data <PLUGIN_DATA>');
+    const data = opt('--data') ?? die('init-run needs --data <PLUGIN_DATA>');
+    loadThesis(tf); // refuse to open a run against a thesis that does not validate
+    const shadow = shadowWarning(tf, opt('--plugin-root') ?? process.env.PLUGIN_ROOT);
+    if (shadow) process.stderr.write(`warning: ${shadow}\n`);
+    const { dir, candidates } = initRun(tf, data);
+    process.stdout.write(
+      `run: ${dir}\ncandidates: ${candidates}\n\n` +
+      `Write one JSON file per candidate into the candidates directory as you finish it.\n` +
+      `Then: winnow set-universe ${candidates} --found <n> --carried <n>\n` +
+      `Then: winnow screen ${tf} ${candidates} --out ${dir}\n`);
+  } else if (cmd === 'set-universe' && opt('--from')) {
+    const dir = positional[0] ?? die('usage: winnow set-universe <candidates-dir> --from <universe.json>');
+    const meta = JSON.parse(readFileSync(path.join(dir, '_run.json'), 'utf8'));
+    const { thesis } = loadThesis(meta.thesis);
+    const cfg = settings(thesis);
+    const r = applyUniverse(dir, opt('--from'), thesis, { filters: filterList(thesis), declaredSegments: cfg.declaredSegments, limits: cfg.limits });
+    process.stdout.write(`universe: ${r.found} found · ${r.fails.length} dropped by firm filters · ${r.carried.length} carried · ${r.research.length} to research · ${r.uncarried.length} past the cap\n`);
+    if (r.fails.length) process.stdout.write(`dropped: ${r.fails.map((x) => `${x.name} (${x.fail.filter})`).join('; ')}\n`);
+    process.stdout.write(`\nResearch these ${r.research.length}, one subagent each, at most four at a time. Each writes exactly the file named:\n`);
+    for (const c of r.research) process.stdout.write(`- ${c.name} | ${c.url} | ${c.location} | ${c.segment} | ${c.source} | ${c.note}\n  → ${c.file}\n`);
+    process.stdout.write(`\nThen: winnow screen ${meta.thesis} ${dir} --out ${path.dirname(dir)}\n`);
+  } else if (cmd === 'set-universe') {
+    const dir = positional[0] ?? die('usage: winnow set-universe <candidates-dir> --found N --carried M');
+    const int = (v) => (v === null || v === undefined ? undefined : Number.parseInt(v, 10));
+    const u = setUniverse(dir, { found: int(opt('--found')), carried: int(opt('--carried')), cap: int(opt('--cap')), note: opt('--note') });
+    process.stdout.write(`universe recorded: ${u.carried_forward} carried forward` +
+      (u.found != null ? ` of ${u.found} found` : '') + '\n');
+  } else if (cmd === 'status') {
+    const dir = positional[0] ?? die('usage: winnow status <candidates-dir>');
+    const st = runStatus(dir);
+    process.stdout.write(
+      `thesis:     ${st.meta.thesis ?? '(unknown)'}\n` +
+      `started:    ${st.meta.started_at ?? '(unknown)'}` + (st.ageHours != null ? `  (${Math.round(st.ageHours)}h ago)` : '') + '\n' +
+      `written:    ${st.written}${st.expected !== null ? ` of ${st.expected} carried forward` : ' (universe not recorded yet)'}\n` +
+      (st.files.length ? `files:      ${st.files.join(', ')}\n` : ''));
+    if (st.expected !== null && st.written < st.expected) {
+      process.stdout.write(`\nincomplete: ${st.expected - st.written} candidate(s) still to research.\n`);
+    }
+  } else {
+    die('usage:\n' +
+        '  winnow init-run     <thesis.yaml> --data <PLUGIN_DATA>\n' +
+        '  winnow set-universe <candidates-dir> --found N --carried M [--cap C] [--note ...]\n' +
+        '  winnow status       <candidates-dir>\n' +
+        '  winnow validate     <thesis.yaml>\n' +
+        '  winnow screen       <thesis.yaml> <judgments.json|dir/> [--out <dir>] [--format md|csv|json] [--force]');
+  }
+} catch (e) {
+  if (e instanceof ThesisError) die(`thesis invalid — ${e.message}`, 3);
+  if (e instanceof JudgmentsError) die(`judgments invalid — ${e.message}`, 4);
+  if (e instanceof RunError) die(`run error — ${e.message}`, 5);
+  throw e;
+}

--- a/finance/winnow/skills/build-universe/SKILL.md
+++ b/finance/winnow/skills/build-universe/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: build-universe
+description: Build a candidate list from a screening thesis using web search. Use when the user asks to find or source targets, build a target universe, generate a candidate list, or start a screen from a thesis that has no candidates yet.
+---
+
+# Build the universe
+
+Turn a thesis into a deduplicated list of candidate companies. Broad and
+cheap — qualification happens later. Missing a real candidate here cannot be
+recovered downstream, so favour recall over precision.
+
+## Two capability tiers
+
+The `tavily` MCP server works with or without an API key, and the difference
+decides your strategy:
+
+| Tier | Tools | What it can do |
+|---|---|---|
+| **Keyless** (no key configured) | `tavily_search`, `tavily_extract` | Search and read. Recall is whatever the index surfaces. |
+| **Keyed** (key in the credentials proxy) | adds `tavily_map`, `tavily_crawl`, `tavily_research` | **Enumerate** a known source rather than searching it. |
+
+Build the base universe with search so an unconfigured install still works.
+Then, if `tavily_map` or `tavily_crawl` are available, enumerate the
+registries the thesis names — that is how coverage gaps get closed, and it is
+not something search can do.
+
+Say which tier you ran in. A keyless run has systematically weaker recall,
+and the coverage report should not imply otherwise.
+
+## Search
+
+**The plan is small and fixed: one query per declared segment, plus two
+adjacency queries, and nothing else.** For each segment in
+`hard_filters.geography.include`, one search of the form
+`<first industry term> <segment>`. Then two adjacency queries across the
+whole region using the trade's neighbouring names — the capability under
+another name, as the thesis's industry terms suggest. A five-segment thesis
+is seven searches. Do not add sub-region, directory, registry, procurement
+or press passes; a run is minutes, not an afternoon, and the coverage report
+will say what the seven did not reach.
+
+Every search: `search_depth: "advanced"` (the default `basic` returns
+glossary pages for generic terms), `max_results: 8`, no
+`include_raw_content`, and the thesis's `source_preferences.domains.exclude`
+as `exclude_domains`. `domains.include` is for a targeted pass at one known
+source only — on a sweep it silently collapses recall.
+
+### The sweep writes `universe.json`; the script does the rest
+
+Whoever runs the sweep — you in standard mode, a subagent in fast mode —
+writes its findings to **`<run dir>/universe.json`** and nothing else goes
+in your context:
+
+```json
+{ "tier": "keyless", "queries": ["<every query actually run>"],
+  "candidates": [
+    { "name": "Acme Co", "url": "https://acme.example", "location": "City, ST",
+      "segment": "<one of the declared segments, spelled exactly>",
+      "source": "<stable source label>", "note": "<one line, ≤200 chars>",
+      "fail": { "filter": "geography", "evidence": "HQ in Texas" } } ] }
+```
+
+`fail` is optional and only for a **firm** filter the search result already
+settles — an out-of-region headquarters, an explicit "private-equity backed"
+line. Never for a revisitable filter, never on a guess.
+
+Then one command does everything that used to be judgment-adjacent
+arithmetic — dedup on domain then name, segment validation, the firm-filter
+drops, the `initial_universe` cap taken round-robin across declared segments
+so every segment is represented, `deep_research_limit`, the stub files for
+candidates that will not be researched, and the universe block:
+
+```bash
+node ${PLUGIN_ROOT}/scripts/winnow.mjs set-universe <candidates-dir> --from <run dir>/universe.json
+```
+
+It prints the rows to research and the exact file each one must be written
+to. **Do not curate the table yourself, do not write stub files yourself,
+and do not read earlier runs** — the caps are enforced by the script and
+cannot be exceeded from your side.
+
+### Fast mode — delegate the sweep
+
+When `research_settings.execution.mode` is `fast`, do not run the searches
+yourself. Open the run, plan the queries as above, then hand the sweep to
+one subagent (the `Agent` tool, general-purpose) whose brief carries:
+
+- the run directory and the `universe.json` shape above, verbatim
+- the full query list, numbered, with `search_depth: "advanced"`,
+  `max_results: 8`, and the thesis's `exclude_domains` spelled out — **one
+  search per query, then stop**; it re-derives nothing and adds nothing
+- the declared segments, spelled exactly, and the firm filter names
+- what to return: the count of candidates written, and one line naming the
+  Tavily tier — **keyless unless a `tavily_map` or `tavily_crawl` call
+  actually succeeded**; those tools being listed proves nothing, the server
+  gates them at call time. Nothing else — no table, no excerpts.
+
+Then run `set-universe --from` as above and hand its rows to
+`research-target`.
+
+When the sweep is done, record what it found — this is what makes
+completeness checkable later:
+
+```bash
+node ${PLUGIN_ROOT}/scripts/winnow.mjs set-universe <candidates-dir> \
+  --found <total found> --carried <carried forward> [--cap <limit>]
+```
+
+`screen` refuses to run if fewer judgment files exist than `--carried`, so a
+run cannot be silently screened half-finished.
+
+## Track coverage as you go
+
+Record, for every candidate, **which source produced it** and **which
+declared segment it belongs to**. You cannot reconstruct this afterwards,
+and the whole coverage report depends on it.
+
+These land in `judgments.json` as each candidate's `sources` and `segments`
+(see `../screen-target/references/judgments-format.md`). Use one stable
+label per source across the whole run — "state licensing registry" every
+time, not a fresh phrasing — because the tally groups on the string. The
+script computes the coverage table; you do not tally it by hand.
+
+## Record
+
+For each candidate capture only: name, website, headquarters location, and
+where you found it. Nothing else — deeper facts are `research-target`'s job
+and cost real money here.
+
+Deduplicate on domain, then on name. Keep DBAs and subsidiaries as separate
+rows flagged as possible duplicates; let `screen-target` resolve them.
+
+## Cheap filtering
+
+Apply hard filters that the universe data already answers — geography and
+obvious industry mismatches. Drop those to FAIL now, with the reason, before
+research spends anything on them.
+
+Do not guess at filters the universe data cannot answer. An unresolved
+filter goes forward and is settled during research.
+
+## Limits — a runtime dial, reported as a coverage event
+
+`research_settings.target_limits.initial_universe` bounds runtime and API
+spend. It says nothing about the thesis: a candidate dropped by the cap was
+not judged and did not fail, it was merely past the line when the budget ran
+out.
+
+Stop at the cap, then **record both numbers** in the judgments file:
+
+```json
+"universe": { "found": 30, "carried_forward": 12, "cap": 12 }
+```
+
+The script states the gap above the results. Say the same in your report, and
+ask whether to raise the cap.
+
+Never silently truncate. The discarded remainder is not a random sample — it
+is whatever the search ordered last, which tracks web presence rather than
+fit, so a bitten cap distorts the funnel in exactly the direction the coverage
+report exists to expose.
+
+## Coverage — report it, always
+
+**Not finding candidates in a segment is not evidence that the segment is
+empty.** It is equally likely that nothing there is indexed the way you
+searched. This is the universe-level form of the rule in
+`evidence-policy.md`, and it is the easiest way for a screen to be
+confidently wrong: one well-indexed source quietly redefines the market, and
+the funnel looks authoritative because a lot of arithmetic sits on top of it.
+
+The script renders this table at the top of the brief, from the `sources`
+and `segments` you recorded:
+
+```
+Coverage · 9 declared segments
+  segment     candidates   sources (top contributor)
+  Segment A           26   association member roster (25)   ⚠ single source 96%
+  Segment B            6   4 sources
+  Segment C            0   no source answered               ⚠ no coverage
+```
+
+Raise two flags:
+
+- **Single-source dominance** — one source supplies more than
+  `coverage.single_source_threshold` of a segment. The segment maps that
+  source's reach, not the market.
+- **Empty segment** — a declared segment returned nothing, and
+  `coverage.flag_empty_segments` is true. Say which sources were tried.
+
+State plainly what a flag means for the result: *"the geographic spread of
+this funnel is unproven; it largely reflects which bodies publish member
+rosters."* Never present a concentrated funnel as a market finding.
+
+## Report
+
+State the count found, the count dropped by cheap filters, and the count
+carried forward, then the coverage table. List the queries you ran so the
+user can see what was and was not covered.

--- a/finance/winnow/skills/define-thesis/SKILL.md
+++ b/finance/winnow/skills/define-thesis/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: define-thesis
+description: Interview the user and write a screening thesis file. Use when the user wants to start a new screen, set up acquisition criteria, define what they are looking for, change an existing screen's criteria, or when a screening request arrives with no active thesis.
+---
+
+# Define a thesis
+
+Produce a thesis YAML at `${PLUGIN_DATA}/theses/<slug>.yaml`. The schema is
+`../screen-target/references/thesis-schema.md` — read it first.
+
+Never write a thesis silently from conversation. Walk the steps, then show
+the interpretation back before anything runs.
+
+## Steps
+
+**1 — The shape of the search.** What kind of company, what geography,
+platform or add-on, rough size, obvious exclusions. Enough for a first draft.
+
+**2 — Sort every criterion.** For each thing the user named, ask the
+disqualification question in plain words:
+
+> "If a company fails this, is it out — or is it just less attractive?"
+
+Out → `hard_filters`. Less attractive → `scored_preferences`. Neither, but
+they want it determined → `research_questions`.
+
+**3 — Find the revisitable filters.** For each hard filter, ask:
+
+> "If a company failed only this one, would you want to see it anyway?"
+
+Yes → `revisitable: true`. Expect one or two. A screen with none is usually
+a screen where someone has not admitted which rule they would bend. A screen
+where everything is revisitable has no filters at all — push back.
+
+**4 — Draft the scoring rubric.** Propose criteria, weights, and 100/50/0
+anchors. The user edits; they should never build it from scratch. Check for
+double-counting against revisitable filters: the filter sets the band, the
+preference orders within it.
+
+**5 — Research questions.** Ask what they would want an analyst to determine
+about every company even when it decides nothing. This is where the unusual
+diligence questions go. For anything where absence of evidence is likely,
+write the evidence guidance to say so explicitly.
+
+**6 — Depth and limits.** `fast` / `standard` / `deep`, universe size, and
+deep-research cap. Say what each will cost in time.
+
+**7 — Output preferences.** Which of the ranked table, briefs, failure
+reasons, score breakdown, confidence, citations, and exports they want.
+
+**8 — Interpretation, read back.** Before writing the file, state the thesis
+in plain language:
+
+> "I will include X, exclude Y — treating Z as revisitable — rank survivors
+> on A, B, C, and investigate D and E for every company."
+
+Correct whatever they push back on. This step catches more errors than the
+rest combined.
+
+**9 — Test run.** Screen 3–5 companies the user already has an opinion
+about. Show band, findings, score, confidence, and reasoning for each. Ask
+whether the calls match their judgement. Adjust the thesis, not the output.
+
+Only then offer the full universe run.
+
+## Writing the file
+
+Write to `${PLUGIN_DATA}/theses/<slug>.yaml`, creating the directory if
+needed. Never write into `${PLUGIN_ROOT}` — it is read-only.
+
+Comment the file as you write it. Record *why* a filter is revisitable and
+why a question is a question rather than a filter; a thesis reread in three
+weeks needs its reasoning attached. `${PLUGIN_ROOT}/theses/example-fencing.yaml`
+shows the commenting style.
+
+**Only copy a thesis you intend to edit.** A shipped thesis under
+`${PLUGIN_ROOT}/theses/` can be run directly — nothing writes to it. A copy
+under `${PLUGIN_DATA}` is not updated when the template is, so an unnecessary
+copy silently keeps running an old screen after an update. `init-run` reports
+it when a copy shadows a shipped thesis that differs, but the cheaper fix is
+not to copy in the first place.
+
+To start from an example you *do* want to change, copy it into
+`${PLUGIN_DATA}/theses/` first, then edit the copy.
+
+## Validate before anything runs
+
+```bash
+node ${PLUGIN_ROOT}/scripts/winnow.mjs validate ${PLUGIN_DATA}/theses/<slug>.yaml
+```
+
+It checks structure — every criterion has a positive weight and 100/50/0
+anchors, `revisitable` is a boolean, `coverage.report_by` names a filter
+with an `include` list, enums are spelled right — and warns if weights do
+not sum to 100. Run it every time you write or edit a thesis, and show the
+user the result. A thesis that fails validation is not active.
+
+The parser accepts a deliberate YAML subset (see `thesis-schema.md`). Write
+plain nested maps and lists; avoid anchors, aliases and flow mappings.

--- a/finance/winnow/skills/produce-brief/SKILL.md
+++ b/finance/winnow/skills/produce-brief/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: produce-brief
+description: Produce the ranked table, per-target briefs, and CSV/JSON export from a completed screen. Use when the user asks for screen results, a shortlist, a ranked table, target briefs, a summary of findings, or an export.
+---
+
+# Produce the brief
+
+The deliverable. Someone must be able to read it and see why every company
+landed where it did.
+
+**The brief is generated, not written.** `winnow.mjs screen --out <dir>`
+produces `brief.md`, `screen.csv` and `screen.json` from the judgments file.
+Your job is to present `brief.md` faithfully and add the one-paragraph
+reading of it — what the counts, the coverage flags and the near-miss band
+mean for the user's decision. Never retype a number; quote the file. If a
+number looks wrong, the fix is in `judgments.json`, re-run the script.
+
+The sections below describe what the generated brief contains and why, so
+you can explain it. The thesis's `output` block controls which sections
+appear.
+
+## Counts first
+
+Open with one line, before anything else:
+
+```
+14 pass · 6 near miss · 20 fail    —  <thesis name>
+```
+
+## Coverage, before the results
+
+When `output.show_coverage_report` is true, the coverage table comes second,
+immediately after the counts and before the ranked table. It qualifies
+everything below it, so it cannot be an appendix.
+
+```
+Coverage · 9 declared segments
+  Segment A   26 candidates · association member roster (25)   ⚠ single source 96%
+  Segment C    0 candidates · no source answered               ⚠ no coverage
+```
+
+Where a flag is raised, say in one line what it means for the result — for
+example that the geographic spread is unproven and largely reflects which
+bodies publish member rosters. A reader who takes a concentrated funnel for a
+market map will draw the wrong conclusion, and the table alone will not stop
+them.
+
+## Ranked table (PASS)
+
+| # | Company | Score | Confidence | Location | Scale | Why |
+|---|---|---|---|---|---|---|
+
+`Why` is one clause naming the strongest evidence — not a restatement of the
+score. Mark priority entries.
+
+## Near miss band
+
+Separate, below PASS, never merged into it. Each row names the filter it
+failed or could not resolve, and what would settle it:
+
+| Company | Score | Filter | Status | What would settle it |
+|---|---|---|---|---|
+
+This band is the point of the format. It is where a firm-but-negotiable
+criterion shows the user what it costs — three companies that failed only on
+a rule the user said they would revisit is a decision they now get to make
+with the evidence in front of them, rather than one made silently by a
+filter.
+
+## Fail list
+
+Compact — company, the filter it failed, one line of evidence. It exists so
+the user can audit the filter, so a wrongly-excluded company is visible.
+
+## Per-target briefs
+
+For each PASS and NEAR MISS:
+
+```
+## <Company>  ·  <score>/100  ·  <band>
+<url> · <location>
+
+Score breakdown
+  <criterion>  <score>  (weight <n>)  <one line of reasoning>  [confidence]
+
+Findings
+  <question>: <answer>  [confidence]
+    fact: <claim> — <url>
+    inference: <claim> — from <basis>
+
+Open questions
+  <question> — <what would settle it>
+```
+
+Never merge fact and inference. Never drop the open questions section — an
+empty one says the screen was thorough; a missing one says nothing.
+
+## Export
+
+`--out` writes `screen.csv` (one row per company: rank, band, priority,
+score, confidence, every criterion score, band reasons) and `screen.json`
+(the full evidence tree with citations) alongside `brief.md`. Both carry the
+thesis name and run timestamp — a shortlist without the thesis that produced
+it cannot be interpreted six weeks later. Tell the user where they are.
+
+## Tone
+
+Report, do not sell. The user is deciding where to spend real time and
+money; overstated confidence costs them more than a hedge does. Where the
+evidence is thin, say so in the brief rather than in a footnote.

--- a/finance/winnow/skills/research-target/SKILL.md
+++ b/finance/winnow/skills/research-target/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: research-target
+description: Gather cited evidence about one company against a thesis's research questions. Use when researching, investigating, enriching, or gathering evidence on a specific company or target, or when a screen needs facts before it can score.
+---
+
+# Research a target
+
+Answer the thesis's research questions for one company, with a citation for
+every claim. Read `../screen-target/references/evidence-policy.md` first —
+it governs everything here.
+
+## Fast mode — one subagent per candidate
+
+When `research_settings.execution.mode` is `fast`, you do not research
+candidates yourself. For each carried-forward candidate that has not firmly
+failed, launch one subagent (the `Agent` tool, general-purpose), **at most
+four in flight at once**: four in one message, wait for all four, then the
+next four. More than four has not been measured against the keyless Tavily
+rate cap; if any subagent reports a rate-limit error, drop to two.
+
+Each subagent's brief carries everything it needs, so it reads nothing you
+did not name:
+
+- the candidate's row exactly as `set-universe --from` printed it — name,
+  url, location, segment, source label, note — and the file path it printed
+- the thesis path, and the paths of this skill,
+  `../screen-target/references/evidence-policy.md` and
+  `../screen-target/references/judgments-format.md`; it reads and follows
+  them, including the depth profile and the length caps
+- the exact file to write: `<candidates dir>/<slug>.json`, one candidate
+  entry in the judgments shape, filters and scores included, written before
+  it returns
+- what to return to you, at most ten lines: each filter's outcome, each
+  criterion's score with its confidence and `why`, and any open question.
+  **Not the evidence.** The file holds the evidence; your context does not
+  need it.
+
+Delegation puts one thing at risk: `screen-target` says to score one
+criterion across all companies, and a subagent sees one company. So every
+subagent scores from the same anchors, and when all digests are in you do
+the cross-company pass yourself before running the script — for each
+criterion, read the scores down the column, and where two companies with
+comparable evidence sit far apart, `Edit` the score in the file it belongs
+to and say so in the brief. Ten lines per company; it is cheap, and it is
+what keeps a fast run's ranking as trustworthy as a standard run's.
+
+A subagent that returns without writing its file, or whose file the script
+rejects, is re-run with the script's message. Never write the file for it
+from the digest — the digest has no evidence in it.
+
+In standard mode, everything below is yours to do directly.
+
+## Fire the whole company's lookups in one go
+
+**Issue every call for a company in a single batch, not one after another.**
+You already know what you need before you start: the company's own site, the
+registries the thesis names, procurement records, press. Nothing about the
+second lookup depends on the first, so waiting for each in turn adds a full
+round trip per source and is the single largest cost in a run.
+
+One batch per company, then read the results together, then write the file.
+A second batch only when the first genuinely left a question open — not as a
+matter of routine.
+
+## What to ask for
+
+Cheapest and most authoritative first:
+
+1. The company's own site — services, projects, about, careers, leadership.
+2. Licensing and professional registries, corporate filings.
+3. Public procurement, bid tabulations, contract awards.
+4. Trade and local press.
+5. Sector-specific sources named in `source_preferences.preferred`.
+
+Use `tavily_search` to locate and `tavily_extract` to read — and note that
+`tavily_extract` accepts **several URLs in one call**, so extract the whole
+candidate set of pages together rather than one at a time. A search snippet
+is a pointer, not a source: extract before concluding. Stop when the questions
+are answered to `research_settings.evidence.minimum_confidence`, not when
+sources are exhausted.
+
+**Always pass `query` to `tavily_extract`** — the research questions you are
+answering, in a sentence. With a query the extract returns the relevant
+passages (about 5KB); without one it returns the whole page (20–35KB), and a
+batch of those forces a context compaction that costs more time than the
+research did. For the same reason, locating searches use `max_results: 5`
+and never `include_raw_content` — the extract is where you read.
+
+Two parameters do real work here:
+
+- **`include_domains`** — when you are checking one specific claim against
+  one known source ("is this company on that registry?"), scope the search to
+  that domain. It turns a hopeful query into a direct lookup.
+- **`exclude_domains`** — apply `source_preferences.domains.exclude` on every
+  search, so excluded aggregators never become the evidence for a claim.
+
+On the keyed tier, `tavily_crawl` over a single company's own site with
+`instructions` naming what you need (project portfolio, certifications,
+leadership) reads the whole site in one call instead of guessing URLs.
+
+## Answer every question
+
+Work through `research_questions.standard` and `.custom`. For each: the
+answer, the evidence, the source URL, and a confidence. An unanswered
+question is reported as unanswered — never skipped and never quietly
+softened into a guess.
+
+Honour each question's `evidence_guidance`. When it says not to infer from
+absence, that instruction outranks your urge to give a clean answer.
+
+## Resolve outstanding filters
+
+Settle any hard filter the universe pass could not answer. Say plainly which
+way it resolved, or that it could not be resolved and what would settle it.
+
+## Depth
+
+- `fast` — the company's own site plus one corroborating source.
+- `standard` — the site, one registry or public record, and press.
+- `deep` — all of the above, plus procurement history, hiring signals, and
+  corroboration of every high-importance question from a second source.
+
+## Write each candidate to disk before starting the next
+
+**Finish a company, write its file, move on.** One JSON file per candidate,
+into the `candidates/` directory that `winnow.mjs init-run` printed — never a
+path you chose yourself:
+
+```
+${PLUGIN_DATA}/runs/<timestamp>/candidates/
+  _run.json              # optional: run_at, universe { found, carried_forward, cap }
+  acme-industrial.json   # one candidate, the shape below
+  northgate-holdings.json
+```
+
+This is not tidiness. Evidence held in your context is lost when the context
+compacts, and a long run compacts several times — carrying twenty companies'
+research in your head is how a run silently forgets its own citations. Writing
+as you go also means a run that dies halfway resumes from what is on disk
+instead of starting over.
+
+`screen-target` points the script at the directory; it merges the files.
+
+## Output
+
+Each file is one candidate entry — the format is
+`../screen-target/references/judgments-format.md`. Keep this shape while you
+work so nothing is lost in translation:
+
+```
+Company · URL
+Filters resolved: <filter> → pass | fail | unresolved (why)
+Findings:
+  <question>: <answer>  [confidence: high|medium|low]
+    fact: <what a source states>  — <url>
+    inference: <what you concluded>  — from <what>
+Unanswered: <question> — <what would settle it>
+```
+
+Never merge fact and inference into one line.

--- a/finance/winnow/skills/screen-target/SKILL.md
+++ b/finance/winnow/skills/screen-target/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: screen-target
+description: Apply a thesis's hard filters, assign pass/near-miss/fail bands, score preferences, and rank. Use when screening, filtering, qualifying, scoring, or ranking companies against acquisition or screening criteria.
+---
+
+# Screen and rank
+
+Turn researched candidates into three banded, ordered lists. Read
+`references/thesis-schema.md` for the schema, `references/evidence-policy.md`
+for what counts as evidence, `references/scoring-methodology.md` for how the
+anchors are read, and `references/judgments-format.md` for the file you write.
+
+## Division of labour — read this first
+
+You make **judgments**. A script does **arithmetic**. Never the reverse.
+
+- You decide, per company and per filter: `pass`, `fail`, or `unresolved`,
+  with the evidence and its URL.
+- You decide, per company and per criterion: a 0–100 against the anchors, a
+  confidence, and one clause of why — or `null` when there is no evidence.
+- You write those to disk **as each company completes**, one file per
+  candidate (format in `references/judgments-format.md`). Never accumulate a
+  whole run's evidence in context — it does not survive compaction.
+- Then you run **`node ${PLUGIN_ROOT}/scripts/winnow.mjs screen`**, which
+  assigns bands, normalises weights, computes totals, ranks within bands,
+  tallies coverage, flags priority, and writes the brief, CSV and JSON.
+
+Do not compute a total, assign a band, tally coverage, or hand-build the
+ranked table yourself. Those are deterministic, the script is tested, and a
+model doing them across forty companies will drift. If the script rejects the
+file it names the company and field — fix the judgment, never work around it.
+
+## 1 — Filter outcomes (yours) → bands (the script's)
+
+Evaluate every hard filter for each company and record `pass`, `fail` or
+`unresolved` with evidence. The script then applies:
+
+| Condition | Band |
+|---|---|
+| Cleared every filter | **PASS** |
+| Failed only `revisitable: true` filters | **NEAR MISS** |
+| One or more filters unresolved, none firmly failed | **NEAR MISS** |
+| Failed any filter without `revisitable: true` | **FAIL** |
+
+A firm failure outranks everything: fail one firm filter and one revisitable
+filter, the company is FAIL.
+
+For each NEAR MISS record which filter put it there and what would settle
+it — a fact to verify, or a judgement the user has to make. That sentence is
+the band's whole purpose.
+
+`missing_data_policy.mode: exclude` is the one override: unresolved filters
+become FAIL rather than NEAR MISS.
+
+## 2 — Criterion scores (yours) → totals (the script's)
+
+Score every criterion 0–100 against its anchors for each company that has
+not firmly failed a filter — you will not always know the band yet, and the
+script ignores scores on FAIL companies. Score against the evidence you have,
+not the company you imagine. No evidence → `null`, never a guessed number;
+the missing-data policy decides what `null` means.
+
+The script normalises weights, computes the weighted sum, rounds, and
+carries the lowest confidence. You never do that arithmetic.
+
+Do not score what a revisitable filter already tested. If the schema and
+thesis disagree here, say so rather than silently double-counting.
+
+## 3 — Run the script
+
+```bash
+node ${PLUGIN_ROOT}/scripts/winnow.mjs screen \
+  ${PLUGIN_DATA}/theses/<thesis>.yaml \
+  ${PLUGIN_DATA}/runs/<timestamp>/candidates/ \
+  --out ${PLUGIN_DATA}/runs/<timestamp>
+```
+
+Point it at the **candidates directory** the run was opened in. The script
+merges every `*.json` in it, with `_run.json` supplying top-level fields.
+
+It refuses to screen a run that is not sound, rather than producing a brief
+that looks fine:
+
+- **fewer judgment files than the universe carried forward** — research the
+  rest, or re-record the universe with `set-universe --carried <actual>`
+- **the thesis changed after the run opened** — the evidence was gathered
+  against a different screen; open a new run
+- **evidence older than a day** — screens, but says so in the output
+
+`winnow.mjs status <candidates-dir>` shows written-versus-expected at any
+point. `--force` overrides the first two and records that it was forced; it
+does not make the problem go away.
+
+It ranks within bands only (a NEAR MISS at 90 never outranks a PASS at 70 —
+it failed a filter the user wrote down), breaks ties on confidence then
+scale, and flags PASS entries at or above `minimum_score_for_priority`.
+
+## 4 — Report
+
+Read `brief.md` from the output directory and present it — counts first.
+`produce-brief` covers the presentation. Do not retype numbers from the
+brief into prose; quote them.
+
+## Consistency
+
+Screen one criterion across all companies before moving to the next, not one
+company at a time. Judging the same criterion repeatedly in a row keeps the
+standard stable; company-by-company scoring drifts.
+
+In fast mode the research subagents scored company by company, so this pass
+is yours to do explicitly before you run the script: one criterion at a
+time, down the column of digests, adjusting any score that sits out of line
+with comparable evidence — see `research-target`.
+
+Where a call was genuinely close, say so. A borderline 55 reported as a
+confident 55 is a lie about precision.

--- a/finance/winnow/skills/screen-target/references/evidence-policy.md
+++ b/finance/winnow/skills/screen-target/references/evidence-policy.md
@@ -1,0 +1,86 @@
+# Evidence policy
+
+A ranked list nobody can audit is worse than no list. These rules are not
+negotiable against convenience.
+
+## Cite everything
+
+Every claim that moves a band or a score carries a source URL. No citation,
+no claim. If it matters and you cannot source it, it is an open question,
+not a finding.
+
+## Never infer from absence
+
+**Not finding evidence of X means "unknown". It never means "not X".**
+
+This is the most common way a screen goes wrong, and it goes wrong
+systematically: it penalises exactly the companies with the thinnest web
+presence, which for private mid-market firms correlates with nothing you
+care about.
+
+A thesis may state this explicitly for a question — for example, that the
+lack of a certification must not be inferred from the absence of
+certification evidence. That instruction is binding.
+
+## Absence at the universe level
+
+The rule above governs one claim about one company. The same error happens
+one level up, where it is harder to see and does more damage.
+
+**Not finding candidates in a segment is not evidence that the segment is
+empty.** A funnel's shape reflects which sources are indexed and reachable,
+not the shape of the market. One well-structured public roster will supply
+most of a segment and silently redefine the market as that roster's reach.
+
+In the real screen behind the example thesis, 27 of 48 targets (56%) came
+from a single association's published member roster, and 25 of the 26
+targets in one state came from that one source. That state does not hold
+half the industry — it holds the body that publishes its roster. A declared
+segment elsewhere returned zero and said nothing about it.
+
+So: report coverage next to results, flag single-source dominance and empty
+segments, and never present a concentrated funnel as a market finding. See
+the `build-universe` skill for the mechanics.
+
+## Fact and inference are different kinds of thing
+
+- **Fact** — a source states it. `"Four Illinois locations" — company site/about`
+- **Inference** — you concluded it. `"Roughly 40–60 employees — inferred
+  from 6 crew trucks and 3 job postings"`
+
+Label every inference and say what it rests on. Never present an inference
+in a table cell that looks like a fact. Never launder an inference into a
+fact by repeating it downstream.
+
+## Confidence
+
+Per claim, not per company:
+
+- **high** — a primary source states it directly.
+- **medium** — one good source, or consistent secondary sources.
+- **low** — inference, a single weak source, or stale material.
+
+Carry the lowest confidence of the evidence a conclusion depends on. Give
+the date when material may be stale.
+
+## Missing data is a finding
+
+Report what you could not determine and what would settle it. Do not score
+around a gap silently. `missing_data_policy` governs how a gap scores; it
+does not license hiding it.
+
+## Sources
+
+Public web only. Never bypass a paywall, login, or scraping control. Prefer
+primary sources — the company, the registry, the filing — over aggregators
+that restate them without sourcing.
+
+Where sources conflict, report the conflict and prefer the primary and more
+recent one. Do not average two numbers into a third nobody stated.
+
+## People
+
+Research companies, not individuals. A named person appears only in their
+public business role where it bears on ownership or succession. Never their
+personal life, home address, family, health, or personal finances. Never
+compile personal contact details.

--- a/finance/winnow/skills/screen-target/references/judgments-format.md
+++ b/finance/winnow/skills/screen-target/references/judgments-format.md
@@ -1,0 +1,156 @@
+# Judgments format
+
+The boundary between judgment and arithmetic. The model writes **one JSON
+document** of judgments; `${PLUGIN_ROOT}/scripts/winnow.mjs screen` does
+everything after — bands, weighted scores, ranking, coverage, priority flags,
+tables and exports. The model never computes a total, assigns a band, or
+tallies coverage itself.
+
+**Write one file per candidate as research completes**, into
+`${PLUGIN_DATA}/runs/<timestamp>/candidates/`, with an optional `_run.json`
+carrying the top-level fields. The script merges the directory. Evidence held
+in context is lost to compaction on any run of real size; evidence on disk is
+not.
+
+Then run:
+
+```bash
+node ${PLUGIN_ROOT}/scripts/winnow.mjs screen \
+  ${PLUGIN_DATA}/theses/<thesis>.yaml \
+  ${PLUGIN_DATA}/runs/<timestamp>/candidates/ \
+  --out ${PLUGIN_DATA}/runs/<timestamp>
+```
+
+The shape below is the whole document. A per-candidate file is just one entry
+from `candidates[]`, written on its own; `_run.json` holds `run_at` and
+`universe`.
+
+It writes `brief.md`, `screen.csv`, `screen.json` and prints the counts line.
+A non-zero exit means the judgments are malformed — the message names the
+company and field. Fix the judgment; never hand-compute around the script.
+
+## Shape
+
+```json
+{
+  "run_at": "2026-01-01T12:00:00Z",
+
+  "universe": {
+    "found": 30,             // how many candidates universe-building surfaced
+    "carried_forward": 12,   // how many are in this file
+    "cap": 12,               // the initial_universe limit that bit, if any
+    "note": ""               // optional, e.g. which sweep was cut short
+  },
+
+  "candidates": [
+    {
+      "name": "Example Co",
+      "url": "https://example.com",
+      "location": "City, ST",
+      "segments": { "geography": "<one of hard_filters.geography.include>" },
+      "sources": ["<where this candidate was found>", "..."],
+
+      "filters": {
+        "<filter name>": {
+          "outcome": "pass | fail | unresolved",
+          "evidence": "one line of what the source states",
+          "url": "https://...",
+          "what_would_settle_it": "required when fail or unresolved"
+        }
+      },
+
+      "scores": {
+        "<criterion name>": {
+          "score": 0-100 or null,
+          "confidence": "high | medium | low",
+          "why": "one clause naming the evidence",
+          "url": "https://..."
+        }
+      },
+
+      "findings": [
+        {
+          "question": "<a research question>",
+          "answer": "the answer, or null if unanswered",
+          "confidence": "high | medium | low",
+          "facts":      [{ "claim": "what a source states", "url": "https://..." }],
+          "inferences": [{ "claim": "what you concluded", "basis": "what it rests on" }]
+        }
+      ],
+      "open_questions": [
+        { "question": "...", "what_would_settle_it": "..." }
+      ]
+    }
+  ]
+}
+```
+
+## Names must match the thesis exactly
+
+- `filters` keys: `industry`, `geography`, `ownership`, `business_model`,
+  `size.revenue` / `size.ebitda` / `size.employees` / `size.locations` (only
+  those present in the thesis), and each `hard_filters.other[].name`
+  verbatim. **Every filter needs an outcome** — a missing one is an error,
+  not a pass.
+- `scores` keys: each `scored_preferences.criteria[].name` verbatim. A
+  criterion with no evidence is `"score": null` — the missing-data policy
+  decides what that means. Never invent a number to fill the slot.
+- `segments` keys: each dimension in `research_settings.coverage.report_by`;
+  the value must be one of that filter's `include` entries, spelled the same.
+- `sources`: at least one. Use a stable label for the same source across
+  candidates ("state licensing registry", not a different phrasing each
+  time) — the coverage tally groups on this string.
+
+## The universe block
+
+Optional, but include it whenever a cap bit. `found` minus `carried_forward`
+is reported above the results as a coverage event, because a cap discards
+whatever the search ordered last rather than a random sample. Omit the block
+entirely when nothing was truncated.
+
+## Profile: what `research_depth.mode` changes about the file
+
+- **`fast`** — `findings` only for `research_questions.custom`. The standard
+  questions are still researched (they are what the filter and score
+  judgments rest on) but are not written up one by one: eight standard
+  write-ups were ~60% of a candidate file's bytes, and every byte the model
+  writes is time. `inferences` may be omitted when there are none.
+- **`standard` / `deep`** — the full shape above, every question answered.
+
+## Length caps
+
+One clause is one clause. The script refuses a file whose prose fields run
+past these, naming every field at once so one edit fixes the file. It never
+trims — a fix is yours, so nothing is ever cut mid-sentence.
+
+| Field | Cap (chars) |
+|---|---|
+| `scores.*.why` | 160 |
+| `filters.*.evidence`, `filters.*.what_would_settle_it` | 240 |
+| `findings[].facts[].claim`, `inferences[].claim`, `inferences[].basis` | 240 |
+| `open_questions[].question`, `open_questions[].what_would_settle_it` | 240 |
+| `findings[].answer` | 300 |
+
+The commonest way to blow a cap is restating the same sentence in three
+places — filter evidence, score `why`, and a finding. Say it once, in the
+field that decides something, and let the others point at it.
+
+## Rules the script enforces
+
+- outcome ∈ {pass, fail, unresolved}; score ∈ [0, 100] or null;
+  confidence ∈ {high, medium, low}
+- every filter has an outcome; no duplicate candidate names
+- FAIL candidates need no `scores` (they are never scored), but they still
+  need `segments` and `sources` — they count toward coverage
+- the length caps and the depth profile above
+
+## Rules the script cannot enforce — yours
+
+- **Never infer from absence.** No evidence → `unresolved` for a filter,
+  `null` for a score, `null` answer for a finding. Not `fail`, not `0`, not
+  a guess.
+- `what_would_settle_it` is a concrete fact to verify or a judgement the user
+  must make — not "more research".
+- `why` names evidence, not the score: "four offices and a 40-truck fleet",
+  not "strong scale".
+- Facts and inferences never share a line.

--- a/finance/winnow/skills/screen-target/references/scoring-methodology.md
+++ b/finance/winnow/skills/screen-target/references/scoring-methodology.md
@@ -1,0 +1,68 @@
+# Scoring methodology
+
+Scoring orders companies that already cleared the filters. It never decides
+whether a company is in.
+
+## Arithmetic
+
+1. Score each criterion 0–100 against its `scoring_guidance` anchors.
+2. Normalise weights to sum to 100: `w_i / Σw × 100`.
+3. Weighted sum: `Σ (score_i × normalised_weight_i) / 100`.
+4. Round to a whole number. Report the breakdown, never just the total.
+
+## Using the anchors
+
+`scoring_guidance` gives anchors at 100, 50, and 0. Interpolate between them;
+do not invent a fourth anchor. If a company sits between the 50 and the 100
+description, it scores 60–90 depending on how much of the 100 description
+holds — say which part.
+
+Anchor to the written description, not to the other companies in the batch.
+Batch-relative scoring makes runs incomparable and drifts with sample
+composition.
+
+## Missing evidence
+
+Per `scoring_settings.missing_data_policy.mode`:
+
+- **neutral** — score 50 and mark confidence low. The default, and correct
+  for private companies with thin public footprints: penalising missing data
+  ranks by web presence, not by fit.
+- **penalize** — score 0 and say so. Only when the evidence should exist and
+  its absence is itself informative.
+- **exclude** — drop the company. Also sends unresolved hard filters to FAIL
+  rather than NEAR MISS.
+
+Always mark a criterion scored under this policy. A 50 from a policy default
+is not the same as a 50 you judged, and the brief must not conflate them.
+
+## Do not double-count
+
+A revisitable hard filter and a scored preference must not test the same
+fact. The filter sets the band; the preference orders within it. When a
+thesis does double-count, say so rather than quietly applying both.
+
+## Confidence
+
+Carry a confidence alongside every criterion score, taken from the evidence
+beneath it. A company whose score rests on low-confidence evidence throughout
+is a different proposition from one with the same total and high-confidence
+evidence — the brief shows both.
+
+Never fold confidence into the score itself. They are separate axes and the
+user needs to see both.
+
+**Company confidence is weighted, not worst-case.** The headline confidence is
+the criterion confidences averaged by the same weights that produced the score
+(high=3, medium=2, low=1; ≥2.5 high, ≥1.5 medium). Taking the single worst
+input instead would let one thin minor criterion drag a well-evidenced case to
+"low", which is the wrong signal about a company whose case is strong.
+
+The weakest single input is still reported — marked `▾` in the ranked table and
+named in that company's breakdown — so a strong average never hides a soft
+spot. Both numbers are visible; neither replaces the other.
+
+## Ranking
+
+Rank within a band only. Ties break on confidence, then scale. Flag PASS
+entries at or above `minimum_score_for_priority`.

--- a/finance/winnow/skills/screen-target/references/thesis-schema.md
+++ b/finance/winnow/skills/screen-target/references/thesis-schema.md
@@ -1,0 +1,278 @@
+# Thesis schema
+
+A *thesis* is the configuration surface of this template. It is a YAML file.
+The plugin contains no industry knowledge; everything specific to a search
+lives here.
+
+Theses ship read-only under `${PLUGIN_ROOT}/theses/`. The live, editable copy
+lives under `${PLUGIN_DATA}/theses/<name>.yaml` — `define-thesis` writes it,
+and every other skill reads it from there.
+
+## Validating a thesis
+
+```bash
+node ${PLUGIN_ROOT}/scripts/winnow.mjs validate <thesis.yaml>
+```
+
+The script parses a deliberate **YAML subset** — the agent container has no
+YAML library, so the parser is ours and small. Supported: nested maps at
+two-space indentation, `- item` lists (scalars or maps), `>` folded and `|`
+literal blocks, `#` comments, quoted strings, numbers, booleans, `~`/empty
+for null, inline `[a, b]` lists, and numeric keys such as the `100:` anchors.
+Not supported: anchors and aliases, multi-line flow mappings, tags,
+multi-document files. Anything outside the subset fails with a line number.
+
+## Three kinds of criteria
+
+Every criterion a user offers belongs in exactly one of three places. The
+distinction is the whole design:
+
+| Question | Goes in |
+|---|---|
+| Does failing this take the company out of the funnel? | `hard_filters` |
+| Does this make one acceptable company better than another? | `scored_preferences` |
+| Do I want this determined and reported either way? | `research_questions` |
+
+Putting a preference in `hard_filters` silently discards good candidates.
+Putting a genuine disqualifier in `scored_preferences` lets a high score
+outvote it. `define-thesis` asks the disqualification question explicitly for
+every criterion so the user does not have to know this distinction in advance.
+
+## Hard filters, and `revisitable`
+
+A hard filter normally drops a company *before* research is spent on it.
+
+Real screens have filters that are firm but negotiable — the user means them,
+but would want to see what they cost. Mark those `revisitable: true`. A
+company that fails **only** revisitable filters is not dropped; it is
+quarantined into the NEAR MISS band, researched, scored, and reported
+separately with the filter it failed and what would have to be true to
+reconsider it.
+
+```yaml
+hard_filters:
+  geography:
+    include: [Illinois, Wisconsin, Arizona]
+  other:
+    - name: Business-customer orientation
+      condition: Company must derive meaningful revenue from business customers.
+      rationale: Consumer-only operators are outside the thesis.
+      revisitable: true
+```
+
+Three bands result, and every run reports all three:
+
+- **PASS** — cleared every hard filter. Researched, scored, ranked, briefed.
+- **NEAR MISS** — failed only revisitable filters. Researched and scored, but
+  ranked in its own band, each with the failed filter named.
+- **FAIL** — failed at least one firm filter. Dropped cheaply, listed with
+  the reason, not researched.
+
+A firm filter beats a revisitable one: fail both and the company is FAIL.
+
+Do not also score what a revisitable filter already tests. The filter decides
+the band; a scored preference on the same fact double-counts it. Score the
+*degree* of an adjacent quality instead (a revisitable "must be commercial"
+filter pairs with a scored "commercial orientation strength", which only
+ranks companies that already cleared the filter).
+
+## Top-level shape
+
+```yaml
+acquisition_thesis:
+  name:
+  description:
+  hard_filters:
+    industry:      { include: [], exclude: [] }
+    geography:     { include: [], exclude: [] }
+    ownership:     { include: [], exclude: [] }
+    size:
+      revenue:   { min:, max: }
+      ebitda:    { min:, max: }
+      employees: { min:, max: }
+      locations: { min:, max: }
+    business_model:
+      required_characteristics: []
+      excluded_characteristics: []
+    other:
+      - name:
+        condition:
+        rationale:
+        revisitable: false     # default
+  scored_preferences:
+    criteria:
+      - name:
+        weight:                # integers; normalised to 100 at scoring time
+        desired_condition:
+        scoring_guidance:      # anchors: 100 / 50 / 0
+        evidence_required:
+  research_questions:
+    standard: []               # named built-ins, see below
+    custom:
+      - question:
+        importance:            # high | medium | low
+        evidence_guidance:
+
+research_settings:
+  research_depth: { mode: fast | standard | deep }   # also sets the judgment profile, see judgments-format.md
+  execution:      { mode: fast | standard }          # fast farms research out to subagents; see below
+  target_limits:
+    initial_universe:
+    deep_research_limit:
+  evidence:
+    minimum_confidence:
+    require_citations: true
+    allow_inference: true
+    distinguish_fact_from_inference: true
+  coverage:
+    report_by: [geography]        # hard-filter dimensions to report coverage across
+    single_source_threshold: 0.5  # flag a segment where one source exceeds this share
+    flag_empty_segments: true     # a declared segment returning nothing is a finding
+  source_preferences:
+    preferred: []                 # prose guidance: what to favour and read
+    excluded: []                  # prose guidance: what not to trust
+    domains:
+      include: []                 # -> search include_domains (targeted passes only)
+      exclude: []                 # -> search exclude_domains (applied always)
+    registries:                   # enumerable sources; needs an API key
+      - name:
+        url:
+        covers:                   # which segment(s) this registry enumerates
+        instructions:             # natural-language: which pages matter
+
+scoring_settings:
+  scale: { min: 0, max: 100 }
+  normalization: weighted
+  missing_data_policy:
+    mode: neutral | penalize | exclude
+    notes:
+  minimum_score_for_priority:
+
+output:
+  ranked_table: true
+  target_briefs: true
+  show_filter_failures: true
+  show_near_miss_band: true
+  show_coverage_report: true
+  show_score_breakdown: true
+  show_confidence: true
+  show_citations: true
+  export: { formats: [csv, json] }
+```
+
+## Source preferences
+
+Four fields, two kinds. `preferred` and `excluded` are **prose** — they guide
+how the agent frames queries and which results are worth reading. The rest are
+**mechanical**, compiled onto the search API:
+
+- **`domains.exclude`** is applied to every search. Use it to permanently
+  silence aggregators that restate other sources without attribution.
+- **`domains.include`** is a *hard restriction* and is applied only on
+  targeted passes. A broad sweep with it set returns nothing but those
+  domains and silently collapses recall.
+- **`registries`** name sources that are **complete by construction** for
+  some population — a licensing database, a membership roster, an award list.
+  With an API key the agent enumerates them by crawling rather than sampling
+  them by searching. This is the main lever on coverage: a declared registry
+  that could not be enumerated is reported as a gap.
+
+`covers` ties a registry to the segments it can complete, so an empty segment
+in the coverage report can be traced to a registry that was missing, not
+consulted, or unreachable.
+
+## Target limits are a cost dial, not a screening criterion
+
+`research_settings.target_limits` exists for one reason: **to bound runtime
+and API spend.** It is a knob for how long a run takes, and nothing else.
+
+- `initial_universe` — how many candidates universe-building carries forward.
+- `deep_research_limit` — how many of those get deep research.
+
+Neither expresses anything about the thesis. A company dropped by a cap was
+not judged and did not fail; it was simply past the line when the budget ran
+out. **The discarded remainder is not a random sample** — it is whatever the
+search happened to order last, which correlates with web presence rather than
+with fit.
+
+So a cap that bites is a **coverage event**, and is reported as one. Record
+what was found alongside what was carried, and the brief states the gap above
+the results:
+
+```json
+"universe": { "found": 30, "carried_forward": 12, "cap": 12 }
+```
+
+Set the caps low for a fast trial run and raise them for a real screen. Never
+reach for them to make a shortlist shorter — that is what `hard_filters` and
+`minimum_score_for_priority` are for, and unlike a cap they leave a reason
+behind.
+
+## Execution mode
+
+`research_settings.execution.mode` is about wall-clock, not evidence. It
+does not change what is researched, how it is judged, or what the brief
+contains — `research_depth` does that.
+
+- **`standard`** (default) — one agent does the whole pipeline in sequence.
+  Cheapest in tokens; a quickstart-sized run takes ten to fifteen minutes,
+  most of it the agent's context filling with search results and being
+  compacted.
+- **`fast`** — the agent delegates the search sweep to one subagent and each
+  candidate's research to its own subagent, a few at a time. Raw search
+  results never enter the main agent's context, so it never compacts, and
+  the candidates are researched concurrently. Several times faster; several
+  times the token spend, because every subagent carries its own baseline.
+
+Pick `fast` when you are waiting on the result and `standard` when the run
+is unattended or the spend matters more than the clock.
+
+## Coverage
+
+`research_settings.coverage` makes the shape of the *search* reportable
+alongside the shape of the *results*.
+
+A screen's funnel reflects which sources are indexed and reachable. One
+well-structured public roster can supply most of a segment, and the funnel
+will look authoritative anyway because a lot of arithmetic sits on top of it.
+Coverage reporting is what stops a search artifact being read as a market
+finding — the universe-level counterpart to "never infer from absence".
+
+- `report_by` — which hard-filter dimensions to segment by. Geography is the
+  usual one; any enumerable dimension works.
+- `single_source_threshold` — flag a segment where one source supplies more
+  than this share of candidates.
+- `flag_empty_segments` — a declared segment that returns nothing is
+  reported as a gap, not omitted.
+
+Keep a declared-but-empty segment in the thesis rather than deleting it.
+Removing it converts a coverage gap into a silent absence.
+
+## `research_questions.standard`
+
+Named built-ins, answered for every researched company unless removed:
+`company_overview`, `ownership`, `management`, `geography`,
+`products_services`, `customer_markets`, `size_indicators`, `growth_signals`,
+`acquisition_signals`.
+
+## Weights
+
+`weight` values are integers in any range; scoring normalises them to sum to
+100. Writing weights that already sum to 100 makes the brief easier to read,
+but nothing enforces it.
+
+## Missing data
+
+`missing_data_policy` governs a **scored criterion** with no evidence.
+
+A **hard filter** with no evidence either way is different, and never
+silently passes. It resolves to NEAR MISS, with the unresolved filter named
+and the evidence that would settle it stated — the same band and the same
+treatment as a revisitable failure, because the user's next action is
+identical: decide one open question about an otherwise-viable company.
+`missing_data_policy.mode: exclude` is the one override, sending unresolved
+filters to FAIL instead.
+
+This keeps the output at three bands. Absence of evidence is never
+inference: a screen that cannot find evidence of a certification reports
+"unresolved", not "uncertified".

--- a/finance/winnow/theses/demo-minimal.yaml
+++ b/finance/winnow/theses/demo-minimal.yaml
@@ -1,0 +1,112 @@
+# DEMO-MINIMAL — the whole pipeline in about three minutes.
+#
+# One metro, two criteria, no custom questions, caps of 2 and 1, standard
+# execution. Every setting here is chosen for the clock, not for the screen:
+# it shows sourcing, the cap reported as a coverage event, one researched
+# candidate with cited evidence, the bands, and the brief. For a screen you
+# would act on, run quickstart-arizona.yaml or example-fencing.yaml.
+
+acquisition_thesis:
+  name: Phoenix Perimeter Security — three-minute demo
+  description: >
+    Commercial fence and gate contractors in the Phoenix metro, screened for
+    an independent acquirer. A deliberately tiny run.
+
+  hard_filters:
+    industry:
+      include:
+        - commercial fencing contractor
+        - access control and automated gate contractor
+      exclude:
+        - DIY fence supply retail
+        - landscaping contractor
+    geography:
+      include:
+        - Phoenix metro
+    ownership:
+      include:
+        - founder owned
+        - family owned
+        - privately held
+      exclude:
+        - publicly traded
+        - private equity controlled
+
+  scored_preferences:
+    criteria:
+      - name: Commercial orientation strength
+        weight: 60
+        desired_condition: Predominantly commercial and industrial revenue mix
+        scoring_guidance:
+          100: Overwhelmingly commercial/industrial; residential incidental
+          50: Meaningful mixed exposure with a real commercial division
+          0: Residential-led
+        evidence_required: Project portfolio, service pages, named customers
+
+      - name: Capability breadth
+        weight: 40
+        desired_condition: Fence AND access control / automated gate capability
+        scoring_guidance:
+          100: Both, delivered in-house
+          50: Fence with some gate or operator work
+          0: Fence erection only
+        evidence_required: Service pages, certifications, dealer listings
+
+  research_questions:
+    standard:
+      - company_overview
+      - ownership
+      - products_services
+
+research_settings:
+  research_depth:
+    mode: fast
+  execution:
+    mode: standard
+    # Three searches and one candidate: the subagent launch-and-return
+    # overhead of fast mode would cost more than it saves here.
+  target_limits:
+    initial_universe: 2
+    deep_research_limit: 1
+  evidence:
+    minimum_confidence: low
+    require_citations: true
+    allow_inference: true
+    distinguish_fact_from_inference: true
+  coverage:
+    report_by:
+      - geography
+    single_source_threshold: 0.5
+    flag_empty_segments: true
+  source_preferences:
+    preferred:
+      - company websites
+    excluded:
+      - content-farm business directories with no primary sourcing
+    domains:
+      include: []
+      exclude:
+        - buzzfile.com
+        - manta.com
+        - dnb.com
+        - zoominfo.com
+        - bizapedia.com
+
+scoring_settings:
+  scale: { min: 0, max: 100 }
+  normalization: weighted
+  missing_data_policy:
+    mode: neutral
+  minimum_score_for_priority: 60
+
+output:
+  ranked_table: true
+  target_briefs: true
+  show_filter_failures: true
+  show_near_miss_band: true
+  show_coverage_report: true
+  show_score_breakdown: true
+  show_confidence: true
+  show_citations: true
+  export:
+    formats: [csv, json]

--- a/finance/winnow/theses/example-fencing.eval.json
+++ b/finance/winnow/theses/example-fencing.eval.json
@@ -1,0 +1,44 @@
+{
+  "thesis": "example-fencing.yaml",
+  "judgments": "example-fencing.eval.judgments.json",
+  "description": "Screening-logic eval against known-correct calls from a real 48-target screen.",
+  "expect": {
+    "counts": { "PASS": 4, "NEAR MISS": 3, "FAIL": 1 },
+    "companies": [
+      { "name": "Midwest Fence Corporation", "band": "PASS", "priority": true,
+        "criterion": "Union tier", "score": 100,
+        "why": "Known-good rank 1: confirmed signatory, family-owned since 1947, commercial portfolio." },
+
+      { "name": "Century Fence Company", "band": "PASS",
+        "criterion": "Union tier", "score": 100,
+        "why": "Positive roster evidence must score as a confirmed signatory." },
+
+      { "name": "Century Fence Company (absent-evidence variant)", "band": "PASS",
+        "criterion": "Union tier", "score": 50, "policy": "neutral",
+        "scoreNotBelow": 60,
+        "why": "THE headline assertion. Same company, union evidence absent. Must score the neutral default and stay in PASS -- never 0, never excluded. A real screen once called this company nonunion by inferring from absence." },
+
+      { "name": "Diversified Construction Services", "band": "NEAR MISS",
+        "why": "Marked Tier Out in the source screen: fence share unconfirmed. Unresolved revisitable filter quarantines rather than drops." },
+
+      { "name": "Priority Grading & Excavating, Inc", "band": "NEAR MISS",
+        "why": "Marked Tier Out in the source screen: access work only." },
+
+      { "name": "Residential Only Fence Co", "band": "NEAR MISS",
+        "why": "Fails a revisitable filter outright -- still researched and reported, not discarded." },
+
+      { "name": "Rommel Fence, LLC", "band": "PASS", "priority": false,
+        "criterion": "Union tier", "score": 0,
+        "why": "Open-shop capable. Ranks below signatories but is NOT excluded -- union status is scored, never filtered." },
+
+      { "name": "PE Platform Fence Holdings", "band": "FAIL", "unscored": true,
+        "why": "Firm ownership filter. Dropped before research; never scored." }
+    ],
+    "invariants": [
+      "no NEAR MISS outranks a PASS",
+      "every FAIL is unscored",
+      "absent-evidence variant scores strictly below its evidenced twin",
+      "coverage flags every declared segment that returned nothing"
+    ]
+  }
+}

--- a/finance/winnow/theses/example-fencing.eval.judgments.json
+++ b/finance/winnow/theses/example-fencing.eval.judgments.json
@@ -1,0 +1,581 @@
+{
+  "run_at": "2026-09-05T20:00:00Z",
+  "candidates": [
+    {
+      "name": "Midwest Fence Corporation",
+      "url": "https://www.mwfence.com/",
+      "location": "Chicago, IL",
+      "segments": {
+        "geography": "Illinois"
+      },
+      "sources": [
+        "Ironworkers Local 63 fence roster",
+        "company website"
+      ],
+      "filters": {
+        "industry": {
+          "outcome": "pass",
+          "evidence": "commercial and industrial fence and gate contractor"
+        },
+        "geography": {
+          "outcome": "pass",
+          "evidence": "HQ 900 N Kedzie Ave, Chicago"
+        },
+        "ownership": {
+          "outcome": "pass",
+          "evidence": "family-owned since 1947"
+        },
+        "Commercial orientation": {
+          "outcome": "pass",
+          "evidence": "portfolio predominantly commercial and institutional"
+        }
+      },
+      "scores": {
+        "Union tier": {
+          "score": 100,
+          "confidence": "high",
+          "why": "named on Local 63 signatory fence roster"
+        },
+        "Commercial orientation strength": {
+          "score": 90,
+          "confidence": "high",
+          "why": "residential incidental in portfolio"
+        },
+        "Ownership and acquirability": {
+          "score": 70,
+          "confidence": "medium",
+          "why": "third-generation family ownership"
+        },
+        "Capability breadth": {
+          "score": 100,
+          "confidence": "high",
+          "why": "fence plus access control and gate operators in-house"
+        },
+        "Scale": {
+          "score": 80,
+          "confidence": "medium",
+          "why": "multiple crews, large public projects"
+        },
+        "End-market attractiveness": {
+          "score": 80,
+          "confidence": "medium",
+          "why": "repeat municipal and transit work"
+        },
+        "Growth indicators": {
+          "score": 50,
+          "confidence": "low",
+          "why": "stable; no expansion signals found"
+        },
+        "Market reputation": {
+          "score": 100,
+          "confidence": "high",
+          "why": "79 years operating"
+        }
+      },
+      "findings": [
+        {
+          "question": "Union status - trade and local",
+          "answer": "Ironworkers, Local 63 (Chicago)",
+          "confidence": "high",
+          "facts": [
+            {
+              "claim": "listed by name on the Local 63 fence contractor roster",
+              "url": "https://www.mwfence.com/"
+            }
+          ],
+          "inferences": []
+        }
+      ],
+      "open_questions": [
+        {
+          "question": "Revenue band",
+          "what_would_settle_it": "Form 5500 participant count or bonding capacity from a bid tab"
+        }
+      ]
+    },
+    {
+      "name": "Century Fence Company",
+      "url": "https://centuryfence.com",
+      "location": "Pewaukee, WI",
+      "segments": {
+        "geography": "Wisconsin"
+      },
+      "sources": [
+        "nwibt.org Ironworkers-fencing roster",
+        "company website"
+      ],
+      "filters": {
+        "industry": {
+          "outcome": "pass",
+          "evidence": "commercial fence and pavement marking contractor"
+        },
+        "geography": {
+          "outcome": "pass",
+          "evidence": "Pewaukee / Waukesha, WI"
+        },
+        "ownership": {
+          "outcome": "pass",
+          "evidence": "independent, family-owned"
+        },
+        "Commercial orientation": {
+          "outcome": "pass",
+          "evidence": "commercial, highway and institutional work"
+        }
+      },
+      "scores": {
+        "Union tier": {
+          "score": 100,
+          "confidence": "high",
+          "why": "listed on the nwibt.org IRONWORKERS-FENCING roster for fence erection"
+        },
+        "Commercial orientation strength": {
+          "score": 85,
+          "confidence": "high",
+          "why": "highway, commercial and institutional; no residential line"
+        },
+        "Ownership and acquirability": {
+          "score": 60,
+          "confidence": "low",
+          "why": "independent/family; no succession signals found"
+        },
+        "Capability breadth": {
+          "score": 50,
+          "confidence": "medium",
+          "why": "fence and highway safety; access control not evidenced"
+        },
+        "Scale": {
+          "score": 85,
+          "confidence": "medium",
+          "why": "multi-state highway contracts"
+        },
+        "End-market attractiveness": {
+          "score": 90,
+          "confidence": "high",
+          "why": "sustained state DOT and municipal work"
+        },
+        "Growth indicators": {
+          "score": 50,
+          "confidence": "low",
+          "why": "stable"
+        },
+        "Market reputation": {
+          "score": 90,
+          "confidence": "high",
+          "why": "long operating history in the region"
+        }
+      },
+      "findings": [
+        {
+          "question": "Union status - trade and local",
+          "answer": "Ironworkers (fence erection), per the regional building trades roster",
+          "confidence": "high",
+          "facts": [
+            {
+              "claim": "appears on the nwibt.org IRONWORKERS-FENCING contractor roster",
+              "url": "https://centuryfence.com"
+            }
+          ],
+          "inferences": []
+        }
+      ],
+      "open_questions": [
+        {
+          "question": "Whether a separate Laborers agreement exists in other states",
+          "what_would_settle_it": "state-by-state signatory check; union status is trade- and state-specific"
+        }
+      ]
+    },
+    {
+      "name": "Century Fence Company (absent-evidence variant)",
+      "url": "https://centuryfence.com",
+      "location": "Pewaukee, WI",
+      "segments": {
+        "geography": "Wisconsin"
+      },
+      "sources": [
+        "company website"
+      ],
+      "filters": {
+        "industry": {
+          "outcome": "pass",
+          "evidence": "commercial fence and pavement marking contractor"
+        },
+        "geography": {
+          "outcome": "pass",
+          "evidence": "Pewaukee / Waukesha, WI"
+        },
+        "ownership": {
+          "outcome": "pass",
+          "evidence": "independent, family-owned"
+        },
+        "Commercial orientation": {
+          "outcome": "pass",
+          "evidence": "commercial, highway and institutional work"
+        }
+      },
+      "scores": {
+        "Union tier": {
+          "score": null
+        },
+        "Commercial orientation strength": {
+          "score": 85,
+          "confidence": "high",
+          "why": "highway, commercial and institutional"
+        },
+        "Ownership and acquirability": {
+          "score": 60,
+          "confidence": "low",
+          "why": "independent/family"
+        },
+        "Capability breadth": {
+          "score": 50,
+          "confidence": "medium",
+          "why": "fence and highway safety"
+        },
+        "Scale": {
+          "score": 85,
+          "confidence": "medium",
+          "why": "multi-state highway contracts"
+        },
+        "End-market attractiveness": {
+          "score": 90,
+          "confidence": "high",
+          "why": "sustained state DOT work"
+        },
+        "Growth indicators": {
+          "score": 50,
+          "confidence": "low",
+          "why": "stable"
+        },
+        "Market reputation": {
+          "score": 90,
+          "confidence": "high",
+          "why": "long operating history"
+        }
+      },
+      "findings": [
+        {
+          "question": "Union status - trade and local",
+          "answer": null,
+          "confidence": "low",
+          "facts": [],
+          "inferences": []
+        }
+      ],
+      "open_questions": [
+        {
+          "question": "Union affiliation",
+          "what_would_settle_it": "signatory roster, CBA reference, or an explicit company statement"
+        }
+      ]
+    },
+    {
+      "name": "Diversified Construction Services",
+      "url": "https://dcsscaffold.com",
+      "location": "Warrenville, IL",
+      "segments": {
+        "geography": "Illinois"
+      },
+      "sources": [
+        "Ironworkers Local 63 fence roster"
+      ],
+      "filters": {
+        "industry": {
+          "outcome": "pass",
+          "evidence": "architectural and ornamental ironwork including fence"
+        },
+        "geography": {
+          "outcome": "pass",
+          "evidence": "Warrenville, IL"
+        },
+        "ownership": {
+          "outcome": "pass",
+          "evidence": "founder-owned; MBE"
+        },
+        "Commercial orientation": {
+          "outcome": "unresolved",
+          "evidence": "site is scaffold-led; fence share of work not stated",
+          "what_would_settle_it": "confirm fence is a meaningful line of business, not incidental to scaffolding"
+        }
+      },
+      "scores": {
+        "Union tier": {
+          "score": 100,
+          "confidence": "high",
+          "why": "Local 63 signatory"
+        },
+        "Commercial orientation strength": {
+          "score": null
+        },
+        "Ownership and acquirability": {
+          "score": 60,
+          "confidence": "low",
+          "why": "founder-owned; no succession signals"
+        },
+        "Capability breadth": {
+          "score": 0,
+          "confidence": "medium",
+          "why": "fence only; primary trade is scaffolding"
+        },
+        "Scale": {
+          "score": 50,
+          "confidence": "low",
+          "why": "single location"
+        },
+        "End-market attractiveness": {
+          "score": 60,
+          "confidence": "low",
+          "why": "commercial construction exposure via scaffold"
+        },
+        "Growth indicators": {
+          "score": null
+        },
+        "Market reputation": {
+          "score": 50,
+          "confidence": "low",
+          "why": "thin third-party evidence"
+        }
+      },
+      "findings": [],
+      "open_questions": []
+    },
+    {
+      "name": "Priority Grading & Excavating, Inc",
+      "url": "https://newbt.org",
+      "location": "Stoughton, WI",
+      "segments": {
+        "geography": "Wisconsin"
+      },
+      "sources": [
+        "Northeast WI Building & Construction Trades Council roster"
+      ],
+      "filters": {
+        "industry": {
+          "outcome": "pass",
+          "evidence": "site work with gate and access installation"
+        },
+        "geography": {
+          "outcome": "pass",
+          "evidence": "Stoughton, Dane County, WI"
+        },
+        "ownership": {
+          "outcome": "pass",
+          "evidence": "privately held small firm"
+        },
+        "Commercial orientation": {
+          "outcome": "unresolved",
+          "evidence": "access work evidenced; no commercial fence portfolio found",
+          "what_would_settle_it": "confirm perimeter or fence scope beyond excavation and grading"
+        }
+      },
+      "scores": {
+        "Union tier": {
+          "score": 50,
+          "confidence": "low",
+          "why": "listed under a council roster but not individually named by trade or local"
+        },
+        "Commercial orientation strength": {
+          "score": null
+        },
+        "Ownership and acquirability": {
+          "score": 50,
+          "confidence": "low",
+          "why": "no ownership records found"
+        },
+        "Capability breadth": {
+          "score": 0,
+          "confidence": "low",
+          "why": "access/site work only"
+        },
+        "Scale": {
+          "score": 40,
+          "confidence": "low",
+          "why": "small regional operator"
+        },
+        "End-market attractiveness": {
+          "score": 50,
+          "confidence": "low",
+          "why": "public works exposure via council membership"
+        },
+        "Growth indicators": {
+          "score": null
+        },
+        "Market reputation": {
+          "score": 50,
+          "confidence": "low",
+          "why": "thin evidence"
+        }
+      },
+      "findings": [],
+      "open_questions": []
+    },
+    {
+      "name": "Rommel Fence, LLC",
+      "url": "https://rommelfence.com",
+      "location": "Poland, NY",
+      "segments": {
+        "geography": "New York"
+      },
+      "sources": [
+        "web search"
+      ],
+      "filters": {
+        "industry": {
+          "outcome": "pass",
+          "evidence": "fence and access control"
+        },
+        "geography": {
+          "outcome": "pass",
+          "evidence": "Poland, NY"
+        },
+        "ownership": {
+          "outcome": "pass",
+          "evidence": "family-owned across three generations"
+        },
+        "Commercial orientation": {
+          "outcome": "pass",
+          "evidence": "commercial and agricultural work shown"
+        }
+      },
+      "scores": {
+        "Union tier": {
+          "score": 0,
+          "confidence": "medium",
+          "why": "describes itself as open-shop capable; no signatory evidence"
+        },
+        "Commercial orientation strength": {
+          "score": 60,
+          "confidence": "medium",
+          "why": "mixed commercial and agricultural"
+        },
+        "Ownership and acquirability": {
+          "score": 80,
+          "confidence": "medium",
+          "why": "third generation, plausible succession"
+        },
+        "Capability breadth": {
+          "score": 100,
+          "confidence": "high",
+          "why": "fence plus access control"
+        },
+        "Scale": {
+          "score": 40,
+          "confidence": "low",
+          "why": "small operator"
+        },
+        "End-market attractiveness": {
+          "score": 40,
+          "confidence": "low",
+          "why": "limited public work"
+        },
+        "Growth indicators": {
+          "score": 50,
+          "confidence": "low",
+          "why": "stable"
+        },
+        "Market reputation": {
+          "score": 80,
+          "confidence": "medium",
+          "why": "long family history"
+        }
+      },
+      "findings": [],
+      "open_questions": []
+    },
+    {
+      "name": "PE Platform Fence Holdings",
+      "url": "",
+      "location": "Milwaukee, WI",
+      "segments": {
+        "geography": "Wisconsin"
+      },
+      "sources": [
+        "press"
+      ],
+      "filters": {
+        "industry": {
+          "outcome": "pass"
+        },
+        "geography": {
+          "outcome": "pass"
+        },
+        "ownership": {
+          "outcome": "fail",
+          "evidence": "acquired by a private equity sponsor 2024",
+          "url": "https://example.invalid/press"
+        },
+        "Commercial orientation": {
+          "outcome": "pass"
+        }
+      },
+      "scores": {},
+      "findings": [],
+      "open_questions": []
+    },
+    {
+      "name": "Residential Only Fence Co",
+      "url": "",
+      "location": "Springfield, IL",
+      "segments": {
+        "geography": "Illinois"
+      },
+      "sources": [
+        "web search"
+      ],
+      "filters": {
+        "industry": {
+          "outcome": "pass"
+        },
+        "geography": {
+          "outcome": "pass"
+        },
+        "ownership": {
+          "outcome": "pass"
+        },
+        "Commercial orientation": {
+          "outcome": "fail",
+          "evidence": "residential-only service pages",
+          "what_would_settle_it": "any evidence of a commercial division"
+        }
+      },
+      "scores": {
+        "Union tier": {
+          "score": null
+        },
+        "Commercial orientation strength": {
+          "score": null
+        },
+        "Ownership and acquirability": {
+          "score": 50,
+          "confidence": "low",
+          "why": "no records found"
+        },
+        "Capability breadth": {
+          "score": 0,
+          "confidence": "medium",
+          "why": "residential fence only"
+        },
+        "Scale": {
+          "score": 20,
+          "confidence": "low",
+          "why": "owner-operator"
+        },
+        "End-market attractiveness": {
+          "score": 0,
+          "confidence": "medium",
+          "why": "no commercial or public work"
+        },
+        "Growth indicators": {
+          "score": null
+        },
+        "Market reputation": {
+          "score": 50,
+          "confidence": "low",
+          "why": "thin evidence"
+        }
+      },
+      "findings": [],
+      "open_questions": []
+    }
+  ]
+}

--- a/finance/winnow/theses/example-fencing.yaml
+++ b/finance/winnow/theses/example-fencing.yaml
@@ -1,0 +1,320 @@
+# Worked example — an ESOP acquirer screening commercial and industrial
+# perimeter-security contractors for union field labour.
+#
+# This is a real screen, not an illustration. It is reproduced from a live
+# v2 target list of 48 priority targets so the template can be validated
+# against known-good and known-bad calls.
+#
+# Nothing in the winnow plugin refers to fencing, union labour, access
+# control, or these states. All of it lives in this file.
+
+acquisition_thesis:
+  name: Union Perimeter Security Platform — Eastern U.S. + Arizona
+  description: >
+    Identify independently held commercial and industrial fence and
+    access-control contractors with union field labour, as platform
+    acquisition candidates for an ESOP acquirer.
+
+  hard_filters:
+    industry:
+      include:
+        - commercial fencing contractor
+        - industrial fencing contractor
+        - perimeter security contractor
+        - access control and automated gate contractor
+      exclude:
+        - DIY fence supply retail
+        - landscaping contractor
+        - fence product manufacturing only
+    geography:
+      include:
+        - Illinois
+        - Indiana
+        - Massachusetts
+        - Michigan
+        - Missouri
+        - New York
+        - Ohio
+        - Wisconsin
+        - Arizona
+      # The buyer states this scope as "eastern U.S. + Arizona". It is
+      # enumerated by state so coverage can be reported per segment -- see
+      # research_settings.coverage.
+      #
+      # Arizona stays in this list even though the v2 screen returned ZERO
+      # candidates there. Removing it would convert a coverage gap into a
+      # silent absence, which is the exact failure this thesis is written
+      # to expose. A declared segment that returns nothing is a finding.
+    ownership:
+      include:
+        - founder owned
+        - family owned
+        - privately held
+      exclude:
+        - publicly traded
+        - private equity controlled
+        - already ESOP-owned
+    other:
+      - name: Commercial orientation
+        condition: >
+          Company must have meaningful commercial, industrial, government, or
+          institutional project activity. Residential-only contractors fail.
+        rationale: >
+          Residential work carries different margins, crew structure, and
+          bonding profile, and does not fit the buyer's operating model.
+        revisitable: true
+        # Revisitable because a predominantly residential contractor with a
+        # real commercial division, or one in a market the buyer wants, is a
+        # conversation worth having. Firm enough to keep out of the ranked
+        # list; not firm enough to discard unseen.
+
+  scored_preferences:
+    criteria:
+      - name: Union tier
+        weight: 20
+        desired_condition: Confirmed signatory to a relevant trade and local
+        scoring_guidance:
+          100: Confirmed signatory — named on a union roster, CBA, or PLA
+          50: Union-crewed, but trade or local not confirmed
+          0: Open-shop capable
+        evidence_required: >
+          Union signatory roster, CBA or PLA reference, or an explicit
+          company statement. Name the trade AND the local where known.
+        # Scored, never filtered. Union evidence is asymmetric -- affiliation
+        # is sometimes published, its absence never is -- so filtering on it
+        # would discard companies for thin web presence. Scoring it under a
+        # neutral missing-data policy ranks the confirmed ones up without
+        # punishing the unknown. An unknown scores 50, ABOVE a confirmed
+        # open shop at 0, which is the correct ordering for this buyer.
+
+      - name: Commercial orientation strength
+        weight: 15
+        desired_condition: Predominantly commercial and industrial revenue mix
+        scoring_guidance:
+          100: Overwhelmingly commercial/industrial; residential incidental
+          50: Meaningful mixed exposure with a real commercial division
+          0: Barely clears the commercial-orientation filter
+        evidence_required: Project portfolio, service pages, named customers
+        # Ranks only companies that already cleared the revisitable filter
+        # above. The filter decides the band; this decides the order.
+
+      - name: Ownership and acquirability
+        weight: 15
+        desired_condition: Founder or family ownership with a plausible succession need
+        scoring_guidance:
+          100: Strong succession or exit signals
+          50: Neutral
+          0: Clearly institutionalised or an unlikely seller
+        evidence_required: Ownership history, leadership tenure, succession signals
+
+      - name: Capability breadth
+        weight: 10
+        desired_condition: Fence AND access control / automated gate capability
+        scoring_guidance:
+          100: Both fence and electronic access control, delivered in-house
+          50: Fence with some gate or operator work
+          0: Fence erection only
+        evidence_required: Service pages, certifications, dealer or partner listings
+
+      - name: Scale
+        weight: 10
+        desired_condition: Multiple crews and evidence of meaningful project capacity
+        scoring_guidance:
+          100: Strong scale indicators across several signals
+          50: Moderate scale
+          0: Owner-operator or single crew
+        evidence_required: Employees, locations, fleet, bonding capacity, project size
+
+      - name: End-market attractiveness
+        weight: 10
+        desired_condition: Government, infrastructure, utility, or institutional exposure
+        scoring_guidance:
+          100: Highly attractive mix with repeat public work
+          50: Mixed
+          0: Weak fit
+        evidence_required: Project records, procurement listings, customer evidence
+
+      - name: Growth indicators
+        weight: 10
+        desired_condition: Expansion, hiring, larger projects, or new capabilities
+        scoring_guidance:
+          100: Strong recent growth across several signals
+          50: Stable
+          0: Weak or declining
+        evidence_required: Hiring activity, new locations, project announcements, fleet growth
+
+      - name: Market reputation
+        weight: 10
+        desired_condition: Established reputation and operating longevity
+        scoring_guidance:
+          100: Long operating history and strong third-party evidence
+          50: Adequate
+          0: Thin or negative evidence
+        evidence_required: Company history, project record, third-party sources, safety record
+
+  research_questions:
+    standard:
+      - company_overview
+      - ownership
+      - management
+      - geography
+      - products_services
+      - customer_markets
+      - size_indicators
+      - growth_signals
+      - acquisition_signals
+    custom:
+      - question: >
+          Determine whether field labour is union, nonunion, mixed, or
+          unknown. Name the specific trade(s) and local number(s).
+        importance: high
+        evidence_guidance: >
+          Prefer union signatory lists, local union rosters, district council
+          agreements, company careers pages, job postings, and project labour
+          agreements.
+
+          Union status is TRADE- and STATE-specific. A company may be
+          signatory to Ironworkers for fence erection in one state and have
+          no agreement elsewhere, or be signatory to Laborers rather than
+          Ironworkers. Never generalise one trade or one state to the whole
+          company -- a real screen wrongly called Century Fence nonunion on
+          the strength of a Laborers matter in Minnesota, when it was in fact
+          Ironworkers-signatory for fence work.
+
+          Do NOT infer nonunion status from the absence of union evidence.
+          Report "unknown".
+
+      - question: Estimate commercial versus residential revenue mix.
+        importance: high
+        evidence_guidance: >
+          Use service pages, project portfolio, named customers, and public
+          references. Give a range and say what it rests on.
+
+      - question: Identify government, utility, or infrastructure project experience.
+        importance: medium
+        evidence_guidance: >
+          Use company project pages, public contract records, bid tabulations,
+          and procurement sources.
+
+      - question: >
+          Identify access-control, automated gate, perimeter security, or
+          related electronic capabilities.
+        importance: medium
+        evidence_guidance: >
+          Use service pages, project descriptions, manufacturer certifications,
+          and partner or dealer listings.
+
+research_settings:
+  research_depth:
+    mode: standard
+  target_limits:
+    initial_universe: 40
+    deep_research_limit: 20
+  evidence:
+    minimum_confidence: low
+    require_citations: true
+    allow_inference: true
+    distinguish_fact_from_inference: true
+
+  coverage:
+    report_by:
+      - geography
+    single_source_threshold: 0.5
+    flag_empty_segments: true
+    # Why this exists. The v2 screen returned 48 priority targets, of which
+    # 26 (54%) were in Illinois -- and 25 of those 26 arrived through ONE
+    # source, the Ironworkers Local 63 fence contractor roster. Local 63
+    # accounts for 27 of all 48 targets (56%), including two Indiana firms
+    # inside its jurisdiction.
+    #
+    # Illinois does not contain half of the union C&I fence contractors in
+    # the eastern United States. What the funnel actually mapped was the
+    # jurisdiction of the one local that publishes a machine-readable
+    # signatory roster. Meanwhile Arizona, a declared segment, returned zero
+    # and said nothing about it.
+    #
+    # That is "never infer from absence" one level up: not finding companies
+    # in a segment is not evidence that the segment is empty. Coverage
+    # reporting makes the shape of the search visible next to the shape of
+    # the results.
+
+  source_preferences:
+    preferred:
+      - union signatory rosters and district council agreements
+      - company websites
+      - state contractor and licensing records
+      - public procurement and bid records
+      - local and trade press
+    excluded:
+      - content-farm business directories with no primary sourcing
+
+    domains:
+      include: []
+      # Left empty deliberately. include_domains is a hard restriction, and a
+      # broad sweep with it set would return only these domains -- exactly the
+      # single-source funnel this thesis exists to expose. Targeted passes set
+      # it per-call instead, scoped to one registry at a time.
+      exclude:
+        - buzzfile.com
+        - manta.com
+        - dnb.com
+        - zoominfo.com
+        - bizapedia.com
+      # Aggregators that restate other sources without attribution. They rank
+      # well, add no evidence, and pollute the coverage tally with a "source"
+      # that is really a mirror of one.
+
+    registries:
+      - name: Ironworkers Local 63 fence contractor roster
+        url: https://iwlocal63.com
+        covers: [Illinois, Indiana]
+        instructions: >
+          Find pages listing signatory or member fence contractors. Capture
+          every company name and any address given.
+        # The source that supplied 27 of 48 targets in the v2 screen. Naming
+        # it explicitly is what turns an accidental concentration into a
+        # deliberate, reportable one.
+
+      - name: North Central States Regional Council of Carpenters signatory list
+        url: https://northcountrycarpenter.org
+        covers: [Wisconsin, Minnesota]
+        instructions: Find signatory contractor listings; capture company names and trades.
+
+      - name: Arizona Registrar of Contractors licence search
+        url: https://roc.az.gov
+        covers: [Arizona]
+        instructions: >
+          Find licensed contractors under fencing and ornamental iron
+          classifications. Capture company name, licence class, and city.
+        # Arizona returned zero candidates in the v2 screen because it was
+        # searched, not enumerated. Every licensed contractor in the state is
+        # in this database. This is the concrete fix for that coverage gap.
+
+scoring_settings:
+  scale:
+    min: 0
+    max: 100
+  normalization: weighted
+  missing_data_policy:
+    mode: neutral
+    notes: >
+      Thin public evidence is the norm for private contractors of this size,
+      and union evidence is asymmetric. Penalising missing data would rank by
+      web presence rather than by fit, and would quietly convert "no union
+      evidence found" into a scoring penalty -- the exact inference this
+      thesis forbids.
+  minimum_score_for_priority: 65
+
+output:
+  ranked_table: true
+  target_briefs: true
+  show_filter_failures: true
+  show_near_miss_band: true
+  show_coverage_report: true
+  show_score_breakdown: true
+  show_confidence: true
+  show_citations: true
+  export:
+    formats:
+      - csv
+      - json

--- a/finance/winnow/theses/quickstart-arizona.yaml
+++ b/finance/winnow/theses/quickstart-arizona.yaml
@@ -1,0 +1,205 @@
+# QUICKSTART — the fastest way to see winnow work.
+#
+# One state, five metro segments, small caps. Runs in a few minutes on the
+# keyless Tavily tier, so it needs no API key and no setup beyond stamping
+# the template.
+#
+# It is deliberately the segment the full example thesis
+# (example-fencing.yaml) reported as EMPTY. That screen searched Arizona and
+# found nothing, and recorded it as a coverage gap rather than as evidence
+# the state had no candidates. A narrow run finds candidates in every metro.
+# That is the template's whole argument, reproducible in one command.
+#
+# Coverage reports by metro rather than by state, so single-source dominance
+# and empty segments stay visible inside a single geography.
+
+acquisition_thesis:
+  name: Arizona Perimeter Security — quickstart
+  description: >
+    Commercial and industrial fence and access-control contractors across
+    Arizona metros, screened for an independent acquirer. A small, fast,
+    zero-setup demonstration of the full pipeline.
+
+  hard_filters:
+    industry:
+      include:
+        - commercial fencing contractor
+        - industrial fencing contractor
+        - perimeter security contractor
+        - access control and automated gate contractor
+      exclude:
+        - DIY fence supply retail
+        - landscaping contractor
+    geography:
+      include:
+        - Phoenix metro
+        - Tucson
+        - Flagstaff
+        - Yuma
+        - Prescott
+      # Metros, not states. A single-state thesis segmented by state has one
+      # coverage row and tells you nothing. Segmenting by metro keeps
+      # single-source dominance and empty-segment flags meaningful.
+    ownership:
+      include:
+        - founder owned
+        - family owned
+        - privately held
+      exclude:
+        - publicly traded
+        - private equity controlled
+    other:
+      - name: Commercial orientation
+        condition: >
+          Company must have meaningful commercial, industrial, government, or
+          institutional project activity. Residential-only contractors fail.
+        rationale: >
+          Residential work carries different margins and crew structure and
+          does not fit the buyer's operating model.
+        revisitable: true
+
+  scored_preferences:
+    criteria:
+      - name: Commercial orientation strength
+        weight: 30
+        desired_condition: Predominantly commercial and industrial revenue mix
+        scoring_guidance:
+          100: Overwhelmingly commercial/industrial; residential incidental
+          50: Meaningful mixed exposure with a real commercial division
+          0: Barely clears the commercial-orientation filter
+        evidence_required: Project portfolio, service pages, named customers
+
+      - name: Capability breadth
+        weight: 25
+        desired_condition: Fence AND access control / automated gate capability
+        scoring_guidance:
+          100: Both, delivered in-house
+          50: Fence with some gate or operator work
+          0: Fence erection only
+        evidence_required: Service pages, certifications, dealer or partner listings
+
+      - name: Ownership and acquirability
+        weight: 20
+        desired_condition: Founder or family ownership with a plausible succession need
+        scoring_guidance:
+          100: Strong succession or exit signals
+          50: Neutral
+          0: Clearly institutionalised or an unlikely seller
+        evidence_required: Ownership history, leadership tenure, succession signals
+
+      - name: Scale
+        weight: 15
+        desired_condition: Multiple crews and evidence of meaningful project capacity
+        scoring_guidance:
+          100: Strong scale indicators across several signals
+          50: Moderate scale
+          0: Owner-operator or single crew
+        evidence_required: Employees, locations, fleet, licence class, project size
+
+      - name: End-market attractiveness
+        weight: 10
+        desired_condition: Government, utility, institutional, or infrastructure exposure
+        scoring_guidance:
+          100: Repeat public or institutional work
+          50: Mixed
+          0: Weak fit
+        evidence_required: Project records, procurement listings, customer evidence
+
+  research_questions:
+    standard:
+      - company_overview
+      - ownership
+      - geography
+      - products_services
+      - customer_markets
+      - size_indicators
+    custom:
+      - question: Estimate commercial versus residential revenue mix.
+        importance: high
+        evidence_guidance: >
+          Use service pages, project portfolio, and named customers. Give a
+          range and say what it rests on.
+
+      - question: >
+          Identify access-control, automated gate, or perimeter security
+          capability delivered in-house rather than subcontracted.
+        importance: medium
+        evidence_guidance: >
+          Use service pages, manufacturer certifications, and dealer listings.
+
+research_settings:
+  research_depth:
+    mode: fast
+  execution:
+    mode: fast
+    # Research is farmed out to subagents, a few candidates at a time, so
+    # the run finishes in minutes rather than a quarter of an hour. It costs
+    # more tokens. Set standard for an unattended run where spend matters
+    # more than the clock.
+  target_limits:
+    initial_universe: 12
+    deep_research_limit: 5
+    # Deliberately small. These are a RUNTIME DIAL, not a screening
+    # criterion -- they bound how long the run takes and nothing else. A
+    # candidate dropped by a cap was not judged and did not fail. Raise both
+    # for a real screen; the brief reports the gap either way.
+  evidence:
+    minimum_confidence: low
+    require_citations: true
+    allow_inference: true
+    distinguish_fact_from_inference: true
+  coverage:
+    report_by:
+      - geography
+    single_source_threshold: 0.5
+    flag_empty_segments: true
+  source_preferences:
+    preferred:
+      - state contractor licence records
+      - company websites
+      - public procurement and bid records
+      - local and trade press
+    excluded:
+      - content-farm business directories with no primary sourcing
+    domains:
+      include: []
+      exclude:
+        - buzzfile.com
+        - manta.com
+        - dnb.com
+        - zoominfo.com
+        - bizapedia.com
+    registries:
+      - name: Arizona Registrar of Contractors licence search
+        url: https://roc.az.gov
+        covers: [Phoenix metro, Tucson, Flagstaff, Yuma, Prescott]
+        instructions: >
+          Find licensed contractors under fencing and ornamental iron
+          classifications. Capture company name, licence class, and city.
+        # Needs the keyed tier. Its live interface is a name-search form
+        # rather than a browsable roster, so even a keyed crawl may need
+        # per-name queries. Left declared on purpose: an unenumerated
+        # registry is reported as an open coverage gap, which is more honest
+        # than deleting it and showing a clean table.
+
+scoring_settings:
+  scale: { min: 0, max: 100 }
+  normalization: weighted
+  missing_data_policy:
+    mode: neutral
+    notes: >
+      Thin public evidence is normal for private contractors of this size.
+      Penalising it would rank by web presence rather than by fit.
+  minimum_score_for_priority: 60
+
+output:
+  ranked_table: true
+  target_briefs: true
+  show_filter_failures: true
+  show_near_miss_band: true
+  show_coverage_report: true
+  show_score_breakdown: true
+  show_confidence: true
+  show_citations: true
+  export:
+    formats: [csv, json]

--- a/index.json
+++ b/index.json
@@ -9,6 +9,14 @@
         "description": "Data analyst agent: pipeline checks, query writing, and recurring report integrity"
       }
     ],
+    "finance": [
+      {
+        "ref": "finance/winnow",
+        "name": "winnow",
+        "version": "1.0.0",
+        "description": "Screening agent: turns a written thesis into a ranked, cited shortlist of companies — reporting the near-misses that failed one negotiable rule, and the segments the search never reached. Runs with no API key."
+      }
+    ],
     "lifestyle": [
       {
         "ref": "lifestyle/family-assistant",


### PR DESCRIPTION
Creates an industry-agnostic search agent leveraging Tavily to identify and screen candidates (M&A, procurement, etc) based on user-tunable criteria. Turn a written thesis into a ranked, cited shortlist — **source → filter → rank → explain**. Built on [Agent Plugins 1.0.0](https://agent-plugins.org).

**Runs on Tavily with no API key by default.** Add a Tavily API key to unlock higher rate limits and site crawling and enumeration tools.

Submitted for the September 2026 hackathon, **Tavily track**.

## Three bands, not a flat list

- **PASS** — cleared every hard filter, ranked by score
- **NEAR MISS** — failed *only* filters marked `revisitable`, or has a filter the evidence could not settle. Researched and ranked separately, each naming what would settle it.
- **FAIL** — failed a firm filter. Dropped before research, listed with the reason so you can audit the filter.

The near-miss band is the point: it is where a firm-but-negotiable rule shows what it costs, instead of silently discarding candidates.

## Tavily

Two tiers, both real:

| Tier | Setup | Tools |
|---|---|---|
| Keyless (default) | none | `tavily_search`, `tavily_extract` |
| Keyed | key in a user-owned server | adds `tavily_map`, `tavily_crawl`, `tavily_research` |

**It runs with no API key at all**, so this can be tried immediately. A key adds *enumeration* — and that is not a rate-limit upgrade, it is the fix for a real failure mode. A licensing database or membership roster is complete by construction: search samples it, `crawl` and `map` enumerate it. Registries are declared per-thesis under `source_preferences.registries`, and `source_preferences.domains` compiles onto `include_domains` / `exclude_domains`.

The template's own `tavily` server never carries a key. Adding one means adding a second, user-owned server — which is what stops a template acquiring a secret.

## Coverage: it reports what it could not see

A screen's results reflect which sources are indexed, not the shape of the market. In the real screen behind the worked example, **27 of 48 targets came from a single union roster**, and a declared segment returned nothing while saying so nowhere.

So the brief opens with candidates per segment, the top contributing source, and flags for **single-source dominance** and **empty segments** — the universe-level form of *never infer from absence*. A cap that truncates the universe is reported the same way: a candidate dropped by a cap was never judged, and the ones dropped are whatever the search ordered last.

## The model judges; a script computes

Bands, weight normalisation, weighted scores, ranking, coverage tallies, priority flags and all rendering are done by `scripts/winnow.mjs` — zero dependencies, **61 tests**. The model supplies judgments; the arithmetic is deterministic and repeatable.

The script also owns the run lifecycle, so nothing about a run is invented: `init-run` issues the directory and fingerprints the thesis, and `screen` refuses a run whose thesis changed underneath it or that has fewer judgment files than the universe carried forward.

```bash
cd finance/winnow/scripts && node --test test/*.test.mjs
```

## Validation

[`EVAL.md`](finance/winnow/EVAL.md) replays a real 48-target screen where the correct calls were known — **including one the original human screen got wrong**: a company recorded as nonunion that was in fact signatory for the relevant trade. The eval screens it twice, with that evidence present and absent. Absent, it loses 10 points and nothing else: it does not fail a filter, score zero, or leave the shortlist.

## Try it

```bash
ncl groups create --template winnow --name "Winnow"
```

Then: *"Run the shipped quickstart thesis from scratch and show me the brief."*

`theses/quickstart-arizona.yaml` is one state, five metro segments, small caps. It deliberately targets a geography the full worked example recorded as **empty** — and finds candidates there.

## Scope

Researches companies from public sources and stops. No outreach, no gated or paid sources, no individuals as subjects, no numbers it cannot source.

## Note for maintainers

This removes `finance/README.md`. That file is the placeholder for an empty category — the five categories that already hold templates carry no README, and the eight empty ones do. Happy to restore it if the convention is meant to be read the other way.

`index.json` is regenerated with `node scripts/build-index.mjs`.

